### PR TITLE
feat(design): add Sprint 1 UI component dataset

### DIFF
--- a/design/components/badge.md
+++ b/design/components/badge.md
@@ -1,0 +1,132 @@
+# Badge 元件規格
+
+## 概述
+
+Badge 用於顯示狀態標籤、分類、tags 等簡短資訊。基於 shadcn/ui Badge 元件。
+
+## 基礎元件
+
+- **來源**：`shadcn/ui` Badge
+- **圖示**：Lucide Icons（配合使用）
+
+## Props
+
+| Prop | Type | Default | 說明 |
+|------|------|---------|------|
+| `variant` | `"default" \| "secondary" \| "destructive" \| "outline"` | `"default"` | 樣式變體 |
+| `className` | `string` | - | 自訂 className |
+
+## 變體樣式
+
+| Variant | 背景 | 文字 | 邊框 | 用途 |
+|---------|------|------|------|------|
+| `default` | `bg-primary` | `text-primary-foreground` | 無 | 預設、Default provider |
+| `secondary` | `bg-secondary` | `text-secondary-foreground` | 無 | 分類名稱、一般 tag |
+| `destructive` | `bg-destructive` | `text-destructive-foreground` | 無 | 錯誤狀態、Unhealthy |
+| `outline` | 透明 | `text-foreground` | `border` | Entry tags |
+
+## 大小規格
+
+| 屬性 | 值 |
+|------|-----|
+| 內距 | `px-2.5 py-0.5` |
+| 字級 | `text-xs` |
+| 字重 | `font-semibold` |
+| 圓角 | `rounded-full` |
+| 行高 | `leading-none` 或 `leading-4` |
+
+## 自訂語義 Badge
+
+除了 shadcn/ui 預設變體，aibo 定義以下語義 Badge：
+
+### 狀態 Badge
+
+```tsx
+// 成功 / Healthy / Active
+<Badge className="bg-success text-success-foreground">
+  <span className="mr-1 h-1.5 w-1.5 rounded-full bg-current" />
+  Healthy
+</Badge>
+
+// 警告 / Expiring
+<Badge className="bg-warning text-warning-foreground">
+  <span className="mr-1 h-1.5 w-1.5 rounded-full bg-current" />
+  即將過期
+</Badge>
+
+// 錯誤 / Unhealthy / Inactive
+<Badge variant="destructive">
+  <span className="mr-1 h-1.5 w-1.5 rounded-full bg-current" />
+  Unhealthy
+</Badge>
+
+// 未測試 / Unknown
+<Badge variant="secondary">
+  <span className="mr-1 h-1.5 w-1.5 rounded-full bg-current" />
+  未測試
+</Badge>
+```
+
+### 圓點指示器
+
+```tsx
+// Active 狀態（綠色圓點）
+<span className="relative flex h-2 w-2">
+  <span className="absolute inline-flex h-full w-full animate-ping rounded-full bg-success opacity-75" />
+  <span className="relative inline-flex h-2 w-2 rounded-full bg-success" />
+</span>
+
+// Inactive 狀態（灰色圓點）
+<span className="h-2 w-2 rounded-full bg-muted-foreground" />
+```
+
+## aibo 專案使用場景
+
+| 場景 | Variant / 樣式 | 範例文字 |
+|------|---------------|---------|
+| Entry tag | `outline` | `golang`, `learning` |
+| Category 名稱（表格中） | `secondary` | `Golang`, `Python` |
+| API Key Active | 自訂 success | `Active` |
+| API Key Expired | 自訂 warning | `Expired` |
+| API Key Inactive | `secondary` | `Inactive` |
+| LLM Provider Default | `default` | `Default` |
+| LLM Provider Active | 自訂 success | `Active` |
+| LLM Provider Inactive | `secondary` | `Inactive` |
+| Health: Healthy | 自訂 success | `Healthy` |
+| Health: Unhealthy | `destructive` | `Unhealthy` |
+| Health: 未測試 | `secondary` | `未測試` |
+| Entry count | `secondary` | `15 條目` |
+| Inbox count（sidebar） | `default`（圓形） | `12` |
+
+## Tag 列表顯示
+
+當 tags 過多時，限制顯示數量：
+
+```tsx
+function TagList({ tags, max = 3 }: { tags: string[]; max?: number }) {
+  const visible = tags.slice(0, max)
+  const remaining = tags.length - max
+
+  return (
+    <div className="flex flex-wrap gap-1">
+      {visible.map((tag) => (
+        <Badge key={tag} variant="outline" className="text-xs">
+          {tag}
+        </Badge>
+      ))}
+      {remaining > 0 && (
+        <Badge variant="secondary" className="text-xs">
+          +{remaining}
+        </Badge>
+      )}
+    </div>
+  )
+}
+```
+
+## Accessibility
+
+- Badge 為純展示元素，使用 `<span>` 或 `<div>`
+- 若 Badge 傳達重要狀態資訊，配合 `aria-label` 或 sr-only 文字
+- 色彩圓點指示器需搭配文字標籤（不單純依賴色彩傳達資訊）
+- Badge 文字對比度符合 WCAG 2.1 AA

--- a/design/components/button.md
+++ b/design/components/button.md
@@ -1,0 +1,112 @@
+# Button 元件規格
+
+## 概述
+
+按鈕元件基於 shadcn/ui Button，提供一致的互動操作入口。所有按鈕變體皆符合 WCAG 2.1 AA 標準。
+
+## 基礎元件
+
+- **來源**：`shadcn/ui` Button
+- **底層**：HTML `<button>` 元素
+- **圖示**：Lucide Icons
+
+## Props
+
+| Prop | Type | Default | 說明 |
+|------|------|---------|------|
+| `variant` | `"default" \| "destructive" \| "outline" \| "secondary" \| "ghost" \| "link"` | `"default"` | 按鈕樣式變體 |
+| `size` | `"default" \| "sm" \| "lg" \| "icon"` | `"default"` | 按鈕大小 |
+| `disabled` | `boolean` | `false` | 是否禁用 |
+| `asChild` | `boolean` | `false` | 使用子元素作為渲染載體 |
+| `className` | `string` | - | 自訂 className |
+
+## 變體樣式
+
+| Variant | 背景 | 文字 | 邊框 | 用途 |
+|---------|------|------|------|------|
+| `default` | `bg-primary` | `text-primary-foreground` | 無 | 主要操作（建立、儲存） |
+| `destructive` | `bg-destructive` | `text-destructive-foreground` | 無 | 刪除、危險操作 |
+| `outline` | 透明 | `text-foreground` | `border` | 次要操作（取消） |
+| `secondary` | `bg-secondary` | `text-secondary-foreground` | 無 | 輔助操作 |
+| `ghost` | 透明 | `text-foreground` | 無 | 工具列按鈕、table action |
+| `link` | 透明 | `text-primary underline` | 無 | 導航連結樣式 |
+
+## 大小規格
+
+| Size | 高度 | 內距 | 字級 | 觸控目標 |
+|------|------|------|------|---------|
+| `sm` | `h-9` (36px) | `px-3` | `text-xs` | 44px（透過外距補足） |
+| `default` | `h-10` (40px) | `px-4 py-2` | `text-sm` | 44px |
+| `lg` | `h-11` (44px) | `px-8` | `text-sm` | 44px |
+| `icon` | `h-10 w-10` (40px) | - | - | 44px |
+
+## 狀態
+
+| 狀態 | 樣式 |
+|------|------|
+| Default | 如變體定義 |
+| Hover | `opacity-90` 或對應 hover 色 |
+| Active | `scale-[0.98]`（微縮） |
+| Focus | `focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2` |
+| Disabled | `opacity-50 pointer-events-none` |
+| Loading | 顯示 `Loader2` icon 旋轉 + 文字灰化 |
+
+## Loading 狀態
+
+```tsx
+import { Loader2 } from "lucide-react"
+
+<Button disabled>
+  <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+  處理中...
+</Button>
+```
+
+## Icon Button
+
+```tsx
+import { Plus, Trash2, MoreHorizontal } from "lucide-react"
+
+// Icon + 文字
+<Button>
+  <Plus className="mr-2 h-4 w-4" />
+  建立條目
+</Button>
+
+// 純 Icon
+<Button variant="ghost" size="icon">
+  <Trash2 className="h-4 w-4" />
+  <span className="sr-only">刪除</span>
+</Button>
+
+// Table 行內操作
+<Button variant="ghost" size="icon">
+  <MoreHorizontal className="h-4 w-4" />
+  <span className="sr-only">更多操作</span>
+</Button>
+```
+
+## aibo 專案使用場景
+
+| 場景 | Variant | Size | Icon |
+|------|---------|------|------|
+| 建立 API Key | `default` | `default` | `Plus` |
+| 建立條目 | `default` | `default` | `Plus` |
+| 建立分類 | `default` | `default` | `Plus` |
+| 新增 LLM Provider | `default` | `default` | `Plus` |
+| 儲存表單 | `default` | `default` | 無 |
+| 取消操作 | `outline` | `default` | 無 |
+| 刪除項目 | `destructive` | `default` | `Trash2` |
+| 刪除確認（AlertDialog 內） | `destructive` | `default` | 無 |
+| 表格行操作 | `ghost` | `icon` | `MoreHorizontal` |
+| 複製 API Key | `ghost` | `icon` | `Copy` |
+| 健康檢查 | `outline` | `sm` | `Activity` |
+| Sidebar 收合 | `ghost` | `icon` | `PanelLeftClose` |
+
+## Accessibility
+
+- 所有按鈕必須有可辨識的 accessible name
+- Icon-only button 必須包含 `<span className="sr-only">` 或 `aria-label`
+- 禁用按鈕使用 `disabled` 屬性而非僅視覺灰化
+- Focus ring 在 keyboard navigation 時可見（`focus-visible`）
+- 按鈕間距確保觸控目標不重疊（最小 8px 間距）

--- a/design/components/card.md
+++ b/design/components/card.md
@@ -1,0 +1,159 @@
+# Card 元件規格
+
+## 概述
+
+Card 元件基於 shadcn/ui Card，用於將相關內容分組顯示。在 aibo 中主要用於 Dashboard 統計、Entry 詳情預覽、設定區塊等場景。
+
+## 基礎元件
+
+- **來源**：`shadcn/ui` Card
+- **圖示**：Lucide Icons
+
+## 子元件
+
+| 元件 | 用途 |
+|------|------|
+| `Card` | 外層容器 |
+| `CardHeader` | 標題區域 |
+| `CardTitle` | 標題文字 |
+| `CardDescription` | 描述文字 |
+| `CardContent` | 主要內容 |
+| `CardFooter` | 底部操作區域 |
+
+## 樣式規格
+
+| 屬性 | 值 |
+|------|-----|
+| 背景 | `bg-card text-card-foreground` |
+| 邊框 | `border rounded-lg` |
+| 陰影 | `shadow-sm` |
+| 內距 | Header: `p-6 pb-0`, Content: `p-6 pt-0`, Footer: `p-6 pt-0` |
+
+## 基礎結構
+
+```tsx
+<Card>
+  <CardHeader>
+    <CardTitle>標題</CardTitle>
+    <CardDescription>描述文字</CardDescription>
+  </CardHeader>
+  <CardContent>
+    {/* 內容 */}
+  </CardContent>
+  <CardFooter>
+    {/* 操作按鈕 */}
+  </CardFooter>
+</Card>
+```
+
+## aibo 專案使用場景
+
+### Dashboard 統計 Card
+
+```tsx
+<Card>
+  <CardHeader className="flex flex-row items-center justify-between pb-2">
+    <CardTitle className="text-sm font-medium text-muted-foreground">
+      Inbox 待處理
+    </CardTitle>
+    <Inbox className="h-4 w-4 text-muted-foreground" />
+  </CardHeader>
+  <CardContent>
+    <div className="text-3xl font-bold">12</div>
+    <p className="text-xs text-muted-foreground mt-1">
+      較昨天 +3
+    </p>
+  </CardContent>
+</Card>
+```
+
+Dashboard 統計 Card 網格：
+
+```tsx
+<div className="grid gap-4 md:grid-cols-2 lg:grid-cols-4">
+  <Card>{/* Inbox 數量 */}</Card>
+  <Card>{/* 總條目數 */}</Card>
+  <Card>{/* 分類數量 */}</Card>
+  <Card>{/* LLM Provider 狀態 */}</Card>
+</div>
+```
+
+### Entry 詳情 Card
+
+```tsx
+<Card>
+  <CardHeader>
+    <div className="flex items-center justify-between">
+      <CardTitle className="text-lg">{entry.title}</CardTitle>
+      <DropdownMenu>{/* 操作選單 */}</DropdownMenu>
+    </div>
+    <CardDescription className="flex items-center gap-2">
+      {entry.category && <Badge variant="secondary">{entry.category.name}</Badge>}
+      <span className="text-xs text-muted-foreground">{entry.updated_at}</span>
+    </CardDescription>
+  </CardHeader>
+  <CardContent>
+    <div className="prose prose-sm dark:prose-invert max-w-none">
+      {/* Markdown 渲染 */}
+    </div>
+  </CardContent>
+  <CardFooter className="flex gap-1">
+    {entry.tags.map((tag) => (
+      <Badge key={tag} variant="outline">{tag}</Badge>
+    ))}
+  </CardFooter>
+</Card>
+```
+
+### Mobile Entry Card（替代表格）
+
+```tsx
+<Card className="hover:bg-muted/50 transition-colors cursor-pointer">
+  <CardContent className="p-4">
+    <div className="flex items-start justify-between">
+      <div className="space-y-1 flex-1 min-w-0">
+        <p className="text-sm font-medium truncate">{entry.title}</p>
+        <p className="text-xs text-muted-foreground line-clamp-2">
+          {entry.content_preview}
+        </p>
+      </div>
+      <Button variant="ghost" size="icon" className="shrink-0">
+        <MoreHorizontal className="h-4 w-4" />
+      </Button>
+    </div>
+    <div className="flex items-center gap-2 mt-2">
+      {entry.category && <Badge variant="secondary" className="text-xs">{entry.category.name}</Badge>}
+      <span className="text-xs text-muted-foreground">{entry.updated_at}</span>
+    </div>
+  </CardContent>
+</Card>
+```
+
+### 設定區塊 Card
+
+```tsx
+<Card>
+  <CardHeader>
+    <CardTitle>LLM Provider</CardTitle>
+    <CardDescription>管理你的 LLM 服務提供者</CardDescription>
+  </CardHeader>
+  <CardContent>
+    {/* Provider 列表或設定內容 */}
+  </CardContent>
+</Card>
+```
+
+## 響應式
+
+| 斷點 | 排列方式 |
+|------|---------|
+| Mobile | 單欄（`grid-cols-1`） |
+| Tablet | 雙欄（`md:grid-cols-2`） |
+| Desktop | 四欄（`lg:grid-cols-4`）用於統計；雙欄用於設定 |
+
+## Accessibility
+
+- Card 本身為 `<div>` 無特殊語義
+- 可點擊的 Card 需加 `role="button"` 和 `tabIndex={0}`
+- Card 內的操作按鈕需有明確的 accessible name
+- 使用 `CardTitle` 作為 Card 的語義標題（對應 heading level）

