### PR TITLE
feat(F-003): 實作 LLM 自動分類功能

### DIFF
--- a/dev/src/dto/llm.go
+++ b/dev/src/dto/llm.go
@@ -1,0 +1,22 @@
+package dto
+
+import "github.com/google/uuid"
+
+// ClassifyResult LLM 分類回傳結果
+type ClassifyResult struct {
+	Category string   `json:"category"`
+	Tags     []string `json:"tags"`
+	Title    string   `json:"title"`
+}
+
+// ClassifyResponse 手動觸發分類的回應
+type ClassifyResponse struct {
+	Message string    `json:"message"`
+	EntryID uuid.UUID `json:"entry_id"`
+}
+
+// ClassifyAllResponse 批次分類的回應
+type ClassifyAllResponse struct {
+	Message    string `json:"message"`
+	EntryCount int    `json:"entry_count"`
+}

--- a/dev/src/go.mod
+++ b/dev/src/go.mod
@@ -8,6 +8,8 @@ require (
 	github.com/google/uuid v1.6.0
 	github.com/jackc/pgx/v5 v5.5.5
 	github.com/joho/godotenv v1.5.1
+	github.com/sashabaranov/go-openai v1.36.1
+	golang.org/x/time v0.9.0
 )
 
 require (

--- a/dev/src/go.sum
+++ b/dev/src/go.sum
@@ -98,6 +98,8 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/rogpeppe/go-internal v1.14.1 h1:UQB4HGPB6osV0SQTLymcB4TgvyWu6ZyliaW0tI/otEQ=
 github.com/rogpeppe/go-internal v1.14.1/go.mod h1:MaRKkUm5W0goXpeCfT7UZI6fk/L7L7so1lCWt35ZSgc=
+github.com/sashabaranov/go-openai v1.36.1 h1:EVfRXwIlW2rUzpx6vR+aeIKCK/xylSrVYAx1TMTSX3g=
+github.com/sashabaranov/go-openai v1.36.1/go.mod h1:lj5b/K+zjTSFxVLijLSTDZuP7adOgerWeFyZLUhAKRg=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
 github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpEOglKo=
@@ -132,6 +134,8 @@ golang.org/x/sys v0.26.0 h1:KHjCJyddX0LoSTb3J+vWpupP9p0oznkqVk/IfjymZbo=
 golang.org/x/sys v0.26.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
 golang.org/x/text v0.14.0 h1:ScX5w1eTa3QqT8oi6+ziP7dTV1S2+ALU0bI+0zXKWiQ=
 golang.org/x/text v0.14.0/go.mod h1:18ZOQIKpY8NJVqYksKHtTdi31H5itFRjB5/qKTNYzSU=
+golang.org/x/time v0.9.0 h1:EsRrnYcQiGH+5FfbgvV4AP7qEZstoyrHB0DzarOQ4ZY=
+golang.org/x/time v0.9.0/go.mod h1:3BpzKBy/shNhVucY/MWOyx10tF3SFh9QdLuxbVysPQM=
 golang.org/x/tools v0.26.0 h1:v/60pFQmzmT9ExmjDv2gGIfi3OqfKoEP6I5+umXlbnQ=
 golang.org/x/tools v0.26.0/go.mod h1:TPVVj70c7JJ3WCazhD8OdXcZg/og+b9+tH/KxylGwH0=
 golang.org/x/xerrors v0.0.0-20220907171357-04be3eba64a2 h1:H2TDz8ibqkAF6YGhCdN3jS9O0/s90v0rJh3X/OLHEUk=

--- a/dev/src/handler/classify.go
+++ b/dev/src/handler/classify.go
@@ -1,0 +1,102 @@
+package handler
+
+import (
+	"context"
+	"log/slog"
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+	"github.com/gpwork4u/aibo/dto"
+	"github.com/gpwork4u/aibo/model"
+	"github.com/gpwork4u/aibo/repository"
+	"github.com/gpwork4u/aibo/service"
+)
+
+// ClassifyHandler 分類相關 HTTP handlers
+type ClassifyHandler struct {
+	classifierSvc *service.ClassifierService
+	entryRepo     *repository.EntryRepository
+}
+
+// NewClassifyHandler 建立新的 ClassifyHandler
+func NewClassifyHandler(classifierSvc *service.ClassifierService, entryRepo *repository.EntryRepository) *ClassifyHandler {
+	return &ClassifyHandler{
+		classifierSvc: classifierSvc,
+		entryRepo:     entryRepo,
+	}
+}
+
+// Classify 手動觸發單筆 entry 分類
+// POST /api/v1/entries/:id/classify
+func (h *ClassifyHandler) Classify(c *gin.Context) {
+	idStr := c.Param("id")
+	id, err := uuid.Parse(idStr)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, dto.ErrorResponse{
+			Code:    model.ErrCodeInvalidInput,
+			Message: "無效的 ID 格式",
+		})
+		return
+	}
+
+	// 確認 entry 存在（同步檢查）
+	entry, err := h.entryRepo.FindByID(c.Request.Context(), id)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, dto.ErrorResponse{
+			Code:    "INTERNAL_ERROR",
+			Message: "查詢條目失敗",
+		})
+		return
+	}
+	if entry == nil {
+		c.JSON(http.StatusNotFound, dto.ErrorResponse{
+			Code:    model.ErrCodeNotFound,
+			Message: "知識條目不存在",
+		})
+		return
+	}
+
+	// 背景 goroutine 執行分類
+	go func() {
+		bgCtx := context.Background()
+		if err := h.classifierSvc.ClassifyEntry(bgCtx, id); err != nil {
+			slog.Error("手動分類失敗", "entry_id", id, "error", err)
+		}
+	}()
+
+	c.JSON(http.StatusAccepted, dto.ClassifyResponse{
+		Message: "Classification started",
+		EntryID: id,
+	})
+}
+
+// ClassifyAll 批次分類所有 inbox entries
+// POST /api/v1/entries/classify-all
+func (h *ClassifyHandler) ClassifyAll(c *gin.Context) {
+	// 取得所有未分類的 entry IDs（同步查詢）
+	entryIDs, err := h.classifierSvc.GetInboxEntryIDs(c.Request.Context())
+	if err != nil {
+		slog.Error("查詢未分類 entries 失敗", "error", err)
+		c.JSON(http.StatusInternalServerError, dto.ErrorResponse{
+			Code:    "INTERNAL_ERROR",
+			Message: "查詢未分類條目失敗",
+		})
+		return
+	}
+
+	count := len(entryIDs)
+
+	// 背景批次處理（序列執行）
+	if count > 0 {
+		go func() {
+			bgCtx := context.Background()
+			h.classifierSvc.ClassifyAllInboxAsync(bgCtx, entryIDs)
+		}()
+	}
+
+	c.JSON(http.StatusAccepted, dto.ClassifyAllResponse{
+		Message:    "Batch classification started",
+		EntryCount: count,
+	})
+}