--- a/design/components/data-table.md
+++ b/design/components/data-table.md
@@ -1,0 +1,219 @@
+# DataTable 元件規格
+
+## 概述
+
+DataTable 基於 TanStack Table v8 + shadcn/ui Table 元件，提供排序、分頁、行操作等功能。為 aibo 的列表頁面提供統一的表格介面。
+
+## 基礎元件
+
+- **來源**：`shadcn/ui` Table + TanStack Table v8
+- **圖示**：Lucide Icons
+
+## Props
+
+| Prop | Type | Default | 說明 |
+|------|------|---------|------|
+| `columns` | `ColumnDef<TData>[]` | - | 欄位定義 |
+| `data` | `TData[]` | - | 資料陣列 |
+| `pagination` | `{ page, per_page, total, total_pages }` | - | 分頁資訊（server-side） |
+| `onPageChange` | `(page: number) => void` | - | 換頁回呼 |
+| `onSortChange` | `(sort: string, order: string) => void` | - | 排序回呼 |
+| `isLoading` | `boolean` | `false` | 是否載入中 |
+| `emptyMessage` | `string` | `"沒有資料"` | 空狀態文字 |
+| `emptyIcon` | `LucideIcon` | `FileText` | 空狀態圖示 |
+
+## 表格樣式
+
+### 結構
+
+```tsx
+<div className="rounded-md border">
+  <Table>
+    <TableHeader>
+      <TableRow>
+        <TableHead className="px-4 py-3 text-sm font-semibold text-muted-foreground">
+          {/* 欄位名稱 */}
+        </TableHead>
+      </TableRow>
+    </TableHeader>
+    <TableBody>
+      <TableRow className="hover:bg-muted/50">
+        <TableCell className="px-4 py-3 text-sm">
+          {/* 資料 */}
+        </TableCell>
+      </TableRow>
+    </TableBody>
+  </Table>
+</div>
+```
+
+### 表格列樣式
+
+| 元素 | 樣式 |
+|------|------|
+| Table 外框 | `rounded-md border` |
+| Header 行 | `bg-muted/50` |
+| Header cell | `px-4 py-3 text-sm font-semibold text-muted-foreground` |
+| Body row | `border-b hover:bg-muted/50 transition-colors` |
+| Body cell | `px-4 py-3 text-sm` |
+| 最後一行 | 無 `border-b` |
+
+## 排序
+
+可排序的欄位在 header 顯示排序圖示：
+
+```tsx
+<Button variant="ghost" onClick={toggleSort} className="-ml-4">
+  標題
+  <ArrowUpDown className="ml-2 h-4 w-4" />
+</Button>
+```
+
+| 狀態 | 圖示 |
+|------|------|
+| 未排序 | `ArrowUpDown`（灰色） |
+| 升序 | `ArrowUp` |
+| 降序 | `ArrowDown` |
+
+## 分頁
+
+分頁元件位於表格下方：
+
+```tsx
+<div className="flex items-center justify-between px-2 py-4">
+  <p className="text-sm text-muted-foreground">
+    共 {total} 筆，第 {page} / {totalPages} 頁
+  </p>
+  <div className="flex items-center gap-2">
+    <Button variant="outline" size="sm" disabled={page <= 1}>
+      <ChevronLeft className="h-4 w-4" />
+      上一頁
+    </Button>
+    <Button variant="outline" size="sm" disabled={page >= totalPages}>
+      下一頁
+      <ChevronRight className="h-4 w-4" />
+    </Button>
+  </div>
+</div>
+```
+
+## 行操作（Row Actions）
+
+每行最後一欄為操作選單：
+
+```tsx
+<DropdownMenu>
+  <DropdownMenuTrigger asChild>
+    <Button variant="ghost" size="icon">
+      <MoreHorizontal className="h-4 w-4" />
+      <span className="sr-only">操作選單</span>
+    </Button>
+  </DropdownMenuTrigger>
+  <DropdownMenuContent align="end">
+    <DropdownMenuItem>
+      <Eye className="mr-2 h-4 w-4" />
+      查看
+    </DropdownMenuItem>
+    <DropdownMenuItem>
+      <Pencil className="mr-2 h-4 w-4" />
+      編輯
+    </DropdownMenuItem>
+    <DropdownMenuSeparator />
+    <DropdownMenuItem className="text-destructive">
+      <Trash2 className="mr-2 h-4 w-4" />
+      刪除
+    </DropdownMenuItem>
+  </DropdownMenuContent>
+</DropdownMenu>
+```
+
+## 載入狀態（Loading）
+
+```tsx
+// Skeleton rows
+<TableBody>
+  {Array.from({ length: 5 }).map((_, i) => (
+    <TableRow key={i}>
+      <TableCell><Skeleton className="h-4 w-[200px]" /></TableCell>
+      <TableCell><Skeleton className="h-4 w-[100px]" /></TableCell>
+      <TableCell><Skeleton className="h-4 w-[80px]" /></TableCell>
+    </TableRow>
+  ))}
+</TableBody>
+```
+
+## 空狀態（Empty State）
+
+```tsx
+<div className="flex flex-col items-center justify-center py-12 text-center">
+  <FileText className="h-12 w-12 text-muted-foreground/50 mb-4" />
+  <h3 className="text-lg font-semibold">沒有資料</h3>
+  <p className="text-sm text-muted-foreground mt-1">
+    {emptyMessage}
+  </p>
+  <Button className="mt-4">
+    <Plus className="mr-2 h-4 w-4" />
+    建立第一筆
+  </Button>
+</div>
+```
+
+## aibo 專案表格定義
+
+### Entry 列表
+
+| 欄位 | 寬度 | 排序 | 內容 |
+|------|------|------|------|
+| 標題 | flex-1 | 是 | `title`（truncate），無 title 時顯示 content_preview |
+| 分類 | 120px | 否 | Badge 顯示 category name |
+| Tags | 200px | 否 | Badge 列表（最多顯示 3 個 + `+N`） |
+| 更新時間 | 140px | 是 | 相對時間（如「3 分鐘前」） |
+| 操作 | 50px | 否 | DropdownMenu |
+
+### Category 列表
+
+| 欄位 | 寬度 | 排序 | 內容 |
+|------|------|------|------|
+| 名稱 | flex-1 | 否 | `name` |
+| 描述 | flex-1 | 否 | `description`（truncate） |
+| 條目數 | 100px | 否 | `entry_count` Badge |
+| 排序 | 80px | 否 | `sort_order` |
+| 操作 | 50px | 否 | DropdownMenu |
+
+### API Key 列表
+
+| 欄位 | 寬度 | 排序 | 內容 |
+|------|------|------|------|
+| 名稱 | flex-1 | 否 | `name` |
+| Key 前綴 | 120px | 否 | `key_prefix`（monospace） |
+| 狀態 | 100px | 否 | Badge（Active / Expired） |
+| 到期日 | 140px | 否 | 日期或「永不過期」 |
+| 最後使用 | 140px | 否 | 相對時間或「從未使用」 |
+| 操作 | 50px | 否 | 刪除按鈕 |
+
+### LLM Provider 列表
+
+| 欄位 | 寬度 | 排序 | 內容 |
+|------|------|------|------|
+| 名稱 | flex-1 | 否 | `name` + Default badge |
+| Endpoint | 200px | 否 | URL（truncate） |
+| Model | 120px | 否 | `model_name` |
+| 狀態 | 100px | 否 | Active / Inactive badge |
+| 健康 | 100px | 否 | HealthStatus 指示器 |
+| 操作 | 50px | 否 | DropdownMenu |
+
+## 響應式
+
+| 斷點 | 行為 |
+|------|------|
+| Desktop (>= 1024px) | 完整表格 |
+| Tablet (768-1023px) | 隱藏較不重要的欄位（如 tags、描述） |
+| Mobile (< 768px) | 改用 Card list 排版替代表格 |
+
+## Accessibility
+
+- 使用語義化 `<table>` 標籤
+- 排序按鈕包含 `aria-sort` 屬性
+- 分頁按鈕包含明確的 `aria-label`
+- 空狀態使用 `role="status"` 標記
+- 行操作 DropdownMenu 可透過鍵盤操作（Enter 展開、方向鍵瀏覽）

--- a/design/components/dialog-modal.md
+++ b/design/components/dialog-modal.md
@@ -1,0 +1,204 @@
+# Dialog / Modal 元件規格
+
+## 概述
+
+Dialog 和 AlertDialog 基於 shadcn/ui（Radix UI primitives），用於確認操作、表單填寫等需要使用者關注的互動場景。
+
+## 基礎元件
+
+- **來源**：`shadcn/ui` Dialog, AlertDialog
+- **底層**：Radix UI Dialog primitive
+- **圖示**：Lucide Icons
+
+---
+
+## Dialog（通用對話框）
+
+用於表單填寫、詳細資訊顯示等場景。
+
+### Props
+
+| Prop | Type | Default | 說明 |
+|------|------|---------|------|
+| `open` | `boolean` | - | 是否開啟 |
+| `onOpenChange` | `(open: boolean) => void` | - | 開關回呼 |
+
+### 結構
+
+```tsx
+<Dialog open={open} onOpenChange={setOpen}>
+  <DialogTrigger asChild>
+    <Button>建立</Button>
+  </DialogTrigger>
+  <DialogContent className="sm:max-w-[425px]">
+    <DialogHeader>
+      <DialogTitle>建立知識條目</DialogTitle>
+      <DialogDescription>
+        填寫以下資訊建立新的知識條目。
+      </DialogDescription>
+    </DialogHeader>
+    <div className="space-y-4 py-4">
+      {/* 表單內容 */}
+    </div>
+    <DialogFooter>
+      <Button variant="outline" onClick={() => setOpen(false)}>取消</Button>
+      <Button type="submit">建立</Button>
+    </DialogFooter>
+  </DialogContent>
+</Dialog>
+```
+
+### 樣式規格
+
+| 屬性 | 值 |
+|------|-----|
+| 最大寬度 | `sm:max-w-[425px]`（小型）/ `sm:max-w-[600px]`（中型） |
+| 內距 | `p-6` |
+| 圓角 | `rounded-lg` |
+| 陰影 | `shadow-lg` |
+| 背景遮罩 | `bg-black/80` |
+| 動畫 | fade-in + scale（Radix 預設） |
+| 位置 | 垂直置中 |
+
+### 大小變體
+
+| 變體 | 最大寬度 | 用途 |
+|------|---------|------|
+| 小型 | `sm:max-w-[425px]` | 簡單表單（建立 API Key、建立分類） |
+| 中型 | `sm:max-w-[600px]` | 較複雜表單（建立/編輯 Entry、LLM Provider） |
+| 大型 | `sm:max-w-[800px]` | 預覽內容（Markdown 預覽） |
+
+---
+
+## AlertDialog（確認對話框）
+
+用於需要二次確認的破壞性操作。
+
+### 結構
+
+```tsx
+<AlertDialog open={open} onOpenChange={setOpen}>
+  <AlertDialogContent>
+    <AlertDialogHeader>
+      <AlertDialogTitle>確認刪除</AlertDialogTitle>
+      <AlertDialogDescription>
+        此操作無法復原。確定要刪除此條目嗎？
+      </AlertDialogDescription>
+    </AlertDialogHeader>
+    <AlertDialogFooter>
+      <AlertDialogCancel>取消</AlertDialogCancel>
+      <AlertDialogAction className="bg-destructive text-destructive-foreground hover:bg-destructive/90">
+        刪除
+      </AlertDialogAction>
+    </AlertDialogFooter>
+  </AlertDialogContent>
+</AlertDialog>
+```
+
+### 與 Dialog 的差異
+
+| 特性 | Dialog | AlertDialog |
+|------|--------|-------------|
+| 點擊遮罩關閉 | 是 | 否 |
+| ESC 關閉 | 是 | 否（必須點按鈕） |
+| 用途 | 表單、資訊 | 確認操作 |
+| 按鈕 | 自訂 | Cancel + Action |
+
+## aibo 專案使用場景
+
+### 建立 API Key Dialog
+
+```
+┌─────────────────────────────────┐
+│ ✕                               │
+│                                 │
+│  建立 API Key                    │
+│  建立新的 API Key 用於存取 API    │
+│                                 │
+│  名稱 *                         │
+│  ┌─────────────────────────┐   │
+│  │ 例如：my-app             │   │
+│  └─────────────────────────┘   │
+│                                 │
+│  到期日                         │
+│  ┌─────────────────────────┐   │
+│  │ 永不過期                 │ ▾ │
+│  └─────────────────────────┘   │
+│                                 │
+│           [取消]  [建立]        │
+└─────────────────────────────────┘
+```
+
+### API Key 建立成功 Dialog
+
+```
+┌─────────────────────────────────┐
+│                                 │
+│  ⚠️ API Key 已建立               │
+│  請立即複製此 Key，關閉後將無法   │
+│  再次查看。                      │
+│                                 │
+│  ┌─────────────────────────┐   │
+│  │ aibo_a1b2c3d4e5f6...  📋 │   │
+│  └─────────────────────────┘   │
+│                                 │
+│                    [我已複製]    │
+└─────────────────────────────────┘
+```
+
+### 刪除確認 AlertDialog
+
+```
+┌─────────────────────────────────┐
+│                                 │
+│  確認刪除                        │
+│  此操作無法復原。刪除分類後，     │
+│  該分類下的所有條目將移至 Inbox。  │
+│                                 │
+│           [取消]  [刪除]        │
+└─────────────────────────────────┘
+```
+
+### 建立/編輯條目 Dialog
+
+```
+┌────────────────────────────────────────┐
+│ ✕                                      │
+│                                        │
+│  建立知識條目                           │
+│                                        │
+│  標題                                  │
+│  ┌──────────────────────────────┐     │
+│  │                              │     │
+│  └──────────────────────────────┘     │
+│                                        │
+│  內容（Markdown）                      │
+│  ┌──────────────────────────────┐     │
+│  │                              │     │
+│  │                              │     │
+│  │                              │     │
+│  └──────────────────────────────┘     │
+│                                        │
+│  分類                                  │
+│  ┌──────────────────────────────┐     │
+│  │ 選擇分類                 │ ▾ │     │
+│  └──────────────────────────────┘     │
+│                                        │
+│  Tags                                  │
+│  ┌──────────────────────────────┐     │
+│  │ [golang] [learning] +        │     │
+│  └──────────────────────────────┘     │
+│                                        │
+│              [取消]  [建立]            │
+└────────────────────────────────────────┘
+```
+
+## Accessibility
+
+- Dialog 開啟時 focus trap（焦點被限制在 Dialog 內）
+- 首次 focus 自動移到第一個可互動元素
+- `Escape` 鍵關閉 Dialog（AlertDialog 除外）
+- 關閉後 focus 回到觸發元素
+- `DialogTitle` 必須存在（作為 `aria-labelledby`）
+- `DialogDescription` 作為 `aria-describedby`
+- AlertDialog 的 Action 按鈕若為破壞性操作，使用 `destructive` 樣式強調

--- a/design/components/dropdown-menu.md
+++ b/design/components/dropdown-menu.md
@@ -1,0 +1,137 @@
+# Dropdown Menu 元件規格
+
+## 概述
+
+Dropdown Menu 基於 shadcn/ui DropdownMenu（Radix UI primitive），用於表格行操作、更多選項等場景。
+
+## 基礎元件
+
+- **來源**：`shadcn/ui` DropdownMenu
+- **底層**：Radix UI DropdownMenu primitive
+- **圖示**：Lucide Icons
+
+## 子元件
+
+| 元件 | 用途 |
+|------|------|
+| `DropdownMenu` | 外層 context |
+| `DropdownMenuTrigger` | 觸發按鈕 |
+| `DropdownMenuContent` | 選單面板 |
+| `DropdownMenuItem` | 選單項目 |
+| `DropdownMenuSeparator` | 分隔線 |
+| `DropdownMenuLabel` | 群組標籤 |
+
+## 樣式規格
+
+### Content 面板
+
+| 屬性 | 值 |
+|------|-----|
+| 最小寬度 | `min-w-[160px]` |
+| 背景 | `bg-popover text-popover-foreground` |
+| 邊框 | `border` |
+| 圓角 | `rounded-md` |
+| 陰影 | `shadow-md` |
+| 內距 | `p-1` |
+| 動畫 | Radix 預設（fade + scale） |
+
+### MenuItem
+
+| 屬性 | 值 |
+|------|-----|
+| 內距 | `px-2 py-1.5` |
+| 字級 | `text-sm` |
+| 圓角 | `rounded-sm` |
+| Hover | `bg-accent text-accent-foreground` |
+| Focus | `bg-accent text-accent-foreground`（鍵盤） |
+| Disabled | `opacity-50 pointer-events-none` |
+| 高度 | 自然高度（約 36px 含內距，滿足觸控目標） |
+
+### Separator
+
+| 屬性 | 值 |
+|------|-----|
+| 高度 | `1px` |
+| 色彩 | `bg-muted` |
+| 邊距 | `my-1 -mx-1` |
+
+## 使用範例
+
+### 表格行操作
+
+```tsx
+<DropdownMenu>
+  <DropdownMenuTrigger asChild>
+    <Button variant="ghost" size="icon">
+      <MoreHorizontal className="h-4 w-4" />
+      <span className="sr-only">操作選單</span>
+    </Button>
+  </DropdownMenuTrigger>
+  <DropdownMenuContent align="end">
+    <DropdownMenuLabel>操作</DropdownMenuLabel>
+    <DropdownMenuSeparator />
+    <DropdownMenuItem onClick={() => router.push(`/entries/${id}`)}>
+      <Eye className="mr-2 h-4 w-4" />
+      查看
+    </DropdownMenuItem>
+    <DropdownMenuItem onClick={() => openEditDialog(id)}>
+      <Pencil className="mr-2 h-4 w-4" />
+      編輯
+    </DropdownMenuItem>
+    <DropdownMenuSeparator />
+    <DropdownMenuItem
+      className="text-destructive focus:text-destructive"
+      onClick={() => openDeleteDialog(id)}
+    >
+      <Trash2 className="mr-2 h-4 w-4" />
+      刪除
+    </DropdownMenuItem>
+  </DropdownMenuContent>
+</DropdownMenu>
+```
+
+## aibo 專案使用場景
+
+### Entry 行操作
+
+| 項目 | Icon | 動作 |
+|------|------|------|
+| 查看 | `Eye` | 導航到詳情頁 |
+| 編輯 | `Pencil` | 開啟編輯 Dialog |
+| 移至分類 | `FolderInput` | 開啟分類選擇 |
+| 歸檔 | `Archive` | 設為 is_archived = true |
+| 刪除 | `Trash2` | 開啟刪除確認 AlertDialog |
+
+### Category 行操作
+
+| 項目 | Icon | 動作 |
+|------|------|------|
+| 編輯 | `Pencil` | 開啟編輯 Dialog |
+| 刪除 | `Trash2` | 開啟刪除確認 AlertDialog |
+
+### LLM Provider 行操作
+
+| 項目 | Icon | 動作 |
+|------|------|------|
+| 編輯 | `Pencil` | 開啟編輯 Dialog |
+| 設為預設 | `Star` | 設為 default provider |
+| 健康檢查 | `Activity` | 發送健康檢查請求 |
+| 刪除 | `Trash2` | 開啟刪除確認 AlertDialog |
+
+### API Key 行操作
+
+API Key 列表較簡單，直接使用按鈕而非 DropdownMenu：
+
+| 操作 | 元件 | 說明 |
+|------|------|------|
+| 撤銷 | Button（destructive ghost） | 直接開啟 AlertDialog |
+
+## Accessibility
+
+- Trigger 按鈕有 `aria-haspopup="menu"` 和 `aria-expanded`
+- 選單開啟時 focus 移到第一個項目
+- 方向鍵（上/下）瀏覽項目
+- Enter / Space 選擇項目
+- Escape 關閉選單，focus 回到 trigger
+- 破壞性項目使用 `text-destructive` 視覺強調
+- Icon-only trigger 必須有 `sr-only` 文字

--- a/design/components/input.md
+++ b/design/components/input.md
@@ -1,0 +1,230 @@
+# Input / Form 元件規格
+
+## 概述
+
+表單系統基於 shadcn/ui 的 Input、Textarea、Select、Checkbox 等元件，搭配 react-hook-form + zod 做表單驗證。
+
+## 基礎元件
+
+- **來源**：`shadcn/ui` Input, Textarea, Select, Checkbox, Label, Form
+- **表單管理**：react-hook-form
+- **驗證**：zod schema validation
+- **圖示**：Lucide Icons
+
+---
+
+## Input
+
+### Props
+
+| Prop | Type | Default | 說明 |
+|------|------|---------|------|
+| `type` | `string` | `"text"` | 輸入類型 |
+| `placeholder` | `string` | - | 佔位文字 |
+| `disabled` | `boolean` | `false` | 是否禁用 |
+| `className` | `string` | - | 自訂 className |
+
+### 樣式規格
+
+| 屬性 | 值 |
+|------|-----|
+| 高度 | `h-10` (40px) |
+| 內距 | `px-3 py-2` |
+| 邊框 | `border border-input` |
+| 圓角 | `rounded-md` |
+| 字級 | `text-sm` |
+| 背景 | `bg-background` |
+| Focus | `focus-visible:ring-2 focus-visible:ring-ring` |
+| Disabled | `disabled:opacity-50 disabled:cursor-not-allowed` |
+| Placeholder | `text-muted-foreground` |
+
+### 使用範例
+
+```tsx
+<div className="space-y-2">
+  <Label htmlFor="name">名稱</Label>
+  <Input id="name" placeholder="輸入名稱" />
+</div>
+```
+
+---
+
+## Textarea
+
+### Props
+
+| Prop | Type | Default | 說明 |
+|------|------|---------|------|
+| `placeholder` | `string` | - | 佔位文字 |
+| `rows` | `number` | `3` | 預設行數 |
+| `disabled` | `boolean` | `false` | 是否禁用 |
+
+### 樣式規格
+
+| 屬性 | 值 |
+|------|-----|
+| 最小高度 | `min-h-[80px]` |
+| 內距 | `px-3 py-2` |
+| 其餘同 Input | - |
+
+### 使用場景
+
+- Entry content 編輯（Markdown 格式）
+- Category description 輸入
+- LLM Provider config 備註
+
+---
+
+## Select
+
+### Props
+
+| Prop | Type | Default | 說明 |
+|------|------|---------|------|
+| `value` | `string` | - | 目前選取值 |
+| `onValueChange` | `(value: string) => void` | - | 選取回呼 |
+| `placeholder` | `string` | - | 佔位文字 |
+| `disabled` | `boolean` | `false` | 是否禁用 |
+
+### 樣式規格
+
+與 Input 相同高度與樣式，下拉面板使用 `shadow-md`。
+
+### 使用場景
+
+- Entry 的 category 選擇（CategorySelector）
+- Entry 的 source_type 選擇
+- 排序選項（sort by）
+
+---
+
+## Checkbox
+
+### 樣式規格
+
+| 屬性 | 值 |
+|------|-----|
+| 大小 | `h-4 w-4` (16px) |
+| 觸控區域 | 透過 Label 擴展至 44px |
+| 選取狀態 | `bg-primary` + Check icon |
+| Focus | `focus-visible:ring-2` |
+
+---
+
+## SearchInput（業務元件）
+
+搜尋專用輸入元件，包含搜尋圖示和 debounce 機制。
+
+### Props
+
+| Prop | Type | Default | 說明 |
+|------|------|---------|------|
+| `value` | `string` | - | 搜尋值 |
+| `onChange` | `(value: string) => void` | - | 值變更回呼（debounced） |
+| `placeholder` | `string` | `"搜尋..."` | 佔位文字 |
+| `debounceMs` | `number` | `300` | debounce 延遲 |
+
+### 樣式
+
+```tsx
+<div className="relative">
+  <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" />
+  <Input className="pl-9" placeholder="搜尋..." />
+</div>
+```
+
+---
+
+## TagInput（業務元件）
+
+Tag 輸入元件，用於 Entry 的 tags 欄位。
+
+### Props
+
+| Prop | Type | Default | 說明 |
+|------|------|---------|------|
+| `value` | `string[]` | `[]` | 目前 tags |
+| `onChange` | `(tags: string[]) => void` | - | tags 變更回呼 |
+| `placeholder` | `string` | `"輸入後按 Enter 新增"` | 佔位文字 |
+| `maxTags` | `number` | `20` | 最多 tag 數量 |
+
+### 行為
+
+1. 輸入文字後按 Enter 新增 tag
+2. 每個 tag 顯示為 Badge + 刪除按鈕
+3. 按 Backspace 可刪除最後一個 tag
+4. 重複的 tag 不會新增
+
+### 樣式
+
+```tsx
+<div className="flex flex-wrap gap-1 rounded-md border border-input p-2 min-h-[40px]">
+  {tags.map((tag) => (
+    <Badge key={tag} variant="secondary" className="gap-1">
+      {tag}
+      <button onClick={() => removeTag(tag)}>
+        <X className="h-3 w-3" />
+        <span className="sr-only">移除 {tag}</span>
+      </button>
+    </Badge>
+  ))}
+  <input className="flex-1 min-w-[120px] outline-none text-sm" />
+</div>
+```
+
+---
+
+## Form 整合（react-hook-form + zod）
+
+### 表單結構
+
+```tsx
+import { useForm } from "react-hook-form"
+import { zodResolver } from "@hookform/resolvers/zod"
+import { z } from "zod"
+
+const entrySchema = z.object({
+  title: z.string().max(100, "標題不可超過 100 字").optional(),
+  content: z.string().optional(),
+  category_id: z.string().uuid().nullable().optional(),
+  tags: z.array(z.string()).default([]),
+}).refine(
+  (data) => data.title || data.content,
+  { message: "標題和內容至少填寫一項" }
+)
+
+// Form 元件使用 shadcn/ui Form wrapper
+<Form {...form}>
+  <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">
+    <FormField
+      control={form.control}
+      name="title"
+      render={({ field }) => (
+        <FormItem>
+          <FormLabel>標題</FormLabel>
+          <FormControl>
+            <Input placeholder="輸入標題" {...field} />
+          </FormControl>
+          <FormMessage />
+        </FormItem>
+      )}
+    />
+  </form>
+</Form>
+```
+
+### 錯誤狀態
+
+| 狀態 | 樣式 |
+|------|------|
+| 欄位錯誤 | Input 邊框 `border-destructive`，下方顯示 `text-destructive text-sm` 錯誤訊息 |
+| 全域錯誤 | 表單頂部 Toast 或 Alert |
+
+## Accessibility
+
+- 所有 Input 必須有對應的 `<Label>` 或 `aria-label`
+- 錯誤訊息透過 `aria-describedby` 關聯到對應欄位
+- Tab 順序遵循視覺順序
+- 必填欄位標示 `*`（`aria-required="true"`）
+- Select 使用 Radix UI primitive，支援鍵盤操作
+- SearchInput 使用 `role="search"` 標記

--- a/design/components/navigation-sidebar.md
+++ b/design/components/navigation-sidebar.md
@@ -1,0 +1,184 @@
+# Navigation Sidebar 元件規格
+
+## 概述
+
+左側導航欄使用 shadcn/ui 的 Sidebar 元件，提供全域導航和 Inbox 數量指示。支援展開/收合。
+
+## 基礎元件
+
+- **來源**：`shadcn/ui` Sidebar
+- **底層**：Radix UI + 自訂 Sidebar context
+- **圖示**：Lucide Icons
+
+## 結構
+
+```tsx
+<SidebarProvider>
+  <Sidebar>
+    <SidebarHeader>
+      {/* Logo + 應用名稱 */}
+    </SidebarHeader>
+    <SidebarContent>
+      <SidebarGroup>
+        <SidebarGroupLabel>主要功能</SidebarGroupLabel>
+        <SidebarGroupContent>
+          <SidebarMenu>
+            {/* 導航項目 */}
+          </SidebarMenu>
+        </SidebarGroupContent>
+      </SidebarGroup>
+      <SidebarGroup>
+        <SidebarGroupLabel>設定</SidebarGroupLabel>
+        <SidebarGroupContent>
+          <SidebarMenu>
+            {/* 設定項目 */}
+          </SidebarMenu>
+        </SidebarGroupContent>
+      </SidebarGroup>
+    </SidebarContent>
+    <SidebarFooter>
+      {/* 版本資訊 */}
+    </SidebarFooter>
+  </Sidebar>
+  <SidebarInset>
+    {/* 主要內容區域 */}
+  </SidebarInset>
+</SidebarProvider>
+```
+
+## 導航項目
+
+| 群組 | 項目 | Icon | 路由 | Badge |
+|------|------|------|------|-------|
+| 主要功能 | Inbox | `Inbox` | `/inbox` | 未分類條目數量 |
+| 主要功能 | 知識條目 | `FileText` | `/entries` | - |
+| 主要功能 | 分類管理 | `FolderTree` | `/categories` | - |
+| 設定 | API Key | `Key` | `/settings/api-keys` | - |
+| 設定 | LLM Provider | `Bot` | `/settings/llm-providers` | - |
+
+## 樣式規格
+
+### Sidebar 容器
+
+| 屬性 | 值 |
+|------|-----|
+| 展開寬度 | `w-64` (256px) |
+| 收合寬度 | `w-16` (64px) |
+| 背景 | `bg-sidebar-background` |
+| 邊框 | `border-r border-sidebar-border` |
+| 高度 | `h-screen` (滿版) |
+| 位置 | `fixed`（mobile）/ `sticky`（desktop） |
+
+### Header
+
+```tsx
+<SidebarHeader className="p-4">
+  <div className="flex items-center gap-2">
+    <div className="flex h-8 w-8 items-center justify-center rounded-md bg-primary text-primary-foreground font-bold text-sm">
+      A
+    </div>
+    <span className="text-lg font-semibold">aibo</span>
+  </div>
+</SidebarHeader>
+```
+
+### 導航項目
+
+```tsx
+<SidebarMenuItem>
+  <SidebarMenuButton asChild isActive={pathname === "/inbox"}>
+    <Link href="/inbox">
+      <Inbox className="h-4 w-4" />
+      <span>Inbox</span>
+    </Link>
+  </SidebarMenuButton>
+  <SidebarMenuBadge>12</SidebarMenuBadge>
+</SidebarMenuItem>
+```
+
+| 狀態 | 樣式 |
+|------|------|
+| Default | `text-sidebar-foreground` |
+| Hover | `bg-sidebar-accent text-sidebar-accent-foreground` |
+| Active | `bg-sidebar-primary text-sidebar-primary-foreground` |
+| Focus | `focus-visible:ring-2 focus-visible:ring-sidebar-ring` |
+
+### 項目尺寸
+
+| 屬性 | 值 |
+|------|-----|
+| 高度 | `h-10` (40px) |
+| 內距 | `px-3 py-2` |
+| 圓角 | `rounded-md` |
+| Icon 大小 | `h-4 w-4` |
+| Icon 與文字間距 | `gap-3` |
+| 項目間距 | `gap-1` |
+
+### Badge（Inbox 數量）
+
+```tsx
+<SidebarMenuBadge className="bg-primary text-primary-foreground text-xs px-2 py-0.5 rounded-full">
+  12
+</SidebarMenuBadge>
+```
+
+### Group Label
+
+| 屬性 | 值 |
+|------|-----|
+| 字級 | `text-xs` |
+| 字重 | `font-medium` |
+| 色彩 | `text-muted-foreground` |
+| 內距 | `px-3 py-2` |
+| 大寫 | `uppercase tracking-wider`（可選） |
+
+### Footer
+
+```tsx
+<SidebarFooter className="p-4 border-t border-sidebar-border">
+  <p className="text-xs text-muted-foreground">aibo v1.0.0</p>
+</SidebarFooter>
+```
+
+## 收合行為
+
+| 狀態 | 顯示 | 觸發 |
+|------|------|------|
+| 展開 | Icon + 文字 + Badge | 預設（desktop） |
+| 收合 | 只有 Icon（tooltip 顯示名稱） | 點擊收合按鈕 |
+| Mobile | 全螢幕 overlay | 點擊 hamburger menu |
+
+### 收合按鈕
+
+```tsx
+<SidebarTrigger className="h-9 w-9">
+  <PanelLeftClose className="h-4 w-4" />
+  <span className="sr-only">收合側邊欄</span>
+</SidebarTrigger>
+```
+
+## 響應式
+
+| 斷點 | 行為 |
+|------|------|
+| Desktop (>= 1024px) | 固定顯示，可收合 |
+| Tablet (768-1023px) | 預設收合，可展開 |
+| Mobile (< 768px) | 隱藏，透過 hamburger 展開為 overlay |
+
+### Mobile Overlay
+
+| 屬性 | 值 |
+|------|-----|
+| 背景遮罩 | `bg-black/50` |
+| 動畫 | slide-in from left |
+| 關閉 | 點擊遮罩或 X 按鈕 |
+
+## Accessibility
+
+- 使用 `<nav>` 語義標籤
+- `aria-label="主要導航"`
+- Active 項目使用 `aria-current="page"`
+- 收合按鈕有 `aria-expanded` 狀態
+- Badge 使用 `aria-label` 描述數量（如 `aria-label="12 筆未分類條目"`）
+- 鍵盤可完整導航（Tab + Enter）
+- Mobile overlay 開啟時 focus trap