--- a/dev/src/handler/entry.go
+++ b/dev/src/handler/entry.go
@@ -15,12 +15,13 @@ import (
 
 // EntryHandler 知識條目 HTTP handlers
 type EntryHandler struct {
-	svc *service.EntryService
+	svc              *service.EntryService
+	classifierWorker *service.ClassifierWorker
 }
 
 // NewEntryHandler 建立新的 EntryHandler
-func NewEntryHandler(svc *service.EntryService) *EntryHandler {
-	return &EntryHandler{svc: svc}
+func NewEntryHandler(svc *service.EntryService, classifierWorker *service.ClassifierWorker) *EntryHandler {
+	return &EntryHandler{svc: svc, classifierWorker: classifierWorker}
 }
 
 // Create 建立新知識條目
@@ -44,6 +45,11 @@ func (h *EntryHandler) Create(c *gin.Context) {
 	if err != nil {
 		handleEntryError(c, err)
 		return
+	}
+
+	// 建立成功後，如果沒有指定 category，觸發背景 LLM 自動分類
+	if entry.CategoryID == nil && h.classifierWorker != nil {
+		h.classifierWorker.Enqueue(entry.ID)
 	}
 
 	c.JSON(http.StatusCreated, toEntryResponse(entry))

--- a/dev/src/main.go
+++ b/dev/src/main.go
@@ -79,10 +79,18 @@ func main() {
 
 	entryRepo := repository.NewEntryRepository(pool)
 	entrySvc := service.NewEntryService(entryRepo)
-	entryHandler := handler.NewEntryHandler(entrySvc)
+
+	// 初始化 LLM 分類服務
+	llmSvc := service.NewLlmService(llmProviderSvc, aesCrypto)
+	classifierSvc := service.NewClassifierService(llmSvc, entryRepo, categoryRepo)
+	classifierWorker := service.NewClassifierWorker(classifierSvc)
+	classifierWorker.Start()
+
+	entryHandler := handler.NewEntryHandler(entrySvc, classifierWorker)
+	classifyHandler := handler.NewClassifyHandler(classifierSvc, entryRepo)
 
 	// 設定路由
-	r := router.Setup(apiKeySvc, apiKeyHandler, categoryHandler, llmProviderHandler, entryHandler)
+	r := router.Setup(apiKeySvc, apiKeyHandler, categoryHandler, llmProviderHandler, entryHandler, classifyHandler)
 
 	// 啟動 HTTP server（graceful shutdown）
 	srv := &http.Server{
@@ -103,6 +111,9 @@ func main() {
 	signal.Notify(quit, syscall.SIGINT, syscall.SIGTERM)
 	<-quit
 	slog.Info("收到關閉信號，正在優雅關閉伺服器...")
+
+	// 先關閉分類 worker（等待進行中的任務完成）
+	classifierWorker.Shutdown()
 
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()

--- a/dev/src/router/router.go
+++ b/dev/src/router/router.go
@@ -10,7 +10,7 @@ import (
 )
 
 // Setup 設定路由
-func Setup(apiKeySvc *service.ApiKeyService, apiKeyHandler *handler.ApiKeyHandler, categoryHandler *handler.CategoryHandler, llmProviderHandler *handler.LlmProviderHandler, entryHandler *handler.EntryHandler) *gin.Engine {
+func Setup(apiKeySvc *service.ApiKeyService, apiKeyHandler *handler.ApiKeyHandler, categoryHandler *handler.CategoryHandler, llmProviderHandler *handler.LlmProviderHandler, entryHandler *handler.EntryHandler, classifyHandler *handler.ClassifyHandler) *gin.Engine {
 	r := gin.Default()
 
 	// 健康檢查（不需認證）
@@ -59,6 +59,10 @@ func Setup(apiKeySvc *service.ApiKeyService, apiKeyHandler *handler.ApiKeyHandle
 			entries.GET("/:id", entryHandler.GetByID)
 			entries.PATCH("/:id", entryHandler.Update)
 			entries.DELETE("/:id", entryHandler.Delete)
+
+			// LLM 自動分類
+			entries.POST("/:id/classify", classifyHandler.Classify)
+			entries.POST("/classify-all", classifyHandler.ClassifyAll)
 		}
 	}
 

--- a/dev/src/service/classifier.go
+++ b/dev/src/service/classifier.go
@@ -1,0 +1,235 @@
+package service
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/gpwork4u/aibo/model"
+	"github.com/gpwork4u/aibo/repository"
+)
+
+// ClassifierService 自動分類業務邏輯
+type ClassifierService struct {
+	llmSvc       *LlmService
+	entryRepo    *repository.EntryRepository
+	categoryRepo *repository.CategoryRepository
+}
+
+// NewClassifierService 建立新的 ClassifierService
+func NewClassifierService(
+	llmSvc *LlmService,
+	entryRepo *repository.EntryRepository,
+	categoryRepo *repository.CategoryRepository,
+) *ClassifierService {
+	return &ClassifierService{
+		llmSvc:       llmSvc,
+		entryRepo:    entryRepo,
+		categoryRepo: categoryRepo,
+	}
+}
+
+// ClassifyEntry 對單筆 entry 進行 LLM 分類
+func (s *ClassifierService) ClassifyEntry(ctx context.Context, entryID uuid.UUID) error {
+	// 取得 entry
+	entry, err := s.entryRepo.FindByID(ctx, entryID)
+	if err != nil {
+		return fmt.Errorf("查詢 entry 失敗: %w", err)
+	}
+	if entry == nil {
+		return model.NewAppError(404, model.ErrCodeNotFound, "知識條目不存在")
+	}
+
+	// 準備要分類的內容
+	content := ""
+	if entry.Content != nil {
+		content = *entry.Content
+	}
+	if entry.Title != nil {
+		content = *entry.Title + "\n" + content
+	}
+	if content == "" {
+		slog.Warn("entry 內容為空，跳過分類", "entry_id", entryID)
+		return nil
+	}
+
+	// 取得所有現有分類名稱
+	categories, err := s.categoryRepo.List(ctx)
+	if err != nil {
+		return fmt.Errorf("查詢分類列表失敗: %w", err)
+	}
+	categoryNames := make([]string, 0, len(categories))
+	for _, cat := range categories {
+		categoryNames = append(categoryNames, cat.Name)
+	}
+
+	// 呼叫 LLM 分類
+	result, err := s.llmSvc.Classify(ctx, content, categoryNames)
+	if err != nil {
+		return fmt.Errorf("LLM 分類失敗: %w", err)
+	}
+
+	slog.Info("LLM 分類結果",
+		"entry_id", entryID,
+		"category", result.Category,
+		"tags", result.Tags,
+		"title", result.Title,
+	)
+
+	// Category 匹配：LOWER(TRIM()) case-insensitive
+	categoryID, err := s.matchOrCreateCategory(ctx, result.Category, categories)
+	if err != nil {
+		return fmt.Errorf("分類匹配/建立失敗: %w", err)
+	}
+
+	// 更新 entry
+	entry.CategoryID = &categoryID
+
+	// tags 合併（union）
+	if len(result.Tags) > 0 {
+		entry.Tags = mergeTags(entry.Tags, result.Tags)
+	}
+
+	// title 僅在原本為空時覆蓋
+	if entry.Title == nil && result.Title != "" {
+		entry.Title = &result.Title
+	}
+
+	if err := s.entryRepo.Update(ctx, entry); err != nil {
+		return fmt.Errorf("更新 entry 失敗: %w", err)
+	}
+
+	slog.Info("entry 分類完成",
+		"entry_id", entryID,
+		"category_id", categoryID,
+		"tags", entry.Tags,
+	)
+
+	return nil
+}
+
+// ClassifyAllInboxAsync 在背景逐筆分類所有 inbox entries（序列執行）
+func (s *ClassifierService) ClassifyAllInboxAsync(ctx context.Context, entryIDs []uuid.UUID) {
+	for _, id := range entryIDs {
+		select {
+		case <-ctx.Done():
+			slog.Info("批次分類被取消", "remaining", len(entryIDs))
+			return
+		default:
+		}
+
+		if err := s.ClassifyEntry(ctx, id); err != nil {
+			slog.Error("批次分類失敗，跳過此 entry",
+				"entry_id", id,
+				"error", err,
+			)
+			// 失敗時 entry 保持原狀，繼續下一筆
+		}
+	}
+}
+
+// GetInboxEntryIDs 取得所有未分類的 entry IDs
+func (s *ClassifierService) GetInboxEntryIDs(ctx context.Context) ([]uuid.UUID, error) {
+	nullStr := "null"
+	filter := model.EntryFilter{
+		CategoryID: &nullStr,
+		Page:       1,
+		PerPage:    100,
+	}
+
+	result, err := s.entryRepo.List(ctx, filter)
+	if err != nil {
+		return nil, fmt.Errorf("查詢未分類 entries 失敗: %w", err)
+	}
+
+	if result.Pagination.Total == 0 {
+		return nil, nil
+	}
+
+	entryIDs := make([]uuid.UUID, 0, result.Pagination.Total)
+	for _, item := range result.Data {
+		entryIDs = append(entryIDs, item.ID)
+	}
+
+	for page := 2; page <= result.Pagination.TotalPages; page++ {
+		filter.Page = page
+		pageResult, err := s.entryRepo.List(ctx, filter)
+		if err != nil {
+			break
+		}
+		for _, item := range pageResult.Data {
+			entryIDs = append(entryIDs, item.ID)
+		}
+	}
+
+	return entryIDs, nil
+}
+
+// matchOrCreateCategory 比對或建立分類
+func (s *ClassifierService) matchOrCreateCategory(ctx context.Context, categoryName string, existingCategories []model.Category) (uuid.UUID, error) {
+	normalizedName := strings.ToLower(strings.TrimSpace(categoryName))
+
+	for _, cat := range existingCategories {
+		if strings.ToLower(strings.TrimSpace(cat.Name)) == normalizedName {
+			return cat.ID, nil
+		}
+	}
+
+	// 不存在，自動建立新的 Category
+	slog.Info("自動建立新分類", "name", categoryName)
+	now := time.Now().UTC()
+	newCat := &model.Category{
+		ID:        uuid.New(),
+		Name:      strings.TrimSpace(categoryName),
+		SortOrder: 0,
+		CreatedAt: now,
+		UpdatedAt: now,
+	}
+
+	if err := s.categoryRepo.Create(ctx, newCat); err != nil {
+		// race condition 處理：重新查詢
+		if strings.Contains(err.Error(), "DUPLICATE_CATEGORY") || strings.Contains(err.Error(), "idx_categories_name_lower") {
+			cats, listErr := s.categoryRepo.List(ctx)
+			if listErr != nil {
+				return uuid.Nil, fmt.Errorf("重新查詢分類列表失敗: %w", listErr)
+			}
+			for _, cat := range cats {
+				if strings.ToLower(strings.TrimSpace(cat.Name)) == normalizedName {
+					return cat.ID, nil
+				}
+			}
+		}
+		return uuid.Nil, fmt.Errorf("建立分類失敗: %w", err)
+	}
+
+	return newCat.ID, nil
+}
+
+// mergeTags 合併 tags（union，去重，保留順序）
+func mergeTags(existing, newTags []string) []string {
+	tagSet := make(map[string]bool)
+	for _, t := range existing {
+		tagSet[t] = true
+	}
+	for _, t := range newTags {
+		tagSet[t] = true
+	}
+
+	result := make([]string, 0, len(tagSet))
+	for _, t := range existing {
+		if tagSet[t] {
+			result = append(result, t)
+			delete(tagSet, t)
+		}
+	}
+	for _, t := range newTags {
+		if tagSet[t] {
+			result = append(result, t)
+			delete(tagSet, t)
+		}
+	}
+	return result
+}

--- a/dev/src/service/classifier_worker.go
+++ b/dev/src/service/classifier_worker.go
@@ -1,0 +1,78 @@
+package service
+
+import (
+	"context"
+	"log/slog"
+	"sync"
+
+	"github.com/google/uuid"
+)
+
+const (
+	// classificationQueueSize 分類佇列大小
+	classificationQueueSize = 100
+)
+
+// ClassifierWorker 背景分類 worker
+type ClassifierWorker struct {
+	classifierSvc *ClassifierService
+	taskCh        chan uuid.UUID
+	wg            sync.WaitGroup
+	ctx           context.Context
+	cancel        context.CancelFunc
+}
+
+// NewClassifierWorker 建立新的 ClassifierWorker
+func NewClassifierWorker(classifierSvc *ClassifierService) *ClassifierWorker {
+	ctx, cancel := context.WithCancel(context.Background())
+	return &ClassifierWorker{
+		classifierSvc: classifierSvc,
+		taskCh:        make(chan uuid.UUID, classificationQueueSize),
+		ctx:           ctx,
+		cancel:        cancel,
+	}
+}
+
+// Start 啟動背景 worker goroutine
+func (w *ClassifierWorker) Start() {
+	w.wg.Add(1)
+	go func() {
+		defer w.wg.Done()
+		slog.Info("分類 worker 已啟動")
+		for {
+			select {
+			case entryID := <-w.taskCh:
+				slog.Info("開始背景分類", "entry_id", entryID)
+				if err := w.classifierSvc.ClassifyEntry(w.ctx, entryID); err != nil {
+					slog.Error("背景分類失敗",
+						"entry_id", entryID,
+						"error", err,
+					)
+				} else {
+					slog.Info("背景分類完成", "entry_id", entryID)
+				}
+			case <-w.ctx.Done():
+				slog.Info("分類 worker 收到關閉信號")
+				return
+			}
+		}
+	}()
+}
+
+// Enqueue 將 entry 加入分類佇列（非阻塞）
+func (w *ClassifierWorker) Enqueue(entryID uuid.UUID) {
+	select {
+	case w.taskCh <- entryID:
+		slog.Info("entry 已加入分類佇列", "entry_id", entryID)
+	default:
+		slog.Warn("分類佇列已滿，跳過", "entry_id", entryID)
+	}
+}
+
+// Shutdown 優雅關閉 worker
+func (w *ClassifierWorker) Shutdown() {
+	slog.Info("正在關閉分類 worker...")
+	w.cancel()
+	w.wg.Wait()
+	slog.Info("分類 worker 已關閉")
+}

--- a/dev/src/service/llm.go
+++ b/dev/src/service/llm.go
@@ -1,0 +1,141 @@
+package service
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"strings"
+	"time"
+
+	openai "github.com/sashabaranov/go-openai"
+	"golang.org/x/time/rate"
+
+	"github.com/gpwork4u/aibo/crypto"
+	"github.com/gpwork4u/aibo/dto"
+	"github.com/gpwork4u/aibo/model"
+)
+
+// LlmService 統一的 LLM 呼叫介面
+type LlmService struct {
+	providerSvc *LlmProviderService
+	crypto      *crypto.AESCrypto
+	limiter     *rate.Limiter
+}
+
+// NewLlmService 建立新的 LlmService
+func NewLlmService(providerSvc *LlmProviderService, aesCrypto *crypto.AESCrypto) *LlmService {
+	return &LlmService{
+		providerSvc: providerSvc,
+		crypto:      aesCrypto,
+		limiter:     rate.NewLimiter(rate.Every(time.Second), 5), // 每秒最多 5 個請求
+	}
+}
+
+// classifySystemPrompt 分類用的 system prompt
+const classifySystemPrompt = `你是一個知識分類助手。根據使用者提供的內容，分析其主題並回傳 JSON 格式的分類結果。
+
+回傳格式必須嚴格為：
+{"category": "分類名稱", "tags": ["tag1", "tag2"], "title": "建議標題"}
+
+規則：
+1. category：選擇最適合的分類名稱，簡潔明確
+2. tags：提取 2-5 個關鍵字作為標籤，使用小寫英文或中文
+3. title：根據內容產生一個簡潔的標題（不超過 50 字）
+
+只回傳 JSON，不要包含任何其他文字、說明或 markdown 格式。`
+
+// Classify 呼叫 LLM 進行分類
+func (s *LlmService) Classify(ctx context.Context, content string, existingCategories []string) (*dto.ClassifyResult, error) {
+	// 取得 active provider
+	provider, err := s.providerSvc.GetActiveProvider(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("取得 LLM provider 失敗: %w", err)
+	}
+
+	// 解密 api_key
+	apiKey := ""
+	if provider.ApiKey != nil && *provider.ApiKey != "" {
+		decrypted, err := s.crypto.Decrypt(*provider.ApiKey)
+		if err != nil {
+			return nil, fmt.Errorf("解密 API Key 失敗: %w", err)
+		}
+		apiKey = decrypted
+	}
+
+	// 建立 go-openai client
+	config := openai.DefaultConfig(apiKey)
+	config.BaseURL = strings.TrimRight(provider.EndpointURL, "/")
+	if !strings.HasSuffix(config.BaseURL, "/v1") {
+		config.BaseURL = config.BaseURL + "/v1"
+	}
+	client := openai.NewClientWithConfig(config)
+
+	// 組裝 user prompt
+	userPrompt := content
+	if len(existingCategories) > 0 {
+		userPrompt = fmt.Sprintf("現有的分類列表：%s\n\n請優先從以上分類中選擇，如果都不適合再建議新分類。\n\n以下是要分類的內容：\n%s",
+			strings.Join(existingCategories, "、"), content)
+	}
+
+	// 取得 timeout 設定
+	timeout := 30 * time.Second
+	if provider.Config != nil {
+		var cfg model.LlmProviderConfig
+		if err := json.Unmarshal(*provider.Config, &cfg); err == nil && cfg.TimeoutSeconds != nil {
+			timeout = time.Duration(*cfg.TimeoutSeconds) * time.Second
+		}
+	}
+
+	callCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	// 等待 rate limiter
+	if err := s.limiter.Wait(callCtx); err != nil {
+		return nil, fmt.Errorf("rate limit 等待取消: %w", err)
+	}
+
+	slog.Info("呼叫 LLM 進行分類",
+		"provider", provider.Name,
+		"model", provider.ModelName,
+	)
+
+	resp, err := client.CreateChatCompletion(callCtx, openai.ChatCompletionRequest{
+		Model: provider.ModelName,
+		Messages: []openai.ChatCompletionMessage{
+			{Role: openai.ChatMessageRoleSystem, Content: classifySystemPrompt},
+			{Role: openai.ChatMessageRoleUser, Content: userPrompt},
+		},
+		ResponseFormat: &openai.ChatCompletionResponseFormat{
+			Type: openai.ChatCompletionResponseFormatTypeJSONObject,
+		},
+	})
+	if err != nil {
+		return nil, fmt.Errorf("LLM API 呼叫失敗: %w", err)
+	}
+
+	if len(resp.Choices) == 0 {
+		return nil, fmt.Errorf("LLM 回傳空結果")
+	}
+
+	rawContent := resp.Choices[0].Message.Content
+	result, err := parseClassifyResult(rawContent)
+	if err != nil {
+		slog.Error("LLM 回傳格式解析失敗", "raw", rawContent, "error", err)
+		return nil, err
+	}
+
+	return result, nil
+}
+
+// parseClassifyResult 解析 LLM 回傳的分類 JSON
+func parseClassifyResult(raw string) (*dto.ClassifyResult, error) {
+	var result dto.ClassifyResult
+	if err := json.Unmarshal([]byte(raw), &result); err != nil {
+		return nil, fmt.Errorf("LLM 回傳格式無效: %w", err)
+	}
+	if result.Category == "" {
+		return nil, fmt.Errorf("LLM 回傳缺少 category 欄位")
+	}
+	return &result, nil
+}


### PR DESCRIPTION
## Summary

- 新增 LLM 共用模組（`service/llm.go`）：使用 `sashabaranov/go-openai` 建立 OpenAI-compatible client，支援自訂 BaseURL、rate limiting（5 req/s）、30 秒 timeout、JSON structured output
- 新增分類服務（`service/classifier.go`）：單筆分類 `ClassifyEntry`、批次分類 `ClassifyAllInboxAsync`，含 category case-insensitive 匹配、自動建立新分類、tags union 合併、title 空值時覆蓋
- 新增背景 worker（`service/classifier_worker.go`）：channel-based 佇列（buffer 100）、單一 goroutine 序列處理、graceful shutdown
- 新增 API endpoints：`POST /entries/:id/classify`（202 Accepted）、`POST /entries/classify-all`（202 Accepted）
- 修改 Entry Create handler：建立後自動觸發背景 LLM 分類（僅限未指定 category 的 entry）
- 新增依賴：`github.com/sashabaranov/go-openai v1.36.1`、`golang.org/x/time v0.9.0`

Closes #18

## Test plan

- [ ] 手動測試 POST /entries/:id/classify 回傳 202 + 背景分類完成
- [ ] 手動測試 POST /entries/classify-all 批次分類 inbox entries
- [ ] 測試新 entry 建立後自動觸發背景分類
- [ ] 測試 category case-insensitive 匹配（"Golang" vs "golang"）
- [ ] 測試不存在的 category 自動建立
- [ ] 測試 title 為空時覆蓋、非空時不覆蓋
- [ ] 測試 tags 合併（union）不取代
- [ ] 測試 LLM 不可用時 entry 保持原狀
- [ ] 測試 404 回應（不存在的 entry ID）
- [ ] 測試 graceful shutdown 等待進行中分類完成

🤖 Generated with [Claude Code](https://claude.com/claude-code)