--- a/design/components/toast.md
+++ b/design/components/toast.md
@@ -1,0 +1,125 @@
+# Toast 元件規格
+
+## 概述
+
+Toast 通知使用 Sonner（shadcn/ui 推薦的 toast 方案），提供輕量級的操作結果回饋。自動消失，不阻擋使用者操作。
+
+## 基礎元件
+
+- **來源**：`shadcn/ui` Sonner integration
+- **底層**：sonner library
+- **圖示**：Lucide Icons（由 Sonner 內建處理）
+
+## 全域設定
+
+在 Layout 中放置 Toaster：
+
+```tsx
+// app/layout.tsx
+import { Toaster } from "@/components/ui/sonner"
+
+export default function RootLayout({ children }) {
+  return (
+    <html>
+      <body>
+        {children}
+        <Toaster position="bottom-right" richColors />
+      </body>
+    </html>
+  )
+}
+```
+
+## Toast 類型
+
+| 類型 | 圖示 | 色彩 | 用途 |
+|------|------|------|------|
+| `success` | `CheckCircle2` | 綠色（success） | 建立、更新、刪除成功 |
+| `error` | `XCircle` | 紅色（destructive） | API 錯誤、驗證失敗 |
+| `warning` | `AlertTriangle` | 琥珀色（warning） | 不可復原操作的警告 |
+| `info` | `Info` | 藍色 | 一般提示 |
+
+## 使用方式
+
+```tsx
+import { toast } from "sonner"
+
+// 成功
+toast.success("條目已建立")
+
+// 錯誤
+toast.error("建立失敗", {
+  description: "標題和內容至少需要填寫一項",
+})
+
+// 帶有操作按鈕
+toast.success("API Key 已建立", {
+  description: "請立即複製，關閉後無法再次查看",
+  action: {
+    label: "複製",
+    onClick: () => copyToClipboard(key),
+  },
+})
+
+// 已複製確認
+toast.success("已複製到剪貼簿")
+
+// 刪除成功
+toast.success("分類已刪除", {
+  description: "該分類下的條目已移至 Inbox",
+})
+
+// 健康檢查結果
+toast.success("LLM Provider 連線正常", {
+  description: "回應時間：150ms",
+})
+toast.error("LLM Provider 連線失敗", {
+  description: "連線逾時",
+})
+```
+
+## 樣式規格
+
+| 屬性 | 值 |
+|------|-----|
+| 位置 | 右下角（`bottom-right`） |
+| 最大寬度 | `356px` |
+| 內距 | `p-4` |
+| 圓角 | `rounded-lg` |
+| 陰影 | `shadow-xl` |
+| 背景 | `bg-background border` |
+| 自動關閉 | 5 秒（success）/ 8 秒（error） |
+| 堆疊 | 最多顯示 3 個，新的在最上方 |
+| 動畫 | slide-in from right + fade |
+
+## aibo 專案 Toast 場景
+
+| 操作 | 類型 | 標題 | 描述 |
+|------|------|------|------|
+| 建立 Entry | success | 條目已建立 | - |
+| 更新 Entry | success | 條目已更新 | - |
+| 刪除 Entry | success | 條目已刪除 | - |
+| 建立 Category | success | 分類已建立 | - |
+| 更新 Category | success | 分類已更新 | - |
+| 刪除 Category | success | 分類已刪除 | 該分類下的條目已移至 Inbox |
+| 建立 API Key | success | API Key 已建立 | 請立即複製 |
+| 刪除 API Key | success | API Key 已撤銷 | - |
+| 刪除最後一把 Key | error | 無法刪除 | 不能刪除最後一把有效的 API Key |
+| 建立 LLM Provider | success | Provider 已建立 | - |
+| 更新 LLM Provider | success | Provider 已更新 | - |
+| 刪除 LLM Provider | success | Provider 已刪除 | - |
+| 健康檢查成功 | success | 連線正常 | 回應時間：{N}ms |
+| 健康檢查失敗 | error | 連線失敗 | {error message} |
+| 複製到剪貼簿 | success | 已複製到剪貼簿 | - |
+| API 錯誤 | error | 操作失敗 | {error message} |
+| 網路錯誤 | error | 網路錯誤 | 請檢查網路連線 |
+| 驗證失敗 | error | 輸入錯誤 | {validation message} |
+| 名稱重複 | error | 名稱已存在 | 請使用不同的名稱 |
+
+## Accessibility
+
+- Toast 使用 `role="status"` 和 `aria-live="polite"`
+- Error toast 使用 `aria-live="assertive"`
+- Toast 可透過鍵盤 dismiss
+- 不依賴 toast 作為唯一的錯誤回饋（表單錯誤同時顯示在欄位旁）
+- 自動消失時間足夠閱讀（success 5s，error 8s）

--- a/design/pages/api-keys.md
+++ b/design/pages/api-keys.md
@@ -1,0 +1,185 @@
+# API Key 管理頁規格
+
+## 概述
+
+API Key 管理頁提供 API Key 的列表、建立、撤銷功能。首次使用時需經 Bootstrap 流程建立第一把 Key。
+
+## 路由
+
+`/settings/api-keys`
+
+## 頁面結構
+
+```
+┌──────────────────────────────────────────────┐
+│  API Key 管理                  [建立 API Key] │
+│  管理 API 存取金鑰                            │
+├──────────────────────────────────────────────┤
+│                                              │
+│  ┌──────────────────────────────────────┐   │
+│  │ 名稱   │ Key 前綴  │ 狀態  │ 到期  │ 最後 │ 操作 │
+│  ├────────┼──────────┼──────┼──────┼──────┼────┤
+│  │ default│aibo_a1b2c│Active│ 永不 │ 3分前│ 🗑  │
+│  │ ci-bot │aibo_x9y8z│Active│12/31 │ 從未 │ 🗑  │
+│  └──────────────────────────────────────┘   │
+│                                              │
+└──────────────────────────────────────────────┘
+```
+
+## 元件組成
+
+### PageHeader
+
+```tsx
+<PageHeader
+  title="API Key 管理"
+  description="管理 API 存取金鑰"
+  action={
+    <Button onClick={() => setCreateDialogOpen(true)}>
+      <Plus className="mr-2 h-4 w-4" />
+      建立 API Key
+    </Button>
+  }
+/>
+```
+
+### API Key 列表（DataTable）
+
+欄位定義：
+
+| 欄位 | 寬度 | 內容 |
+|------|------|------|
+| 名稱 | flex-1 | `name`，字重 `font-medium` |
+| Key 前綴 | 120px | `key_prefix`，`font-mono text-sm text-muted-foreground` |
+| 狀態 | 100px | Badge：Active（綠色）/ Expired（琥珀色）/ Inactive（灰色） |
+| 到期日 | 140px | 日期字串或「永不過期」（`text-muted-foreground`） |
+| 最後使用 | 140px | 相對時間或「從未使用」（`text-muted-foreground`） |
+| 操作 | 80px | 撤銷按鈕 |
+
+### 狀態判斷邏輯
+
+```
+if (!is_active) → Inactive（灰色）
+else if (expires_at && expires_at < now) → Expired（琥珀色）
+else → Active（綠色）
+```
+
+### 操作欄
+
+```tsx
+<Button
+  variant="ghost"
+  size="sm"
+  className="text-destructive hover:text-destructive"
+  onClick={() => openRevokeDialog(apiKey)}
+>
+  <Trash2 className="mr-2 h-4 w-4" />
+  撤銷
+</Button>
+```
+
+## 建立 API Key Dialog
+
+### 表單欄位
+
+| 欄位 | 元件 | 驗證 |
+|------|------|------|
+| 名稱 * | Input | 必填，max 50 chars，不可重複 |
+| 到期日 | Select | 選項：永不過期 / 30 天 / 90 天 / 1 年 / 自訂日期 |
+
+### 流程
+
+1. 使用者填寫名稱 + 選擇到期日
+2. 點擊「建立」→ POST API
+3. 成功後顯示「API Key 建立成功」Dialog
+4. 顯示完整 Key + 複製按鈕
+5. 使用者點「我已複製」關閉
+
+### 建立成功 Dialog
+
+```tsx
+<Dialog open={showKeyDialog} onOpenChange={setShowKeyDialog}>
+  <DialogContent className="sm:max-w-[425px]">
+    <DialogHeader>
+      <DialogTitle className="flex items-center gap-2">
+        <AlertTriangle className="h-5 w-5 text-warning" />
+        API Key 已建立
+      </DialogTitle>
+      <DialogDescription>
+        請立即複製此 Key，關閉後將無法再次查看。
+      </DialogDescription>
+    </DialogHeader>
+    <div className="flex items-center gap-2 rounded-md border bg-muted p-3">
+      <code className="flex-1 font-mono text-sm break-all">{newKey}</code>
+      <Button variant="ghost" size="icon" onClick={copyKey}>
+        <Copy className="h-4 w-4" />
+        <span className="sr-only">複製</span>
+      </Button>
+    </div>
+    <DialogFooter>
+      <Button onClick={() => setShowKeyDialog(false)}>我已複製</Button>
+    </DialogFooter>
+  </DialogContent>
+</Dialog>
+```
+
+## 撤銷確認 AlertDialog
+
+```tsx
+<AlertDialog>
+  <AlertDialogContent>
+    <AlertDialogHeader>
+      <AlertDialogTitle>確認撤銷 API Key</AlertDialogTitle>
+      <AlertDialogDescription>
+        撤銷後，使用此 Key 的所有應用程式將無法存取 API。此操作無法復原。
+      </AlertDialogDescription>
+    </AlertDialogHeader>
+    <AlertDialogFooter>
+      <AlertDialogCancel>取消</AlertDialogCancel>
+      <AlertDialogAction className="bg-destructive text-destructive-foreground">
+        撤銷
+      </AlertDialogAction>
+    </AlertDialogFooter>
+  </AlertDialogContent>
+</AlertDialog>
+```
+
+### 最後一把 Key 保護
+
+當只剩一把有效 Key 時，撤銷按鈕 disabled，tooltip 顯示「不能撤銷最後一把有效的 API Key」。
+
+## Bootstrap 狀態
+
+首次使用（無任何 API Key）時，顯示引導畫面：
+
+```
+┌──────────────────────────────────────────────┐
+│                                              │
+│           🔑                                 │
+│                                              │
+│     歡迎使用 aibo                            │
+│     建立你的第一把 API Key 開始使用           │
+│                                              │
+│     [建立 API Key]                           │
+│                                              │
+└──────────────────────────────────────────────┘
+```
+
+## 狀態
+
+| 狀態 | 顯示 |
+|------|------|
+| 載入中 | Skeleton rows |
+| 空（Bootstrap） | 引導畫面 |
+| 正常 | DataTable |
+| API 錯誤 | ErrorState |
+
+## Toast 通知
+
+| 操作 | 類型 | 訊息 |
+|------|------|------|
+| 建立成功 | success | API Key 已建立 |
+| 撤銷成功 | success | API Key 已撤銷 |
+| 撤銷最後一把 | error | 不能撤銷最後一把有效的 API Key |
+| 名稱重複 | error | 名稱已存在 |
+| 複製成功 | success | 已複製到剪貼簿 |

--- a/design/pages/categories.md
+++ b/design/pages/categories.md
@@ -1,0 +1,172 @@
+# 分類管理頁規格
+
+## 概述
+
+分類管理頁提供 Category 的 CRUD 功能，顯示各分類下的條目數量。
+
+## 路由
+
+`/categories`
+
+## 頁面結構
+
+```
+┌──────────────────────────────────────────────────┐
+│  分類管理                            [建立分類]  │
+│  組織你的知識條目                                  │
+├──────────────────────────────────────────────────┤
+│                                                    │
+│  ┌──────────────────────────────────────────┐    │
+│  │ 名稱      │ 描述         │ 條目 │ 排序 │ ⋮  │
+│  ├───────────┼─────────────┼──────┼──────┼───┤
+│  │ Golang    │ Go 語言相關  │  15  │  0   │ ⋮  │
+│  │ Python    │ Python 相關  │   8  │  1   │ ⋮  │
+│  │ 前端      │ 前端開發     │  12  │  2   │ ⋮  │
+│  └──────────────────────────────────────────┘    │
+│                                                    │
+└──────────────────────────────────────────────────┘
+```
+
+## 元件組成
+
+### PageHeader
+
+```tsx
+<PageHeader
+  title="分類管理"
+  description="組織你的知識條目"
+  action={
+    <Button onClick={() => setCreateDialogOpen(true)}>
+      <Plus className="mr-2 h-4 w-4" />
+      建立分類
+    </Button>
+  }
+/>
+```
+
+### DataTable 欄位
+
+| 欄位 | 寬度 | 內容 |
+|------|------|------|
+| 名稱 | flex-1 | `name`，`font-medium` |
+| 描述 | flex-1 | `description`，`text-muted-foreground truncate`；null 時顯示 `—` |
+| 條目數 | 100px | Badge（`secondary`），如 `15 條目` |
+| 排序 | 80px | `sort_order`，`text-muted-foreground` |
+| 操作 | 50px | DropdownMenu |
+
+### 行操作（DropdownMenu）
+
+| 項目 | Icon | 說明 |
+|------|------|------|
+| 編輯 | `Pencil` | 開啟編輯 Dialog |
+| 查看條目 | `FileText` | 導航到 `/entries?category_id={id}` |
+| 刪除 | `Trash2` | 開啟刪除確認 AlertDialog |
+
+## 建立/編輯 Dialog
+
+### 表單欄位
+
+| 欄位 | 元件 | 驗證規則 |
+|------|------|---------|
+| 名稱 * | Input | 必填，max 50 chars，不可重複（case-insensitive） |
+| 描述 | Textarea（2 rows） | 選填，max 200 chars |
+| 排序 | Input (number) | 選填，>= 0，default 0 |
+
+### Dialog 大小
+
+小型（`sm:max-w-[425px]`）
+
+### 建立 vs 編輯差異
+
+| | 建立 | 編輯 |
+|--|------|------|
+| Dialog 標題 | 建立分類 | 編輯分類 |
+| HTTP 方法 | POST | PUT（全量更新） |
+| 按鈕文字 | 建立 | 儲存 |
+
+### 表單結構
+
+```tsx
+<Dialog open={open} onOpenChange={setOpen}>
+  <DialogContent className="sm:max-w-[425px]">
+    <DialogHeader>
+      <DialogTitle>{isEdit ? "編輯分類" : "建立分類"}</DialogTitle>
+    </DialogHeader>
+    <form onSubmit={handleSubmit} className="space-y-4">
+      <div className="space-y-2">
+        <Label htmlFor="name">名稱 *</Label>
+        <Input id="name" placeholder="例如：Golang" maxLength={50} />
+      </div>
+      <div className="space-y-2">
+        <Label htmlFor="description">描述</Label>
+        <Textarea id="description" placeholder="分類描述（選填）" rows={2} maxLength={200} />
+      </div>
+      <div className="space-y-2">
+        <Label htmlFor="sort_order">排序</Label>
+        <Input id="sort_order" type="number" min={0} defaultValue={0} />
+        <p className="text-xs text-muted-foreground">數字越小排越前面</p>
+      </div>
+      <DialogFooter>
+        <Button variant="outline" type="button" onClick={() => setOpen(false)}>取消</Button>
+        <Button type="submit">{isEdit ? "儲存" : "建立"}</Button>
+      </DialogFooter>
+    </form>
+  </DialogContent>
+</Dialog>
+```
+
+## 刪除確認 AlertDialog
+
+```tsx
+<AlertDialog>
+  <AlertDialogContent>
+    <AlertDialogHeader>
+      <AlertDialogTitle>確認刪除分類</AlertDialogTitle>
+      <AlertDialogDescription>
+        刪除「{category.name}」後，該分類下的 {category.entry_count} 筆條目將移至 Inbox。此操作無法復原。
+      </AlertDialogDescription>
+    </AlertDialogHeader>
+    <AlertDialogFooter>
+      <AlertDialogCancel>取消</AlertDialogCancel>
+      <AlertDialogAction className="bg-destructive text-destructive-foreground">
+        刪除
+      </AlertDialogAction>
+    </AlertDialogFooter>
+  </AlertDialogContent>
+</AlertDialog>
+```
+
+## 狀態
+
+| 狀態 | 顯示 |
+|------|------|
+| 載入中 | Skeleton rows |
+| 空 | EmptyState：「還沒有分類」+ 建立按鈕 |
+| 正常 | DataTable |
+| 錯誤 | ErrorState |
+
+### 空狀態
+
+```tsx
+<EmptyState
+  icon={FolderTree}
+  title="還沒有分類"
+  description="建立分類來組織你的知識條目"
+  action={
+    <Button onClick={() => setCreateDialogOpen(true)}>
+      <Plus className="mr-2 h-4 w-4" />
+      建立分類
+    </Button>
+  }
+/>
+```
+
+## Toast 通知
+
+| 操作 | 類型 | 訊息 |
+|------|------|------|
+| 建立成功 | success | 分類已建立 |
+| 更新成功 | success | 分類已更新 |
+| 刪除成功 | success | 分類已刪除（描述：該分類下的條目已移至 Inbox） |
+| 名稱重複 | error | 名稱已存在 |
+| 驗證失敗 | error | 請檢查表單欄位 |

--- a/design/pages/entries.md
+++ b/design/pages/entries.md
@@ -1,0 +1,294 @@
+# 知識條目頁規格
+
+## 概述
+
+知識條目頁包含列表頁、詳情頁、建立/編輯功能。為 aibo 的核心頁面。
+
+## 路由
+
+| 路由 | 頁面 |
+|------|------|
+| `/entries` | 列表頁 |
+| `/entries/:id` | 詳情頁 |
+
+---
+
+## 列表頁
+
+### 頁面結構
+
+```
+┌──────────────────────────────────────────────────┐
+│  知識條目                            [建立條目]  │
+│  管理你的知識庫                                    │
+├──────────────────────────────────────────────────┤
+│                                                    │
+│  ┌──────────────────────────────────────────┐    │
+│  │ 🔍 搜尋條目...    [分類 ▾] [排序 ▾]      │    │
+│  └──────────────────────────────────────────┘    │
+│                                                    │
+│  ┌──────────────────────────────────────────┐    │
+│  │ 標題          │ 分類    │ Tags     │ 更新  │ ⋮ │
+│  ├───────────────┼────────┼─────────┼──────┼───┤
+│  │ Golang 筆記   │ Golang │ go, tip │ 3分前 │ ⋮ │
+│  │ React Hook... │ 前端   │ react   │ 1天前 │ ⋮ │
+│  │ [只有 content]│   —    │         │ 2天前 │ ⋮ │
+│  └──────────────────────────────────────────┘    │
+│                                                    │
+│  共 25 筆，第 1 / 3 頁         [< 上一頁] [下一頁 >] │
+└──────────────────────────────────────────────────┘
+```
+
+### 篩選列
+
+```tsx
+<div className="flex flex-col gap-4 sm:flex-row sm:items-center">
+  <SearchInput
+    placeholder="搜尋條目..."
+    value={search}
+    onChange={setSearch}
+    className="sm:w-[300px]"
+  />
+  <div className="flex gap-2">
+    <Select value={categoryFilter} onValueChange={setCategoryFilter}>
+      <SelectTrigger className="w-[160px]">
+        <SelectValue placeholder="所有分類" />
+      </SelectTrigger>
+      <SelectContent>
+        <SelectItem value="all">所有分類</SelectItem>
+        <SelectItem value="null">未分類</SelectItem>
+        {categories.map((cat) => (
+          <SelectItem key={cat.id} value={cat.id}>{cat.name}</SelectItem>
+        ))}
+      </SelectContent>
+    </Select>
+    <Select value={sortBy} onValueChange={setSortBy}>
+      <SelectTrigger className="w-[140px]">
+        <SelectValue placeholder="排序" />
+      </SelectTrigger>
+      <SelectContent>
+        <SelectItem value="created_at:desc">最新建立</SelectItem>
+        <SelectItem value="updated_at:desc">最近更新</SelectItem>
+        <SelectItem value="title:asc">標題 A-Z</SelectItem>
+      </SelectContent>
+    </Select>
+  </div>
+</div>
+```
+
+### DataTable 欄位
+
+| 欄位 | 寬度 | 排序 | 內容 |
+|------|------|------|------|
+| 標題 | flex-1 | 是 | `title`（truncate）；無 title 時顯示 `content_preview` 灰色斜體 |
+| 分類 | 120px | 否 | Badge（`secondary`）或 `—`（灰色） |
+| Tags | 200px | 否 | Badge 列表（最多 3 個 + `+N`） |
+| 更新時間 | 140px | 是 | 相對時間（`text-muted-foreground text-xs`） |
+| 操作 | 50px | 否 | DropdownMenu（查看、編輯、移至分類、歸檔、刪除） |
+
+### 標題欄位渲染
+
+```tsx
+function EntryTitleCell({ entry }) {
+  if (entry.title) {
+    return <span className="font-medium truncate">{entry.title}</span>
+  }
+  return (
+    <span className="text-muted-foreground italic truncate">
+      {entry.content_preview}
+    </span>
+  )
+}
+```
+
+### 行操作（DropdownMenu）
+
+| 項目 | Icon | 說明 |
+|------|------|------|
+| 查看 | `Eye` | 導航到 `/entries/:id` |
+| 編輯 | `Pencil` | 開啟編輯 Dialog |
+| 移至分類 | `FolderInput` | 開啟分類選擇 Popover |
+| 歸檔 | `Archive` | PATCH `is_archived: true` |
+| 刪除 | `Trash2` | 開啟刪除確認 AlertDialog |
+
+---
+
+## 詳情頁
+
+### 路由
+
+`/entries/:id`
+
+### 頁面結構
+
+```
+┌──────────────────────────────────────────────────┐
+│  ← 返回列表                                      │
+│                                                    │
+│  ┌──────────────────────────────────────────┐    │
+│  │  Golang goroutine 筆記          [編輯] [⋮] │    │
+│  │                                            │    │
+│  │  分類：[Golang]  Tags：[go] [concurrency]  │    │
+│  │  來源：manual  建立：2026-04-20            │    │
+│  │  更新：2026-04-22 15:30                    │    │
+│  ├──────────────────────────────────────────┤    │
+│  │                                            │    │
+│  │  ## 重要觀念                              │    │
+│  │                                            │    │
+│  │  Goroutine 是 Go 的輕量級執行緒...        │    │
+│  │                                            │    │
+│  │  ```go                                    │    │
+│  │  go func() {                              │    │
+│  │      // ...                               │    │
+│  │  }()                                      │    │
+│  │  ```                                      │    │
+│  │                                            │    │
+│  └──────────────────────────────────────────┘    │
+│                                                    │
+└──────────────────────────────────────────────────┘
+```
+
+### 元件結構
+
+```tsx
+<div className="space-y-6">
+  {/* 返回連結 */}
+  <Button variant="ghost" size="sm" asChild>
+    <Link href="/entries">
+      <ArrowLeft className="mr-2 h-4 w-4" />
+      返回列表
+    </Link>
+  </Button>
+
+  {/* Entry Card */}
+  <Card>
+    <CardHeader>
+      <div className="flex items-center justify-between">
+        <CardTitle className="text-xl">{entry.title}</CardTitle>
+        <div className="flex gap-2">
+          <Button variant="outline" size="sm" onClick={openEditDialog}>
+            <Pencil className="mr-2 h-4 w-4" />
+            編輯
+          </Button>
+          <DropdownMenu>{/* 更多操作 */}</DropdownMenu>
+        </div>
+      </div>
+      <div className="flex flex-wrap items-center gap-3 text-sm text-muted-foreground">
+        {entry.category && <Badge variant="secondary">{entry.category.name}</Badge>}
+        {entry.tags.map((tag) => (
+          <Badge key={tag} variant="outline">{tag}</Badge>
+        ))}
+        <span>建立：{formatDate(entry.created_at)}</span>
+        <span>更新：{formatDate(entry.updated_at)}</span>
+      </div>
+    </CardHeader>
+    <CardContent>
+      <div className="prose prose-sm dark:prose-invert max-w-none">
+        {/* Markdown 渲染 */}
+      </div>
+    </CardContent>
+  </Card>
+</div>
+```
+
+---
+
+## 建立/編輯 Dialog
+
+### 表單欄位
+
+| 欄位 | 元件 | 驗證規則 |
+|------|------|---------|
+| 標題 | Input | max 100 chars，與內容至少填一項 |
+| 內容 | Textarea（6 rows） | Markdown 格式，與標題至少填一項 |
+| 分類 | Select（CategorySelector） | 選填，必須為已存在的 category |
+| Tags | TagInput | 選填，陣列 |
+| 來源 | Input | 選填，max 500 chars |
+| 來源類型 | Select | 選填，enum: manual / git / gcal |
+
+### CategorySelector
+
+```tsx
+<Select value={categoryId} onValueChange={setCategoryId}>
+  <SelectTrigger>
+    <SelectValue placeholder="選擇分類（選填）" />
+  </SelectTrigger>
+  <SelectContent>
+    <SelectItem value="none">不分類</SelectItem>
+    {categories.map((cat) => (
+      <SelectItem key={cat.id} value={cat.id}>{cat.name}</SelectItem>
+    ))}
+  </SelectContent>
+</Select>
+```
+
+### Dialog 大小
+
+- 建立/編輯 Dialog 使用中型（`sm:max-w-[600px]`）
+
+### 表單提交
+
+- 建立：POST `/api/v1/entries`
+- 編輯：PATCH `/api/v1/entries/:id`
+- 成功後關閉 Dialog + Toast 通知 + 刷新列表
+
+---
+
+## 刪除確認
+
+```tsx
+<AlertDialog>
+  <AlertDialogContent>
+    <AlertDialogHeader>
+      <AlertDialogTitle>確認刪除</AlertDialogTitle>
+      <AlertDialogDescription>
+        此操作無法復原。確定要刪除「{entry.title}」嗎？
+      </AlertDialogDescription>
+    </AlertDialogHeader>
+    <AlertDialogFooter>
+      <AlertDialogCancel>取消</AlertDialogCancel>
+      <AlertDialogAction className="bg-destructive text-destructive-foreground">
+        刪除
+      </AlertDialogAction>
+    </AlertDialogFooter>
+  </AlertDialogContent>
+</AlertDialog>
+```
+
+## 狀態
+
+| 狀態 | 列表頁 | 詳情頁 |
+|------|--------|--------|
+| 載入中 | Skeleton table rows | Skeleton Card |
+| 空 | EmptyState + 建立按鈕 | - |
+| 正常 | DataTable | Entry Card |
+| 搜尋無結果 | 「找不到符合的條目」 | - |
+| 404 | - | 條目不存在 + 返回列表 |
+| 錯誤 | ErrorState | ErrorState |
+
+### 空狀態
+
+```tsx
+<EmptyState
+  icon={FileText}
+  title="還沒有知識條目"
+  description="建立你的第一筆知識條目開始使用"
+  action={
+    <Button onClick={() => setCreateDialogOpen(true)}>
+      <Plus className="mr-2 h-4 w-4" />
+      建立條目
+    </Button>
+  }
+/>
+```
+
+## Toast 通知
+
+| 操作 | 類型 | 訊息 |
+|------|------|------|
+| 建立成功 | success | 條目已建立 |
+| 更新成功 | success | 條目已更新 |
+| 刪除成功 | success | 條目已刪除 |
+| 歸檔成功 | success | 條目已歸檔 |
+| 驗證失敗 | error | 標題和內容至少需要填寫一項 |
+| 分類不存在 | error | 指定的分類不存在 |

--- a/design/pages/inbox.md
+++ b/design/pages/inbox.md
@@ -1,0 +1,217 @@
+# Inbox 頁規格
+
+## 概述
+
+Inbox 是 aibo 的預設首頁，顯示所有未分類且未歸檔的知識條目。支援快速新增、搜尋、分類指派。
+
+## 路由
+
+`/inbox`（首頁 `/` redirect 至此）
+
+## 頁面結構
+
+```
+┌──────────────────────────────────────────────────┐
+│  Inbox                               [快速新增]  │
+│  未分類的知識條目                                  │
+├──────────────────────────────────────────────────┤
+│                                                    │
+│  ┌──────────────────────────────────────────┐    │
+│  │ 🔍 搜尋 Inbox...              [排序 ▾]   │    │
+│  └──────────────────────────────────────────┘    │
+│                                                    │
+│  ┌──────────────────────────────────────────┐    │
+│  │ 標題            │ Tags      │ 建立時間  │ ⋮  │
+│  ├─────────────────┼──────────┼──────────┼───┤
+│  │ 快速筆記：明天要 │          │ 5 分鐘前  │ ⋮  │
+│  │ 查 goroutine... │          │          │    │
+│  │ React 效能優化  │ react    │ 1 天前   │ ⋮  │
+│  └──────────────────────────────────────────┘    │
+│                                                    │
+│  共 12 筆，第 1 / 1 頁                            │
+└──────────────────────────────────────────────────┘
+```
+
+## 與 Entry 列表頁的差異
+
+| 特性 | Inbox | Entry 列表 |
+|------|-------|-----------|
+| 查詢參數 | `category_id=null&is_archived=false`（固定） | 使用者自選 |
+| 分類篩選 | 無（固定未分類） | 有 |
+| 行操作重點 | 移至分類、歸檔 | 查看、編輯 |
+| 操作按鈕 | 快速新增 | 建立條目 |
+| 空狀態 | 「太棒了，沒有待處理的條目！」 | 「還沒有知識條目」 |
+
+## 元件組成
+
+### PageHeader
+
+```tsx
+<PageHeader
+  title="Inbox"
+  description="未分類的知識條目"
+  action={
+    <Button onClick={() => setQuickAddOpen(true)}>
+      <Plus className="mr-2 h-4 w-4" />
+      快速新增
+    </Button>
+  }
+/>
+```
+
+### 篩選列
+
+Inbox 篩選較簡單（無分類篩選）：
+
+```tsx
+<div className="flex flex-col gap-4 sm:flex-row sm:items-center">
+  <SearchInput
+    placeholder="搜尋 Inbox..."
+    value={search}
+    onChange={setSearch}
+    className="sm:w-[300px]"
+  />
+  <Select value={sortBy} onValueChange={setSortBy}>
+    <SelectTrigger className="w-[140px]">
+      <SelectValue placeholder="排序" />
+    </SelectTrigger>
+    <SelectContent>
+      <SelectItem value="created_at:desc">最新建立</SelectItem>
+      <SelectItem value="updated_at:desc">最近更新</SelectItem>
+    </SelectContent>
+  </Select>
+</div>
+```
+
+### DataTable 欄位
+
+| 欄位 | 寬度 | 內容 |
+|------|------|------|
+| 標題/內容 | flex-1 | `title` 或 `content_preview`（灰色斜體） |
+| Tags | 180px | Badge 列表 |
+| 建立時間 | 140px | 相對時間 |
+| 操作 | 50px | DropdownMenu |
+
+### 行操作（DropdownMenu）
+
+| 項目 | Icon | 說明 |
+|------|------|------|
+| 查看 | `Eye` | 導航到 `/entries/:id` |
+| 編輯 | `Pencil` | 開啟編輯 Dialog |
+| 移至分類 | `FolderInput` | 開啟分類選擇 Popover（重點操作） |
+| 歸檔 | `Archive` | PATCH `is_archived: true` |
+| 刪除 | `Trash2` | 開啟刪除確認 |
+
+### 移至分類 Popover
+
+```tsx
+<Popover>
+  <PopoverTrigger asChild>
+    <Button variant="ghost" size="sm">
+      <FolderInput className="mr-2 h-4 w-4" />
+      移至分類
+    </Button>
+  </PopoverTrigger>
+  <PopoverContent className="w-[200px] p-2">
+    <div className="space-y-1">
+      {categories.map((cat) => (
+        <Button
+          key={cat.id}
+          variant="ghost"
+          className="w-full justify-start"
+          onClick={() => moveToCategory(entryId, cat.id)}
+        >
+          <FolderTree className="mr-2 h-4 w-4" />
+          {cat.name}
+        </Button>
+      ))}
+    </div>
+  </PopoverContent>
+</Popover>
+```
+
+## 快速新增 Dialog
+
+簡化版的建立表單，只保留最關鍵的欄位：
+
+```tsx
+<Dialog open={quickAddOpen} onOpenChange={setQuickAddOpen}>
+  <DialogContent className="sm:max-w-[425px]">
+    <DialogHeader>
+      <DialogTitle>快速新增</DialogTitle>
+      <DialogDescription>快速記錄想法，之後再整理</DialogDescription>
+    </DialogHeader>
+    <form className="space-y-4">
+      <div className="space-y-2">
+        <Label htmlFor="title">標題</Label>
+        <Input id="title" placeholder="選填" />
+      </div>
+      <div className="space-y-2">
+        <Label htmlFor="content">內容</Label>
+        <Textarea
+          id="content"
+          placeholder="在這裡記下你的想法..."
+          rows={4}
+        />
+      </div>
+      <div className="space-y-2">
+        <Label>Tags</Label>
+        <TagInput value={tags} onChange={setTags} />
+      </div>
+      <DialogFooter>
+        <Button variant="outline" onClick={() => setQuickAddOpen(false)}>取消</Button>
+        <Button type="submit">新增</Button>
+      </DialogFooter>
+    </form>
+  </DialogContent>
+</Dialog>
+```
+
+## 狀態
+
+| 狀態 | 顯示 |
+|------|------|
+| 載入中 | Skeleton rows |
+| 空（全部處理完） | 慶祝空狀態 |
+| 正常 | DataTable |
+| 搜尋無結果 | 「找不到符合的條目」 |
+| 錯誤 | ErrorState |
+
+### 空狀態（慶祝版）
+
+```tsx
+<div className="flex flex-col items-center justify-center py-16 text-center">
+  <div className="flex h-16 w-16 items-center justify-center rounded-full bg-success/10 mb-4">
+    <CheckCircle2 className="h-8 w-8 text-success" />
+  </div>
+  <h3 className="text-lg font-semibold">太棒了！</h3>
+  <p className="text-sm text-muted-foreground mt-1">
+    沒有待處理的條目，所有知識都已歸類
+  </p>
+  <Button variant="outline" className="mt-4" onClick={() => setQuickAddOpen(true)}>
+    <Plus className="mr-2 h-4 w-4" />
+    記錄新想法
+  </Button>
+</div>
+```
+
+## Sidebar Badge 連動
+
+Inbox 頁的條目數量會同步顯示在 Sidebar 的 Inbox 項目旁：
+
+```tsx
+// Sidebar 中的 Inbox 項目
+<SidebarMenuBadge>{inboxCount}</SidebarMenuBadge>
+```
+
+- 當 Inbox 為空時，不顯示 Badge
+- 新增/移出/歸檔/刪除操作後，自動更新 Badge 數字
+
+## Toast 通知
+
+| 操作 | 類型 | 訊息 |
+|------|------|------|
+| 快速新增成功 | success | 已新增至 Inbox |
+| 移至分類成功 | success | 已移至「{category.name}」 |
+| 歸檔成功 | success | 條目已歸檔 |
+| 刪除成功 | success | 條目已刪除 |

--- a/design/pages/layout.md
+++ b/design/pages/layout.md
@@ -1,0 +1,228 @@
+# 整體 Layout 規格
+
+## 概述
+
+aibo 使用固定左側 Sidebar + Header + Main Content 的經典管理介面佈局。基於 shadcn/ui Sidebar + Next.js App Router layout。
+
+## 結構
+
+```
+┌──────────────────────────────────────────────────┐
+│                                                    │
+│  ┌─────────┬──────────────────────────────────┐  │
+│  │         │  Header（頁面標題 + 操作按鈕）    │  │
+│  │         ├──────────────────────────────────┤  │
+│  │ Sidebar │                                    │  │
+│  │         │  Main Content                      │  │
+│  │ - Inbox │                                    │  │
+│  │ - 條目  │                                    │  │
+│  │ - 分類  │                                    │  │
+│  │         │                                    │  │
+│  │ 設定    │                                    │  │
+│  │ - API   │                                    │  │
+│  │ - LLM   │                                    │  │
+│  │         │                                    │  │
+│  │         │                                    │  │
+│  │ v1.0.0  │                                    │  │
+│  └─────────┴──────────────────────────────────┘  │
+│                                                    │
+└──────────────────────────────────────────────────┘
+```
+
+## Next.js App Router 結構
+
+```
+app/
+├── layout.tsx              ← Root layout（SidebarProvider + Toaster）
+├── page.tsx                ← Redirect to /inbox
+├── (dashboard)/
+│   ├── layout.tsx          ← Dashboard layout（Sidebar + SidebarInset）
+│   ├── inbox/
+│   │   └── page.tsx
+│   ├── entries/
+│   │   ├── page.tsx        ← 列表頁
+│   │   └── [id]/
+│   │       └── page.tsx    ← 詳情頁
+│   ├── categories/
+│   │   └── page.tsx
+│   └── settings/
+│       ├── api-keys/
+│       │   └── page.tsx
+│       └── llm-providers/
+│           └── page.tsx
+```
+
+## Root Layout
+
+```tsx
+// app/layout.tsx
+import { Inter, JetBrains_Mono } from "next/font/google"
+import { Toaster } from "@/components/ui/sonner"
+
+const inter = Inter({ subsets: ["latin"], variable: "--font-sans" })
+const jetbrainsMono = JetBrains_Mono({ subsets: ["latin"], variable: "--font-mono" })
+
+export default function RootLayout({ children }) {
+  return (
+    <html lang="zh-Hant" suppressHydrationWarning>
+      <body className={`${inter.variable} ${jetbrainsMono.variable} font-sans antialiased`}>
+        {children}
+        <Toaster position="bottom-right" richColors />
+      </body>
+    </html>
+  )
+}
+```
+
+## Dashboard Layout
+
+```tsx
+// app/(dashboard)/layout.tsx
+import { SidebarProvider, SidebarInset, SidebarTrigger } from "@/components/ui/sidebar"
+import { AppSidebar } from "@/components/app-sidebar"
+
+export default function DashboardLayout({ children }) {
+  return (
+    <SidebarProvider>
+      <AppSidebar />
+      <SidebarInset>
+        <header className="flex h-14 items-center gap-4 border-b px-6">
+          <SidebarTrigger className="-ml-2" />
+          {/* 麵包屑或頁面標題由各頁面提供 */}
+        </header>
+        <main className="flex-1 p-6">
+          {children}
+        </main>
+      </SidebarInset>
+    </SidebarProvider>
+  )
+}
+```
+
+## 尺寸規格
+
+### Sidebar
+
+| 屬性 | 值 |
+|------|-----|
+| 展開寬度 | 256px (`w-64`) |
+| 收合寬度 | 64px (`w-16`) |
+| 高度 | `h-screen`（固定滿版） |
+| 位置 | `sticky top-0` |
+
+### Header
+
+| 屬性 | 值 |
+|------|-----|
+| 高度 | 56px (`h-14`) |
+| 內距 | `px-6` |
+| 邊框 | `border-b` |
+| 背景 | `bg-background` |
+| 位置 | `sticky top-0 z-10` |
+
+### Main Content
+
+| 屬性 | 值 |
+|------|-----|
+| 內距 | `p-6`（desktop）/ `p-4`（mobile） |
+| 最大寬度 | 無限制（隨 Sidebar 狀態自適應） |
+| 背景 | `bg-background` |
+| 溢出 | `overflow-y-auto` |
+
+## 頁面標題區域
+
+每個頁面頂部包含統一的標題區域：
+
+```tsx
+// 共用 PageHeader 元件
+function PageHeader({
+  title,
+  description,
+  action,
+}: {
+  title: string
+  description?: string
+  action?: React.ReactNode
+}) {
+  return (
+    <div className="flex items-center justify-between mb-6">
+      <div>
+        <h1 className="text-2xl font-bold tracking-tight">{title}</h1>
+        {description && (
+          <p className="text-muted-foreground mt-1">{description}</p>
+        )}
+      </div>
+      {action && <div>{action}</div>}
+    </div>
+  )
+}
+```
+
+### 各頁面標題
+
+| 頁面 | 標題 | 描述 | 操作按鈕 |
+|------|------|------|---------|
+| Inbox | Inbox | 未分類的知識條目 | 快速新增 |
+| 知識條目 | 知識條目 | 管理你的知識庫 | 建立條目 |
+| 條目詳情 | {entry.title} | - | 編輯 / 刪除 |
+| 分類管理 | 分類管理 | 組織你的知識條目 | 建立分類 |
+| API Key | API Key 管理 | 管理 API 存取金鑰 | 建立 API Key |
+| LLM Provider | LLM Provider | 管理 LLM 服務提供者 | 新增 Provider |
+
+## 響應式斷點
+
+| 斷點 | Sidebar | Header | Content |
+|------|---------|--------|---------|
+| Mobile (< 768px) | 隱藏（overlay） | hamburger + 標題 | `p-4` 滿版 |
+| Tablet (768-1023px) | 收合（icon only） | 標題 + 操作 | `p-6` |
+| Desktop (>= 1024px) | 展開 | 標題 + 操作 | `p-6` |
+
+## 載入狀態
+
+頁面初始載入時顯示 skeleton：
+
+```tsx
+function PageSkeleton() {
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center justify-between">
+        <div className="space-y-2">
+          <Skeleton className="h-8 w-[200px]" />
+          <Skeleton className="h-4 w-[300px]" />
+        </div>
+        <Skeleton className="h-10 w-[120px]" />
+      </div>
+      <Skeleton className="h-[400px] w-full rounded-md" />
+    </div>
+  )
+}
+```
+
+## 錯誤狀態
+
+API 錯誤頁面：
+
+```tsx
+function ErrorState({ message, onRetry }: { message: string; onRetry: () => void }) {
+  return (
+    <div className="flex flex-col items-center justify-center py-12 text-center">
+      <AlertCircle className="h-12 w-12 text-destructive mb-4" />
+      <h3 className="text-lg font-semibold">發生錯誤</h3>
+      <p className="text-sm text-muted-foreground mt-1">{message}</p>
+      <Button variant="outline" className="mt-4" onClick={onRetry}>
+        <RefreshCw className="mr-2 h-4 w-4" />
+        重試
+      </Button>
+    </div>
+  )
+}
+```
+
+## Accessibility
+
+- `<html lang="zh-Hant">` 設定語言
+- `<main>` 標籤包裹主內容
+- `<nav>` 標籤包裹 Sidebar
+- `<header>` 標籤包裹頂部列
+- Skip link：頁面頂部提供「跳到主要內容」連結
+- 所有頁面標題使用適當的 heading level（h1 唯一）

--- a/design/pages/llm-providers.md
+++ b/design/pages/llm-providers.md
@@ -1,0 +1,259 @@
+# LLM Provider 設定頁規格
+
+## 概述
+
+LLM Provider 管理頁提供 Provider 的 CRUD、設為預設、健康檢查功能。
+
+## 路由
+
+`/settings/llm-providers`
+
+## 頁面結構
+
+```
+┌──────────────────────────────────────────────────────┐
+│  LLM Provider                        [新增 Provider] │
+│  管理 LLM 服務提供者                                   │
+├──────────────────────────────────────────────────────┤
+│                                                        │
+│  ┌──────────────────────────────────────────────┐    │
+│  │ 名稱          │ Endpoint    │ Model │ 狀態  │健康│ ⋮ │
+│  ├───────────────┼────────────┼──────┼──────┼────┼──┤
+│  │ LM Studio     │ localhost  │llama │Active│ ● │ ⋮ │
+│  │  [Default]    │ :1234/v1   │  -3  │      │   │   │
+│  │ OpenAI        │ api.openai │gpt-4 │Active│ ● │ ⋮ │
+│  │               │ .com/v1    │      │      │   │   │
+│  └──────────────────────────────────────────────┘    │
+│                                                        │
+└──────────────────────────────────────────────────────┘
+```
+
+## 元件組成
+
+### PageHeader
+
+```tsx
+<PageHeader
+  title="LLM Provider"
+  description="管理 LLM 服務提供者"
+  action={
+    <Button onClick={() => setCreateDialogOpen(true)}>
+      <Plus className="mr-2 h-4 w-4" />
+      新增 Provider
+    </Button>
+  }
+/>
+```
+
+### DataTable 欄位
+
+| 欄位 | 寬度 | 內容 |
+|------|------|------|
+| 名稱 | flex-1 | `name`（`font-medium`）+ Default badge（若 `is_default`） |
+| Endpoint | 200px | `endpoint_url`（`font-mono text-xs text-muted-foreground truncate`） |
+| Model | 120px | `model_name` |
+| 狀態 | 100px | Active / Inactive badge |
+| 健康 | 100px | HealthStatus 指示器 |
+| 操作 | 50px | DropdownMenu |
+
+### 名稱欄位渲染
+
+```tsx
+function ProviderNameCell({ provider }) {
+  return (
+    <div className="flex items-center gap-2">
+      <span className="font-medium">{provider.name}</span>
+      {provider.is_default && (
+        <Badge variant="default" className="text-xs">Default</Badge>
+      )}
+    </div>
+  )
+}
+```
+
+### HealthStatus 元件
+
+```tsx
+function HealthStatus({ status }: { status: "healthy" | "unhealthy" | "unknown" }) {
+  const config = {
+    healthy: {
+      icon: CheckCircle2,
+      label: "Healthy",
+      className: "text-success",
+    },
+    unhealthy: {
+      icon: XCircle,
+      label: "Unhealthy",
+      className: "text-destructive",
+    },
+    unknown: {
+      icon: HelpCircle,
+      label: "未測試",
+      className: "text-muted-foreground",
+    },
+  }
+  const { icon: Icon, label, className } = config[status]
+
+  return (
+    <div className={`flex items-center gap-1.5 ${className}`}>
+      <Icon className="h-4 w-4" />
+      <span className="text-xs">{label}</span>
+    </div>
+  )
+}
+```
+
+### 行操作（DropdownMenu）
+
+| 項目 | Icon | 條件 | 說明 |
+|------|------|------|------|
+| 編輯 | `Pencil` | 永遠可用 | 開啟編輯 Dialog |
+| 設為預設 | `Star` | 非 default 時 | PUT + `is_default: true` |
+| 健康檢查 | `Activity` | 永遠可用 | POST health check |
+| 刪除 | `Trash2` | 永遠可用 | 開啟刪除確認 |
+
+## 建立/編輯 Dialog
+
+### 表單欄位
+
+| 欄位 | 元件 | 驗證規則 |
+|------|------|---------|
+| 名稱 * | Input | 必填，max 50 chars，不可重複 |
+| Endpoint URL * | Input | 必填，max 500 chars，有效 URL 格式 |
+| API Key | Input (password) | 選填，max 500 chars |
+| Model 名稱 * | Input | 必填，max 100 chars |
+| 設為預設 | Checkbox | 選填，default false |
+| 啟用 | Checkbox | 選填，default true |
+| 進階設定 | Collapsible | 可展開區塊 |
+
+### 進階設定（Config）
+
+| 欄位 | 元件 | 預設 |
+|------|------|------|
+| Temperature | Input (number) | 0.7 |
+| Max Tokens | Input (number) | 1000 |
+| Timeout (秒) | Input (number) | 30 |
+
+### Dialog 大小
+
+中型（`sm:max-w-[600px]`）
+
+### API Key 欄位特殊處理
+
+- 建立時：顯示為密碼欄位，帶顯示/隱藏切換
+- 編輯時：顯示「已設定」或「未設定」，提供「更新 API Key」按鈕
+- 清除 API Key：設為 null
+
+```tsx
+<div className="space-y-2">
+  <Label>API Key</Label>
+  <div className="relative">
+    <Input
+      type={showKey ? "text" : "password"}
+      placeholder="選填，例如 sk-..."
+      {...field}
+    />
+    <Button
+      variant="ghost"
+      size="icon"
+      className="absolute right-0 top-0"
+      onClick={() => setShowKey(!showKey)}
+    >
+      {showKey ? <EyeOff className="h-4 w-4" /> : <Eye className="h-4 w-4" />}
+    </Button>
+  </div>
+  <p className="text-xs text-muted-foreground">
+    API Key 將以加密方式儲存，不會以明文顯示
+  </p>
+</div>
+```
+
+### 進階設定展開
+
+```tsx
+<Collapsible>
+  <CollapsibleTrigger asChild>
+    <Button variant="ghost" size="sm" className="gap-2">
+      <Settings className="h-4 w-4" />
+      進階設定
+      <ChevronDown className="h-4 w-4" />
+    </Button>
+  </CollapsibleTrigger>
+  <CollapsibleContent className="space-y-4 pt-4">
+    {/* Temperature, Max Tokens, Timeout 欄位 */}
+  </CollapsibleContent>
+</Collapsible>
+```
+
+## 刪除確認 AlertDialog
+
+```tsx
+<AlertDialog>
+  <AlertDialogContent>
+    <AlertDialogHeader>
+      <AlertDialogTitle>確認刪除 LLM Provider</AlertDialogTitle>
+      <AlertDialogDescription>
+        確定要刪除「{provider.name}」嗎？此操作無法復原。
+        {provider.is_default && (
+          <span className="block mt-2 font-medium text-warning">
+            注意：這是目前的預設 Provider，刪除後將沒有預設 Provider。
+          </span>
+        )}
+      </AlertDialogDescription>
+    </AlertDialogHeader>
+    <AlertDialogFooter>
+      <AlertDialogCancel>取消</AlertDialogCancel>
+      <AlertDialogAction className="bg-destructive text-destructive-foreground">
+        刪除
+      </AlertDialogAction>
+    </AlertDialogFooter>
+  </AlertDialogContent>
+</AlertDialog>
+```
+
+## 健康檢查互動
+
+點擊健康檢查後：
+
+1. 對應行的 HealthStatus 顯示 loading spinner
+2. POST `/api/v1/llm-providers/:id/health`
+3. 成功：更新 HealthStatus + Toast
+4. 失敗：更新 HealthStatus + Error Toast
+
+## 狀態
+
+| 狀態 | 顯示 |
+|------|------|
+| 載入中 | Skeleton rows |
+| 空 | EmptyState：「還沒有 LLM Provider」+ 新增按鈕 |
+| 正常 | DataTable |
+| 錯誤 | ErrorState |
+
+### 空狀態
+
+```tsx
+<EmptyState
+  icon={Bot}
+  title="還沒有 LLM Provider"
+  description="新增 LLM 服務提供者以啟用智慧功能"
+  action={
+    <Button onClick={() => setCreateDialogOpen(true)}>
+      <Plus className="mr-2 h-4 w-4" />
+      新增 Provider
+    </Button>
+  }
+/>
+```
+
+## Toast 通知
+
+| 操作 | 類型 | 訊息 |
+|------|------|------|
+| 建立成功 | success | Provider 已建立 |
+| 更新成功 | success | Provider 已更新 |
+| 刪除成功 | success | Provider 已刪除 |
+| 設為預設 | success | 已設為預設 Provider |
+| 健康檢查成功 | success | 連線正常（描述：回應時間 {N}ms） |
+| 健康檢查失敗 | error | 連線失敗（描述：{error}） |
+| 名稱重複 | error | 名稱已存在 |
+| URL 格式錯誤 | error | Endpoint URL 格式不正確 |

--- a/design/tokens/colors.md
+++ b/design/tokens/colors.md
@@ -1,0 +1,164 @@
+# 色彩系統（Color Tokens）
+
+## 概述
+
+aibo 使用基於 HSL 的語義色彩系統，搭配 Tailwind CSS v4 的 CSS 自訂屬性。支援 Light / Dark 雙主題，所有色彩對比度符合 WCAG 2.1 AA 標準（>= 4.5:1）。
+
+## 基礎色彩變數
+
+以下定義於 `globals.css`，使用 Tailwind CSS v4 的 `@theme` 語法：
+
+```css
+@layer base {
+  :root {
+    --background: 0 0% 100%;
+    --foreground: 240 10% 3.9%;
+
+    --card: 0 0% 100%;
+    --card-foreground: 240 10% 3.9%;
+
+    --popover: 0 0% 100%;
+    --popover-foreground: 240 10% 3.9%;
+
+    --primary: 240 5.9% 10%;
+    --primary-foreground: 0 0% 98%;
+
+    --secondary: 240 4.8% 95.9%;
+    --secondary-foreground: 240 5.9% 10%;
+
+    --accent: 240 4.8% 95.9%;
+    --accent-foreground: 240 5.9% 10%;
+
+    --muted: 240 4.8% 95.9%;
+    --muted-foreground: 240 3.8% 46.1%;
+
+    --destructive: 0 84.2% 60.2%;
+    --destructive-foreground: 0 0% 98%;
+
+    --warning: 38 92% 50%;
+    --warning-foreground: 38 92% 14%;
+
+    --success: 142 76% 36%;
+    --success-foreground: 0 0% 98%;
+
+    --border: 240 5.9% 90%;
+    --input: 240 5.9% 90%;
+    --ring: 240 5.9% 10%;
+
+    --radius: 0.5rem;
+
+    --sidebar-background: 0 0% 98%;
+    --sidebar-foreground: 240 5.3% 26.1%;
+    --sidebar-primary: 240 5.9% 10%;
+    --sidebar-primary-foreground: 0 0% 98%;
+    --sidebar-accent: 240 4.8% 95.9%;
+    --sidebar-accent-foreground: 240 5.9% 10%;
+    --sidebar-border: 220 13% 91%;
+    --sidebar-ring: 240 5.9% 10%;
+  }
+
+  .dark {
+    --background: 240 10% 3.9%;
+    --foreground: 0 0% 98%;
+
+    --card: 240 10% 3.9%;
+    --card-foreground: 0 0% 98%;
+
+    --popover: 240 10% 3.9%;
+    --popover-foreground: 0 0% 98%;
+
+    --primary: 0 0% 98%;
+    --primary-foreground: 240 5.9% 10%;
+
+    --secondary: 240 3.7% 15.9%;
+    --secondary-foreground: 0 0% 98%;
+
+    --accent: 240 3.7% 15.9%;
+    --accent-foreground: 0 0% 98%;
+
+    --muted: 240 3.7% 15.9%;
+    --muted-foreground: 240 5% 64.9%;
+
+    --destructive: 0 62.8% 30.6%;
+    --destructive-foreground: 0 0% 98%;
+
+    --warning: 38 92% 50%;
+    --warning-foreground: 38 92% 14%;
+
+    --success: 142 76% 36%;
+    --success-foreground: 0 0% 98%;
+
+    --border: 240 3.7% 15.9%;
+    --input: 240 3.7% 15.9%;
+    --ring: 240 4.9% 83.9%;
+
+    --sidebar-background: 240 5.9% 10%;
+    --sidebar-foreground: 240 4.8% 95.9%;
+    --sidebar-primary: 0 0% 98%;
+    --sidebar-primary-foreground: 240 5.9% 10%;
+    --sidebar-accent: 240 3.7% 15.9%;
+    --sidebar-accent-foreground: 240 4.8% 95.9%;
+    --sidebar-border: 240 3.7% 15.9%;
+    --sidebar-ring: 240 4.9% 83.9%;
+  }
+}
+```
+
+## 語義色彩對照表
+
+| Token | 用途 | Light 色值 | Dark 色值 |
+|-------|------|-----------|----------|
+| `primary` | 主要按鈕、重要操作、連結 | 深灰藍 `hsl(240 5.9% 10%)` | 白色 `hsl(0 0% 98%)` |
+| `secondary` | 次要按鈕、輔助操作 | 淺灰 `hsl(240 4.8% 95.9%)` | 深灰 `hsl(240 3.7% 15.9%)` |
+| `accent` | 高亮元素、hover 狀態 | 同 secondary | 同 secondary |
+| `destructive` | 刪除、危險操作 | 紅色 `hsl(0 84.2% 60.2%)` | 深紅 `hsl(0 62.8% 30.6%)` |
+| `warning` | 警告訊息、過期提醒 | 琥珀色 `hsl(38 92% 50%)` | 同 light |
+| `success` | 成功訊息、健康狀態 | 綠色 `hsl(142 76% 36%)` | 同 light |
+| `muted` | 次要文字、禁用狀態 | 淺灰 `hsl(240 4.8% 95.9%)` | 深灰 `hsl(240 3.7% 15.9%)` |
+
+## 業務語義色彩
+
+以下為 aibo 專案特定的語義色彩，使用基礎 token 組合：
+
+| 場景 | 色彩 Token | 說明 |
+|------|-----------|------|
+| API Key 已啟用 | `success` | 綠色圓點指示器 |
+| API Key 已停用 | `muted` | 灰色圓點指示器 |
+| API Key 已過期 | `warning` | 琥珀色圓點指示器 |
+| LLM Provider 健康 | `success` | 綠色 badge |
+| LLM Provider 不健康 | `destructive` | 紅色 badge |
+| LLM Provider 未測試 | `muted` | 灰色 badge |
+| Inbox 數量指示 | `primary` | Sidebar badge |
+| 刪除確認 | `destructive` | 刪除按鈕、AlertDialog |
+| 預設 Provider | `primary` | Default badge |
+
+## 對比度驗證
+
+所有前景/背景組合必須通過以下檢查：
+
+| 組合 | 最低對比度 | 標準 |
+|------|----------|------|
+| foreground / background | 4.5:1 | AA 正文 |
+| primary-foreground / primary | 4.5:1 | AA 正文 |
+| destructive-foreground / destructive | 4.5:1 | AA 正文 |
+| muted-foreground / background | 4.5:1 | AA 正文 |
+| 大字（>= 18pt）前景 / 背景 | 3:1 | AA 大字 |
+
+## Tailwind 使用範例
+
+```tsx
+// 主要按鈕
+<Button className="bg-primary text-primary-foreground">建立</Button>
+
+// 刪除按鈕
+<Button variant="destructive">刪除</Button>
+
+// 成功 Badge
+<Badge className="bg-success text-success-foreground">Healthy</Badge>
+
+// 警告文字
+<p className="text-warning">此 API Key 即將過期</p>
+
+// Muted 次要文字
+<p className="text-muted-foreground">上次使用：3 天前</p>
+```

--- a/design/tokens/shadows.md
+++ b/design/tokens/shadows.md
@@ -1,0 +1,90 @@
+# 陰影系統（Shadow Tokens）
+
+## 概述
+
+aibo 使用分層陰影系統表達元素的視覺層級。陰影配合 Tailwind CSS v4 的預設 shadow 工具類別使用，並針對 Dark mode 做適配。
+
+## 陰影層級
+
+| Token | 值 | 用途 |
+|-------|-----|------|
+| `shadow-none` | none | 預設狀態、flat 元素 |
+| `shadow-sm` | `0 1px 2px 0 rgb(0 0 0 / 0.05)` | Input 元素、subtle 浮起 |
+| `shadow` | `0 1px 3px 0 rgb(0 0 0 / 0.1), 0 1px 2px -1px rgb(0 0 0 / 0.1)` | Card 預設、hover 浮起 |
+| `shadow-md` | `0 4px 6px -1px rgb(0 0 0 / 0.1), 0 2px 4px -2px rgb(0 0 0 / 0.1)` | Dropdown menu、Popover |
+| `shadow-lg` | `0 10px 15px -3px rgb(0 0 0 / 0.1), 0 4px 6px -4px rgb(0 0 0 / 0.1)` | Dialog、Modal |
+| `shadow-xl` | `0 20px 25px -5px rgb(0 0 0 / 0.1), 0 8px 10px -6px rgb(0 0 0 / 0.1)` | Toast 通知 |
+
+## 元件陰影對照
+
+| 元件 | 預設陰影 | Hover 陰影 | 說明 |
+|------|---------|-----------|------|
+| Card | `shadow-sm` | `shadow` | hover 時微幅提升 |
+| Input | `shadow-sm` | - | focus 使用 ring 而非陰影 |
+| Button | `shadow-sm` | `shadow` | ghost/outline variant 無陰影 |
+| Dropdown Menu | `shadow-md` | - | 浮層元素 |
+| Dialog / Modal | `shadow-lg` | - | 最高層級浮層 |
+| Toast | `shadow-xl` | - | 通知浮於所有內容之上 |
+| Sidebar | `shadow-none` | - | 固定面板，使用 border 分隔 |
+| Table | `shadow-none` | - | 嵌入頁面，使用 border 分隔 |
+| Popover | `shadow-md` | - | 與 Dropdown 同層級 |
+
+## Dark Mode 適配
+
+Dark mode 下陰影效果較不明顯，主要靠 border 和背景色差異來區分層級：
+
+```css
+.dark {
+  /* Card 在 dark mode 使用 border 替代陰影 */
+  /* shadow-sm → border border-border */
+
+  /* Dialog 保留輕量陰影 + border */
+  /* shadow-lg + border border-border */
+}
+```
+
+| 元件 | Light Mode | Dark Mode |
+|------|-----------|-----------|
+| Card | `shadow-sm` | `shadow-none border` |
+| Dropdown | `shadow-md` | `shadow-md border` |
+| Dialog | `shadow-lg` | `shadow-lg border` |
+| Toast | `shadow-xl` | `shadow-lg border` |
+
+## Focus Ring
+
+Focus 狀態使用 ring 而非陰影，確保 Accessibility：
+
+```css
+/* 預設 focus ring */
+focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2
+
+/* Ring 色彩 */
+--ring: 240 5.9% 10%;        /* Light */
+--ring: 240 4.9% 83.9%;      /* Dark */
+```
+
+| 元素 | Focus 樣式 |
+|------|-----------|
+| Button | `focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2` |
+| Input | `focus-visible:ring-2 focus-visible:ring-ring` |
+| Sidebar item | `focus-visible:ring-2 focus-visible:ring-sidebar-ring` |
+| Dialog trigger | `focus-visible:ring-2 focus-visible:ring-ring` |
+
+## 動畫與過渡
+
+陰影變化需搭配過渡效果：
+
+```css
+/* Card hover 過渡 */
+transition-shadow duration-200
+
+/* 範例 */
+<Card className="shadow-sm hover:shadow transition-shadow duration-200">
+```
+
+| 屬性 | 時長 | 緩動函數 | 用途 |
+|------|------|---------|------|
+| Shadow transition | 200ms | `ease-in-out` | Card hover |
+| Opacity transition | 150ms | `ease-in-out` | Toast 出現/消失 |
+| Transform transition | 200ms | `ease-out` | Dialog 開啟/關閉 |
+| Color transition | 150ms | `ease-in-out` | Button hover 色彩變化 |

--- a/design/tokens/spacing.md
+++ b/design/tokens/spacing.md
@@ -1,0 +1,119 @@
+# 間距系統（Spacing Tokens）
+
+## 概述
+
+aibo 使用 Tailwind CSS v4 的 4px 基數間距系統，確保介面元素之間的距離一致。所有間距值為 4 的倍數（4px grid）。
+
+## 基礎間距表
+
+| Token | 值 | 用途 |
+|-------|-----|------|
+| `0` | 0px | 無間距 |
+| `0.5` | 2px | 微間距（icon 與文字的細微調整） |
+| `1` | 4px | Badge 內距、極小元素間距 |
+| `1.5` | 6px | 行內元素間距、小按鈕內距 |
+| `2` | 8px | 表單元素間距、表格 cell 內距 |
+| `3` | 12px | 按鈕內距（y）、Card 內元素間距 |
+| `4` | 16px | 標準內距、表單群組間距 |
+| `5` | 20px | Section 內距 |
+| `6` | 24px | Card 內距、Dialog 內距 |
+| `8` | 32px | 頁面區塊間距 |
+| `10` | 40px | 頁面上下留白 |
+| `12` | 48px | 大區塊間距 |
+| `16` | 64px | 頁面最大留白 |
+
+## 元件間距規範
+
+### 頁面 Layout
+
+| 區域 | 屬性 | Token |
+|------|------|-------|
+| Main content padding | `p-6` | 24px |
+| Main content padding (mobile) | `p-4` | 16px |
+| 頁面標題與內容間距 | `mb-6` | 24px |
+| 頁面標題與描述間距 | `mt-1` | 4px |
+
+### Card
+
+| 屬性 | Token | 值 |
+|------|-------|-----|
+| 內距 | `p-6` | 24px |
+| Card 之間間距 | `gap-4` | 16px |
+| Card header 與 content 間距 | `space-y-1.5` | 6px |
+
+### 表格（DataTable）
+
+| 屬性 | Token | 值 |
+|------|-------|-----|
+| Cell 內距 | `px-4 py-3` | 16px / 12px |
+| Header cell 內距 | `px-4 py-3` | 16px / 12px |
+| 表格與其他元素間距 | `mt-4` | 16px |
+
+### 表單
+
+| 屬性 | Token | 值 |
+|------|-------|-----|
+| 欄位間距（垂直） | `space-y-4` | 16px |
+| Label 與 input 間距 | `space-y-2` | 8px |
+| Input 內距 | `px-3 py-2` | 12px / 8px |
+| 表單群組間距 | `space-y-6` | 24px |
+| 按鈕區域與表單間距 | `mt-6` | 24px |
+
+### Dialog
+
+| 屬性 | Token | 值 |
+|------|-------|-----|
+| 內距 | `p-6` | 24px |
+| Header 與 content 間距 | `space-y-2` | 8px |
+| Footer 與 content 間距 | `mt-6` | 24px |
+| Footer 按鈕間距 | `gap-2` | 8px |
+
+### Sidebar
+
+| 屬性 | Token | 值 |
+|------|-------|-----|
+| 寬度 | `w-64` | 256px |
+| 收合寬度 | `w-16` | 64px |
+| 內距 | `p-4` | 16px |
+| 項目內距 | `px-3 py-2` | 12px / 8px |
+| 項目間距 | `gap-1` | 4px |
+| 群組間距 | `gap-4` | 16px |
+
+### 按鈕
+
+| 屬性 | Token | 值 |
+|------|-------|-----|
+| Default 內距 | `px-4 py-2` | 16px / 8px |
+| Small 內距 | `px-3 py-1.5` | 12px / 6px |
+| Large 內距 | `px-6 py-3` | 24px / 12px |
+| Icon button 大小 | `h-9 w-9` | 36px |
+| 按鈕之間間距 | `gap-2` | 8px |
+
+### Badge
+
+| 屬性 | Token | 值 |
+|------|-------|-----|
+| 內距 | `px-2.5 py-0.5` | 10px / 2px |
+| Badge 之間間距 | `gap-1` | 4px |
+
+## 觸控目標
+
+所有可互動元素的最小觸控目標為 44x44pt（WCAG 2.1 AA）：
+
+| 元素 | 最小高度 | 實作方式 |
+|------|---------|---------|
+| Button (default) | `h-10` (40px) | 加 padding 達到 44px 觸控區 |
+| Button (sm) | `h-9` (36px) | 透過 padding/margin 補足 |
+| Input | `h-10` (40px) | 原生即滿足 |
+| Table row | `h-12` (48px) | 滿足觸控要求 |
+| Sidebar item | `h-10` (40px) | 加 padding 達到 44px |
+| Checkbox / Radio | `h-4 w-4` (16px) | 透過 label 擴大觸控區域至 44px |
+| Icon button | `h-9 w-9` (36px) | 透過 padding 補足 |
+
+## 響應式斷點間距
+
+| 斷點 | 頁面內距 | 容器最大寬度 |
+|------|---------|-------------|
+| Mobile (< 768px) | `p-4` (16px) | 100% |
+| Tablet (768px-1023px) | `p-6` (24px) | 100% |
+| Desktop (>= 1024px) | `p-6` (24px) | `max-w-7xl` (1280px) |

--- a/design/tokens/typography.md
+++ b/design/tokens/typography.md
@@ -1,0 +1,102 @@
+# 字型系統（Typography Tokens）
+
+## 概述
+
+aibo 使用系統字型堆疊搭配 Tailwind CSS v4 的預設字級系統，確保跨平台一致的閱讀體驗。程式碼區塊使用等寬字型。
+
+## 字型堆疊
+
+```css
+@layer base {
+  :root {
+    --font-sans: "Inter", ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont,
+      "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif;
+    --font-mono: "JetBrains Mono", ui-monospace, SFMono-Regular, "SF Mono",
+      Menlo, Consolas, "Liberation Mono", monospace;
+  }
+}
+```
+
+| 類別 | 字型 | 用途 |
+|------|------|------|
+| Sans-serif | Inter | 所有 UI 文字 |
+| Monospace | JetBrains Mono | 程式碼、API Key 顯示、Markdown 程式碼區塊 |
+
+## 字級系統
+
+使用 Tailwind CSS 預設字級，定義 aibo 中各場景的使用規範：
+
+| Token | 大小 | 行高 | 用途 |
+|-------|------|------|------|
+| `text-xs` | 12px (0.75rem) | 16px (1rem) | Badge 文字、輔助標籤、時間戳 |
+| `text-sm` | 14px (0.875rem) | 20px (1.25rem) | 表格內容、表單標籤、次要文字、Sidebar 項目 |
+| `text-base` | 16px (1rem) | 24px (1.5rem) | 正文、表單輸入、按鈕文字 |
+| `text-lg` | 18px (1.125rem) | 28px (1.75rem) | Card 標題、Section 標題 |
+| `text-xl` | 20px (1.25rem) | 28px (1.75rem) | 頁面副標題 |
+| `text-2xl` | 24px (1.5rem) | 32px (2rem) | 頁面主標題 |
+| `text-3xl` | 30px (1.875rem) | 36px (2.25rem) | Dashboard 數據大字 |
+
+## 字重系統
+
+| Token | 字重 | 用途 |
+|-------|------|------|
+| `font-normal` | 400 | 正文、表格內容、描述文字 |
+| `font-medium` | 500 | 表單標籤、Sidebar 項目、按鈕文字 |
+| `font-semibold` | 600 | Card 標題、表格標頭、Badge |
+| `font-bold` | 700 | 頁面標題、數據大字 |
+
+## 頁面標題層級
+
+| 層級 | 樣式 | 使用場景 |
+|------|------|---------|
+| H1 | `text-2xl font-bold tracking-tight` | 頁面主標題（如「知識條目」「API Key 管理」） |
+| H2 | `text-xl font-semibold` | Section 標題（如「建立新條目」） |
+| H3 | `text-lg font-semibold` | Card 標題、Dialog 標題 |
+| H4 | `text-base font-medium` | 子區塊標題 |
+| Body | `text-sm text-foreground` | 正文內容 |
+| Caption | `text-xs text-muted-foreground` | 輔助說明、時間戳 |
+
+## 文字截斷
+
+| 場景 | 策略 | 樣式 |
+|------|------|------|
+| 表格中的標題 | 單行省略 | `truncate` |
+| 條目預覽 | 多行省略（2 行） | `line-clamp-2` |
+| Sidebar 項目名 | 單行省略 | `truncate` |
+| Badge 文字 | 不截斷 | `whitespace-nowrap` |
+
+## Markdown 內容排版
+
+條目內容使用 Markdown 渲染，需套用 prose 排版：
+
+```tsx
+<div className="prose prose-sm dark:prose-invert max-w-none">
+  {/* Markdown 渲染內容 */}
+</div>
+```
+
+| 元素 | 樣式 |
+|------|------|
+| 標題 | 使用 prose 預設，自動處理 h1-h6 |
+| 段落 | `text-sm leading-relaxed` |
+| 程式碼區塊 | `font-mono text-sm bg-muted rounded-md p-4` |
+| 行內程式碼 | `font-mono text-sm bg-muted px-1.5 py-0.5 rounded` |
+| 連結 | `text-primary underline` |
+| 列表 | prose 預設 |
+
+## 使用範例
+
+```tsx
+// 頁面標題
+<h1 className="text-2xl font-bold tracking-tight">知識條目</h1>
+<p className="text-muted-foreground">管理你的知識庫條目</p>
+
+// 表格標頭
+<th className="text-sm font-semibold text-muted-foreground">名稱</th>
+
+// 時間戳
+<span className="text-xs text-muted-foreground">2026-04-22 15:30</span>
+
+// API Key 顯示
+<code className="font-mono text-sm">aibo_a1b2c3d4e5</code>
+```


### PR DESCRIPTION
## Summary
- 建立完整的 Design Token 系統（色彩、字型、間距、陰影），支援 Light/Dark 雙主題
- 定義 9 個 UI 元件規格（基於 shadcn/ui + Tailwind CSS v4），包含 props、樣式、狀態、accessibility 要求
- 定義 6 個頁面規格，涵蓋 Sprint 1 所有功能介面的 wireframe 與互動流程

## Changes

### Design Tokens (`design/tokens/`)
- `colors.md` — HSL 語義色彩系統（primary, destructive, warning, success, muted），WCAG 2.1 AA 對比度驗證
- `typography.md` — Inter + JetBrains Mono 字型堆疊、字級/字重規範、Markdown prose 排版
- `spacing.md` — 4px grid 間距系統、各元件間距規範、觸控目標 44x44pt、響應式斷點
- `shadows.md` — 分層陰影系統、Dark mode 適配、focus ring、動畫過渡

### Component Specs (`design/components/`)
- `button.md` — 6 variants、4 sizes、loading 狀態、icon button
- `input.md` — Input/Textarea/Select/Checkbox + SearchInput（debounce）+ TagInput + react-hook-form/zod 整合
- `data-table.md` — TanStack Table v8 整合、排序/分頁/行操作、loading/empty 狀態、4 張業務表格定義
- `dialog-modal.md` — Dialog + AlertDialog、3 種大小、建立/編輯/刪除確認場景
- `toast.md` — Sonner 整合、4 種類型、所有業務場景的 Toast 訊息定義
- `navigation-sidebar.md` — shadcn/ui Sidebar、展開/收合、Inbox badge、響應式 overlay
- `card.md` — Dashboard 統計卡、Entry 詳情卡、Mobile 卡片列表
- `badge.md` — 狀態 Badge（健康/啟用/過期）、Tag 列表顯示、圓點指示器
- `dropdown-menu.md` — 表格行操作選單、各業務場景操作項目定義

### Page Specs (`design/pages/`)
- `layout.md` — Sidebar + Header + Main 整體佈局、Next.js App Router 路由結構、PageHeader 元件
- `api-keys.md` — 列表/建立/撤銷流程、Bootstrap 引導畫面、Key 明文顯示與複製
- `entries.md` — 列表頁（搜尋/篩選/分頁）、詳情頁（Markdown 預覽）、建立/編輯 Dialog
- `categories.md` — CRUD 表格、建立/編輯 Dialog、刪除確認（條目移至 Inbox 提示）
- `llm-providers.md` — CRUD 表格、HealthStatus 元件、進階設定 Collapsible、API Key 加密提示
- `inbox.md` — 快速新增 Dialog、移至分類 Popover、慶祝版空狀態、Sidebar badge 連動

## Test Plan
- [ ] 確認所有元件規格涵蓋 props、使用範例、accessibility 要求
- [ ] 確認頁面規格覆蓋 Loading / Empty / Error 三種狀態
- [ ] 確認色彩對比度符合 WCAG 2.1 AA 標準
- [ ] 確認觸控目標最小 44x44pt
- [ ] 確認所有 Sprint 1 功能（F-001, F-002, F-004, F-007, F-010）的 UI 需求都有對應規格

Closes #10

🤖 Generated with [Claude Code](https://claude.com/claude-code)