### PR TITLE
feat(F-009): Google Calendar 整合匯入功能

### DIFF
--- a/dev/src/config/config.go
+++ b/dev/src/config/config.go
@@ -9,8 +9,11 @@ import (
 
 // Config 應用程式設定
 type Config struct {
-	DatabaseURL string
-	ServerPort  string
+	DatabaseURL       string
+	ServerPort        string
+	GoogleClientID    string
+	GoogleClientSecret string
+	GoogleRedirectURL string
 }
 
 // Load 從環境變數載入設定
@@ -28,8 +31,16 @@ func Load() (*Config, error) {
 		port = "8080"
 	}
 
+	googleRedirectURL := os.Getenv("GOOGLE_REDIRECT_URL")
+	if googleRedirectURL == "" {
+		googleRedirectURL = "http://localhost:8080/api/v1/integrations/gcal/callback"
+	}
+
 	return &Config{
-		DatabaseURL: dbURL,
-		ServerPort:  port,
+		DatabaseURL:       dbURL,
+		ServerPort:        port,
+		GoogleClientID:    os.Getenv("GOOGLE_CLIENT_ID"),
+		GoogleClientSecret: os.Getenv("GOOGLE_CLIENT_SECRET"),
+		GoogleRedirectURL: googleRedirectURL,
 	}, nil
 }

--- a/dev/src/dto/gcal.go
+++ b/dev/src/dto/gcal.go
@@ -1,0 +1,27 @@
+package dto
+
+// GcalAuthResponse OAuth 授權回應
+type GcalAuthResponse struct {
+	AuthURL string `json:"auth_url"`
+}
+
+// GcalCallbackResponse OAuth callback 成功回應
+type GcalCallbackResponse struct {
+	Message string `json:"message"`
+	Email   string `json:"email"`
+}
+
+// GcalImportRequest 匯入 Google Calendar 事件請求
+type GcalImportRequest struct {
+	CalendarID       *string `json:"calendar_id"`
+	Since            *string `json:"since"`
+	Until            *string `json:"until"`
+	IncludeRecurring *bool   `json:"include_recurring"`
+}
+
+// GcalImportResponse 匯入結果回應
+type GcalImportResponse struct {
+	EventsFound    int `json:"events_found"`
+	EntriesCreated int `json:"entries_created"`
+	EntriesSkipped int `json:"entries_skipped"`
+}

--- a/dev/src/dto/git_import.go
+++ b/dev/src/dto/git_import.go
@@ -1,0 +1,24 @@
+package dto
+
+// GitImportRequest Git 匯入請求
+type GitImportRequest struct {
+	RepoPath string  `json:"repo_path" binding:"required"`
+	Since    *string `json:"since"`
+	Until    *string `json:"until"`
+	Author   *string `json:"author"`
+	Branch   *string `json:"branch"`
+}
+
+// GitImportResponse Git 匯入回應
+type GitImportResponse struct {
+	CommitsFound   int             `json:"commits_found"`
+	EntriesCreated int             `json:"entries_created"`
+	EntriesSkipped int             `json:"entries_skipped"`
+	SkippedReasons []SkippedReason `json:"skipped_reasons"`
+}
+
+// SkippedReason 略過原因
+type SkippedReason struct {
+	CommitHash string `json:"commit_hash"`
+	Reason     string `json:"reason"`
+}

--- a/dev/src/go.mod
+++ b/dev/src/go.mod
@@ -4,12 +4,15 @@ go 1.23
 
 require (
 	github.com/gin-gonic/gin v1.9.1
+	github.com/go-git/go-git/v5 v5.12.0
 	github.com/golang-migrate/migrate/v4 v4.17.1
 	github.com/google/uuid v1.6.0
 	github.com/jackc/pgx/v5 v5.5.5
 	github.com/joho/godotenv v1.5.1
 	github.com/sashabaranov/go-openai v1.36.1
+	golang.org/x/oauth2 v0.25.0
 	golang.org/x/time v0.9.0
+	google.golang.org/api v0.214.0
 )
 
 require (

--- a/dev/src/handler/gcal.go
+++ b/dev/src/handler/gcal.go
@@ -1,0 +1,125 @@
+package handler
+
+import (
+	"net/http"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/gpwork4u/aibo/dto"
+	"github.com/gpwork4u/aibo/model"
+	"github.com/gpwork4u/aibo/service"
+)
+
+// GcalHandler Google Calendar 整合 handler
+type GcalHandler struct {
+	gcalSvc *service.GcalService
+}
+
+// NewGcalHandler 建立新的 GcalHandler
+func NewGcalHandler(gcalSvc *service.GcalService) *GcalHandler {
+	return &GcalHandler{gcalSvc: gcalSvc}
+}
+
+// StartAuth 開始 OAuth 授權流程
+// POST /api/v1/integrations/gcal/auth
+func (h *GcalHandler) StartAuth(c *gin.Context) {
+	authURL, err := h.gcalSvc.StartOAuth()
+	if err != nil {
+		if appErr, ok := err.(*model.AppError); ok {
+			c.JSON(appErr.Status, dto.ErrorResponse{Code: appErr.Code, Message: appErr.Message})
+			return
+		}
+		c.JSON(http.StatusInternalServerError, dto.ErrorResponse{Code: "INTERNAL_ERROR", Message: "伺服器內部錯誤"})
+		return
+	}
+
+	c.JSON(http.StatusOK, dto.GcalAuthResponse{AuthURL: authURL})
+}
+
+// Callback 處理 OAuth callback
+// GET /api/v1/integrations/gcal/callback
+func (h *GcalHandler) Callback(c *gin.Context) {
+	code := c.Query("code")
+	state := c.Query("state")
+
+	if code == "" || state == "" {
+		c.JSON(http.StatusBadRequest, dto.ErrorResponse{Code: model.ErrCodeInvalidInput, Message: "code 和 state 參數為必填"})
+		return
+	}
+
+	email, err := h.gcalSvc.HandleCallback(c.Request.Context(), code, state)
+	if err != nil {
+		if appErr, ok := err.(*model.AppError); ok {
+			c.JSON(appErr.Status, dto.ErrorResponse{Code: appErr.Code, Message: appErr.Message})
+			return
+		}
+		c.JSON(http.StatusInternalServerError, dto.ErrorResponse{Code: "INTERNAL_ERROR", Message: "伺服器內部錯誤"})
+		return
+	}
+
+	c.JSON(http.StatusOK, dto.GcalCallbackResponse{
+		Message: "Google Calendar connected",
+		Email:   email,
+	})
+}
+
+// Import 匯入 Google Calendar 事件
+// POST /api/v1/import/gcal
+func (h *GcalHandler) Import(c *gin.Context) {
+	var req dto.GcalImportRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		// 允許空 body（全部使用預設值）
+		req = dto.GcalImportRequest{}
+	}
+
+	// 解析參數，設定預設值
+	calendarID := "primary"
+	if req.CalendarID != nil && *req.CalendarID != "" {
+		calendarID = *req.CalendarID
+	}
+
+	now := time.Now().UTC()
+	since := now.AddDate(0, 0, -7) // 預設 7 天前
+	until := now.AddDate(0, 0, 7)  // 預設 7 天後
+
+	if req.Since != nil && *req.Since != "" {
+		parsed, err := time.Parse(time.RFC3339, *req.Since)
+		if err != nil {
+			c.JSON(http.StatusBadRequest, dto.ErrorResponse{Code: model.ErrCodeInvalidInput, Message: "since 格式無效，須為 ISO 8601（例：2024-01-01T00:00:00Z）"})
+			return
+		}
+		since = parsed
+	}
+
+	if req.Until != nil && *req.Until != "" {
+		parsed, err := time.Parse(time.RFC3339, *req.Until)
+		if err != nil {
+			c.JSON(http.StatusBadRequest, dto.ErrorResponse{Code: model.ErrCodeInvalidInput, Message: "until 格式無效，須為 ISO 8601（例：2024-01-31T23:59:59Z）"})
+			return
+		}
+		until = parsed
+	}
+
+	includeRecurring := true
+	if req.IncludeRecurring != nil {
+		includeRecurring = *req.IncludeRecurring
+	}
+
+	eventsFound, entriesCreated, entriesSkipped, err := h.gcalSvc.ImportEvents(
+		c.Request.Context(), calendarID, since, until, includeRecurring,
+	)
+	if err != nil {
+		if appErr, ok := err.(*model.AppError); ok {
+			c.JSON(appErr.Status, dto.ErrorResponse{Code: appErr.Code, Message: appErr.Message})
+			return
+		}
+		c.JSON(http.StatusInternalServerError, dto.ErrorResponse{Code: "INTERNAL_ERROR", Message: "伺服器內部錯誤"})
+		return
+	}
+
+	c.JSON(http.StatusOK, dto.GcalImportResponse{
+		EventsFound:    eventsFound,
+		EntriesCreated: entriesCreated,
+		EntriesSkipped: entriesSkipped,
+	})
+}

--- a/dev/src/handler/git_import.go
+++ b/dev/src/handler/git_import.go
@@ -1,0 +1,51 @@
+package handler
+
+import (
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+	"github.com/gpwork4u/aibo/dto"
+	"github.com/gpwork4u/aibo/model"
+	"github.com/gpwork4u/aibo/service"
+)
+
+// GitImportHandler Git 匯入 HTTP handler
+type GitImportHandler struct {
+	svc *service.GitImportService
+}
+
+// NewGitImportHandler 建立新的 GitImportHandler
+func NewGitImportHandler(svc *service.GitImportService) *GitImportHandler {
+	return &GitImportHandler{svc: svc}
+}
+
+// Import 同步匯入 Git commits
+// POST /api/v1/import/git
+func (h *GitImportHandler) Import(c *gin.Context) {
+	var req dto.GitImportRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, dto.ErrorResponse{
+			Code:    model.ErrCodeInvalidInput,
+			Message: "請求格式錯誤: " + err.Error(),
+		})
+		return
+	}
+
+	result, err := h.svc.ImportCommits(c.Request.Context(), req)
+	if err != nil {
+		if appErr, ok := err.(*model.AppError); ok {
+			c.JSON(appErr.Status, dto.ErrorResponse{
+				Code:    appErr.Code,
+				Message: appErr.Message,
+			})
+			return
+		}
+		c.JSON(http.StatusInternalServerError, dto.ErrorResponse{
+			Code:    "INTERNAL_ERROR",
+			Message: "伺服器內部錯誤",
+		})
+		return
+	}
+
+	c.JSON(http.StatusOK, result)
+}

--- a/dev/src/main.go
+++ b/dev/src/main.go
@@ -89,13 +89,27 @@ func main() {
 	entryHandler := handler.NewEntryHandler(entrySvc, classifierWorker)
 	classifyHandler := handler.NewClassifyHandler(classifierSvc, classifierWorker, entryRepo)
 
+	// 初始化 Git 匯入服務
+	gitImportSvc := service.NewGitImportService(entryRepo)
+	gitImportHandler := handler.NewGitImportHandler(gitImportSvc)
+
+	// 初始化 Google Calendar 整合服務
+	gcalRepo := repository.NewGcalIntegrationRepository(pool)
+	gcalConfig := &service.GcalConfig{
+		ClientID:     cfg.GoogleClientID,
+		ClientSecret: cfg.GoogleClientSecret,
+		RedirectURL:  cfg.GoogleRedirectURL,
+	}
+	gcalSvc := service.NewGcalService(gcalRepo, entryRepo, aesCrypto, gcalConfig)
+	gcalHandler := handler.NewGcalHandler(gcalSvc)
+
 	// 初始化搜尋服務
 	searchRepo := repository.NewSearchRepository(pool)
 	searchSvc := service.NewSearchService(llmSvc, searchRepo)
 	searchHandler := handler.NewSearchHandler(searchSvc)
 
 	// 設定路由
-	r := router.Setup(apiKeySvc, apiKeyHandler, categoryHandler, llmProviderHandler, entryHandler, classifyHandler, searchHandler)
+	r := router.Setup(apiKeySvc, apiKeyHandler, categoryHandler, llmProviderHandler, entryHandler, classifyHandler, searchHandler, gitImportHandler, gcalHandler)
 
 	// 啟動 HTTP server（graceful shutdown）
 	srv := &http.Server{

--- a/dev/src/migration/005_create_gcal_integrations.down.sql
+++ b/dev/src/migration/005_create_gcal_integrations.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS gcal_integrations;

--- a/dev/src/migration/005_create_gcal_integrations.up.sql
+++ b/dev/src/migration/005_create_gcal_integrations.up.sql
@@ -1,0 +1,11 @@
+CREATE TABLE gcal_integrations (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  email VARCHAR(200) NOT NULL,
+  client_id VARCHAR(500) NOT NULL,
+  client_secret VARCHAR(500) NOT NULL,
+  access_token TEXT NOT NULL,
+  refresh_token TEXT NOT NULL,
+  token_expiry TIMESTAMPTZ NOT NULL,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);

--- a/dev/src/model/error.go
+++ b/dev/src/model/error.go
@@ -13,6 +13,9 @@ const (
 	ErrCodeDuplicateProvider = "DUPLICATE_PROVIDER"
 	ErrCodeCategoryNotFound  = "CATEGORY_NOT_FOUND"
 	ErrCodeDuplicateSource   = "DUPLICATE_SOURCE"
+	ErrCodeGcalNotConnected  = "GCAL_NOT_CONNECTED"
+	ErrCodeGcalTokenExpired  = "GCAL_TOKEN_EXPIRED"
+	ErrCodeCalendarNotFound  = "CALENDAR_NOT_FOUND"
 )
 
 // AppError 應用程式錯誤

--- a/dev/src/model/gcal_integration.go
+++ b/dev/src/model/gcal_integration.go
@@ -1,0 +1,20 @@
+package model
+
+import (
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// GcalIntegration Google Calendar 整合資料庫模型
+type GcalIntegration struct {
+	ID           uuid.UUID `json:"id"`
+	Email        string    `json:"email"`
+	ClientID     string    `json:"client_id"`
+	ClientSecret string    `json:"client_secret"` // AES-256 加密儲存
+	AccessToken  string    `json:"access_token"`  // AES-256 加密儲存
+	RefreshToken string    `json:"refresh_token"` // AES-256 加密儲存
+	TokenExpiry  time.Time `json:"token_expiry"`
+	CreatedAt    time.Time `json:"created_at"`
+	UpdatedAt    time.Time `json:"updated_at"`
+}

--- a/dev/src/repository/entry.go
+++ b/dev/src/repository/entry.go
@@ -251,6 +251,16 @@ func (r *EntryRepository) Delete(ctx context.Context, id uuid.UUID) error {
 	return nil
 }
 
+// ExistsBySourceRef 檢查指定 source_type + source_ref 的 entry 是否已存在（用於去重）
+func (r *EntryRepository) ExistsBySourceRef(ctx context.Context, sourceType, sourceRef string) (bool, error) {
+	var exists bool
+	err := r.pool.QueryRow(ctx,
+		"SELECT EXISTS(SELECT 1 FROM entries WHERE source_type = $1 AND source_ref = $2)",
+		sourceType, sourceRef,
+	).Scan(&exists)
+	return exists, err
+}
+
 // CategoryExists 檢查分類是否存在
 func (r *EntryRepository) CategoryExists(ctx context.Context, id uuid.UUID) (bool, error) {
 	var exists bool

--- a/dev/src/repository/gcal_integration.go
+++ b/dev/src/repository/gcal_integration.go
@@ -1,0 +1,82 @@
+package repository
+
+import (
+	"context"
+	"errors"
+
+	"github.com/gpwork4u/aibo/model"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+// GcalIntegrationRepository Google Calendar 整合資料庫操作
+type GcalIntegrationRepository struct {
+	pool *pgxpool.Pool
+}
+
+// NewGcalIntegrationRepository 建立新的 GcalIntegrationRepository
+func NewGcalIntegrationRepository(pool *pgxpool.Pool) *GcalIntegrationRepository {
+	return &GcalIntegrationRepository{pool: pool}
+}
+
+// Get 取得唯一的 GcalIntegration 記錄（只支援一組）
+func (r *GcalIntegrationRepository) Get(ctx context.Context) (*model.GcalIntegration, error) {
+	integration := &model.GcalIntegration{}
+	err := r.pool.QueryRow(ctx,
+		`SELECT id, email, client_id, client_secret, access_token, refresh_token, token_expiry, created_at, updated_at
+		 FROM gcal_integrations
+		 ORDER BY created_at DESC
+		 LIMIT 1`,
+	).Scan(
+		&integration.ID, &integration.Email, &integration.ClientID,
+		&integration.ClientSecret, &integration.AccessToken, &integration.RefreshToken,
+		&integration.TokenExpiry, &integration.CreatedAt, &integration.UpdatedAt,
+	)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	return integration, nil
+}
+
+// Upsert 建立或更新 GcalIntegration（刪除舊的，插入新的）
+func (r *GcalIntegrationRepository) Upsert(ctx context.Context, integration *model.GcalIntegration) error {
+	tx, err := r.pool.Begin(ctx)
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback(ctx)
+
+	// 刪除所有現有記錄（只支援一組）
+	_, err = tx.Exec(ctx, `DELETE FROM gcal_integrations`)
+	if err != nil {
+		return err
+	}
+
+	// 插入新記錄
+	_, err = tx.Exec(ctx,
+		`INSERT INTO gcal_integrations (id, email, client_id, client_secret, access_token, refresh_token, token_expiry, created_at, updated_at)
+		 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)`,
+		integration.ID, integration.Email, integration.ClientID,
+		integration.ClientSecret, integration.AccessToken, integration.RefreshToken,
+		integration.TokenExpiry, integration.CreatedAt, integration.UpdatedAt,
+	)
+	if err != nil {
+		return err
+	}
+
+	return tx.Commit(ctx)
+}
+
+// UpdateTokens 更新 access_token 和 refresh_token
+func (r *GcalIntegrationRepository) UpdateTokens(ctx context.Context, id interface{}, accessToken, refreshToken string, expiry interface{}) error {
+	_, err := r.pool.Exec(ctx,
+		`UPDATE gcal_integrations
+		 SET access_token = $1, refresh_token = $2, token_expiry = $3, updated_at = NOW()
+		 WHERE id = $4`,
+		accessToken, refreshToken, expiry, id,
+	)
+	return err
+}

--- a/dev/src/router/router.go
+++ b/dev/src/router/router.go
@@ -10,7 +10,7 @@ import (
 )
 
 // Setup 設定路由
-func Setup(apiKeySvc *service.ApiKeyService, apiKeyHandler *handler.ApiKeyHandler, categoryHandler *handler.CategoryHandler, llmProviderHandler *handler.LlmProviderHandler, entryHandler *handler.EntryHandler, classifyHandler *handler.ClassifyHandler, searchHandler *handler.SearchHandler) *gin.Engine {
+func Setup(apiKeySvc *service.ApiKeyService, apiKeyHandler *handler.ApiKeyHandler, categoryHandler *handler.CategoryHandler, llmProviderHandler *handler.LlmProviderHandler, entryHandler *handler.EntryHandler, classifyHandler *handler.ClassifyHandler, searchHandler *handler.SearchHandler, gitImportHandler *handler.GitImportHandler, gcalHandler *handler.GcalHandler) *gin.Engine {
 	r := gin.Default()
 
 	// 健康檢查（不需認證）
@@ -63,6 +63,20 @@ func Setup(apiKeySvc *service.ApiKeyService, apiKeyHandler *handler.ApiKeyHandle
 			// LLM 自動分類
 			entries.POST("/:id/classify", classifyHandler.Classify)
 			entries.POST("/classify-all", classifyHandler.ClassifyAll)
+		}
+
+		// Google Calendar 整合
+		integrations := v1.Group("/integrations")
+		{
+			integrations.POST("/gcal/auth", gcalHandler.StartAuth)
+			integrations.GET("/gcal/callback", gcalHandler.Callback)
+		}
+
+		// 匯入
+		importGroup := v1.Group("/import")
+		{
+			importGroup.POST("/git", gitImportHandler.Import)
+			importGroup.POST("/gcal", gcalHandler.Import)
 		}
 
 		// 搜尋

--- a/dev/src/service/gcal.go
+++ b/dev/src/service/gcal.go
@@ -1,0 +1,369 @@
+package service
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"sync"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/gpwork4u/aibo/crypto"
+	"github.com/gpwork4u/aibo/model"
+	"github.com/gpwork4u/aibo/repository"
+	"golang.org/x/oauth2"
+	"golang.org/x/oauth2/google"
+	"google.golang.org/api/calendar/v3"
+	"google.golang.org/api/option"
+)
+
+// 錯誤碼定義於 model.ErrCodeGcalNotConnected 和 model.ErrCodeGcalTokenExpired
+
+// GcalConfig Google OAuth 設定
+type GcalConfig struct {
+	ClientID     string
+	ClientSecret string
+	RedirectURL  string
+}
+
+// GcalService Google Calendar 整合服務
+type GcalService struct {
+	gcalRepo  *repository.GcalIntegrationRepository
+	entryRepo *repository.EntryRepository
+	aesCrypto *crypto.AESCrypto
+	config    *GcalConfig
+
+	// OAuth state 管理（記憶體中暫存）
+	stateMu sync.RWMutex
+	states  map[string]time.Time // state → 建立時間
+}
+
+// NewGcalService 建立新的 GcalService
+func NewGcalService(
+	gcalRepo *repository.GcalIntegrationRepository,
+	entryRepo *repository.EntryRepository,
+	aesCrypto *crypto.AESCrypto,
+	config *GcalConfig,
+) *GcalService {
+	return &GcalService{
+		gcalRepo:  gcalRepo,
+		entryRepo: entryRepo,
+		aesCrypto: aesCrypto,
+		config:    config,
+		states:    make(map[string]time.Time),
+	}
+}
+
+// oauthConfig 建立 OAuth2 Config
+func (s *GcalService) oauthConfig() *oauth2.Config {
+	return &oauth2.Config{
+		ClientID:     s.config.ClientID,
+		ClientSecret: s.config.ClientSecret,
+		RedirectURL:  s.config.RedirectURL,
+		Scopes:       []string{calendar.CalendarReadonlyScope},
+		Endpoint:     google.Endpoint,
+	}
+}
+
+// StartOAuth 開始 OAuth 授權流程，回傳 auth_url
+func (s *GcalService) StartOAuth() (string, error) {
+	if s.config.ClientID == "" || s.config.ClientSecret == "" {
+		return "", model.NewAppError(http.StatusInternalServerError, "INTERNAL_ERROR", "Google OAuth client 未設定")
+	}
+
+	state, err := generateRandomState()
+	if err != nil {
+		return "", fmt.Errorf("產生 state 失敗: %w", err)
+	}
+
+	// 儲存 state（10 分鐘後過期）
+	s.stateMu.Lock()
+	s.states[state] = time.Now()
+	s.stateMu.Unlock()
+
+	// 清理過期 states
+	go s.cleanExpiredStates()
+
+	authURL := s.oauthConfig().AuthCodeURL(state, oauth2.AccessTypeOffline, oauth2.ApprovalForce)
+	return authURL, nil
+}
+
+// HandleCallback 處理 OAuth callback
+func (s *GcalService) HandleCallback(ctx context.Context, code, state string) (string, error) {
+	// 驗證 state
+	s.stateMu.Lock()
+	createdAt, exists := s.states[state]
+	if exists {
+		delete(s.states, state)
+	}
+	s.stateMu.Unlock()
+
+	if !exists {
+		return "", model.NewAppError(http.StatusBadRequest, model.ErrCodeInvalidInput, "無效的 state 參數")
+	}
+
+	// 檢查 state 是否過期（10 分鐘）
+	if time.Since(createdAt) > 10*time.Minute {
+		return "", model.NewAppError(http.StatusBadRequest, model.ErrCodeInvalidInput, "state 已過期，請重新授權")
+	}
+
+	// 交換 code 取得 token
+	oauthCfg := s.oauthConfig()
+	token, err := oauthCfg.Exchange(ctx, code)
+	if err != nil {
+		return "", model.NewAppError(http.StatusInternalServerError, "INTERNAL_ERROR", "token 交換失敗: "+err.Error())
+	}
+
+	// 使用 token 取得使用者 email
+	client := oauthCfg.Client(ctx, token)
+	srv, err := calendar.NewService(ctx, option.WithHTTPClient(client))
+	if err != nil {
+		return "", model.NewAppError(http.StatusInternalServerError, "INTERNAL_ERROR", "建立 Calendar service 失敗: "+err.Error())
+	}
+
+	calendarEntry, err := srv.Calendars.Get("primary").Do()
+	if err != nil {
+		return "", model.NewAppError(http.StatusInternalServerError, "INTERNAL_ERROR", "取得 Calendar 資訊失敗: "+err.Error())
+	}
+
+	email := calendarEntry.Id // primary calendar 的 ID 就是 email
+
+	// 加密 token
+	encClientSecret, err := s.aesCrypto.Encrypt(s.config.ClientSecret)
+	if err != nil {
+		return "", fmt.Errorf("加密 client_secret 失敗: %w", err)
+	}
+	encAccessToken, err := s.aesCrypto.Encrypt(token.AccessToken)
+	if err != nil {
+		return "", fmt.Errorf("加密 access_token 失敗: %w", err)
+	}
+	encRefreshToken, err := s.aesCrypto.Encrypt(token.RefreshToken)
+	if err != nil {
+		return "", fmt.Errorf("加密 refresh_token 失敗: %w", err)
+	}
+
+	// 儲存（upsert，覆蓋舊的）
+	integration := &model.GcalIntegration{
+		ID:           uuid.New(),
+		Email:        email,
+		ClientID:     s.config.ClientID,
+		ClientSecret: encClientSecret,
+		AccessToken:  encAccessToken,
+		RefreshToken: encRefreshToken,
+		TokenExpiry:  token.Expiry,
+		CreatedAt:    time.Now(),
+		UpdatedAt:    time.Now(),
+	}
+
+	if err := s.gcalRepo.Upsert(ctx, integration); err != nil {
+		return "", fmt.Errorf("儲存 GcalIntegration 失敗: %w", err)
+	}
+
+	slog.Info("Google Calendar 連線成功", "email", email)
+	return email, nil
+}
+
+// ImportEvents 匯入 Google Calendar 事件
+func (s *GcalService) ImportEvents(ctx context.Context, calendarID string, since, until time.Time, includeRecurring bool) (eventsFound, entriesCreated, entriesSkipped int, err error) {
+	// 取得整合資訊
+	integration, err := s.gcalRepo.Get(ctx)
+	if err != nil {
+		return 0, 0, 0, fmt.Errorf("查詢 GcalIntegration 失敗: %w", err)
+	}
+	if integration == nil {
+		return 0, 0, 0, model.NewAppError(http.StatusUnauthorized, model.ErrCodeGcalNotConnected, "Google Calendar 尚未授權")
+	}
+
+	// 解密 tokens
+	accessToken, err := s.aesCrypto.Decrypt(integration.AccessToken)
+	if err != nil {
+		return 0, 0, 0, fmt.Errorf("解密 access_token 失敗: %w", err)
+	}
+	refreshToken, err := s.aesCrypto.Decrypt(integration.RefreshToken)
+	if err != nil {
+		return 0, 0, 0, fmt.Errorf("解密 refresh_token 失敗: %w", err)
+	}
+	clientSecret, err := s.aesCrypto.Decrypt(integration.ClientSecret)
+	if err != nil {
+		return 0, 0, 0, fmt.Errorf("解密 client_secret 失敗: %w", err)
+	}
+
+	// 建立 OAuth2 token
+	token := &oauth2.Token{
+		AccessToken:  accessToken,
+		RefreshToken: refreshToken,
+		TokenType:    "Bearer",
+		Expiry:       integration.TokenExpiry,
+	}
+
+	// 建立 OAuth config（使用儲存的 client_id/secret）
+	oauthCfg := &oauth2.Config{
+		ClientID:     integration.ClientID,
+		ClientSecret: clientSecret,
+		RedirectURL:  s.config.RedirectURL,
+		Scopes:       []string{calendar.CalendarReadonlyScope},
+		Endpoint:     google.Endpoint,
+	}
+
+	// 建立可自動 refresh 的 HTTP client
+	tokenSource := oauthCfg.TokenSource(ctx, token)
+	newToken, err := tokenSource.Token()
+	if err != nil {
+		return 0, 0, 0, model.NewAppError(http.StatusUnauthorized, model.ErrCodeGcalTokenExpired, "Token 過期且 refresh 失敗，請重新授權")
+	}
+
+	// 如果 token 被 refresh 了，更新到 DB
+	if newToken.AccessToken != accessToken {
+		slog.Info("Google Calendar token 已自動 refresh")
+		encNewAccess, encErr := s.aesCrypto.Encrypt(newToken.AccessToken)
+		if encErr == nil {
+			encNewRefresh := integration.RefreshToken // 預設用原來的
+			if newToken.RefreshToken != "" && newToken.RefreshToken != refreshToken {
+				encNewRefresh, _ = s.aesCrypto.Encrypt(newToken.RefreshToken)
+			}
+			_ = s.gcalRepo.UpdateTokens(ctx, integration.ID, encNewAccess, encNewRefresh, newToken.Expiry)
+		}
+	}
+
+	// 建立 Calendar service
+	client := oauth2.NewClient(ctx, tokenSource)
+	srv, err := calendar.NewService(ctx, option.WithHTTPClient(client))
+	if err != nil {
+		return 0, 0, 0, fmt.Errorf("建立 Calendar service 失敗: %w", err)
+	}
+
+	// 列出事件
+	call := srv.Events.List(calendarID).
+		TimeMin(since.Format(time.RFC3339)).
+		TimeMax(until.Format(time.RFC3339)).
+		SingleEvents(includeRecurring).
+		OrderBy("startTime").
+		MaxResults(500)
+
+	events, err := call.Do()
+	if err != nil {
+		return 0, 0, 0, fmt.Errorf("列出 Calendar 事件失敗: %w", err)
+	}
+
+	eventsFound = len(events.Items)
+
+	// 逐筆匯入
+	for _, event := range events.Items {
+		// 跳過無 summary 的事件
+		if event.Summary == "" {
+			entriesSkipped++
+			continue
+		}
+
+		// 檢查去重：source_type="gcal" + source_ref=event ID
+		sourceType := "gcal"
+		exists, err := s.entryRepo.ExistsBySourceRef(ctx, sourceType, event.Id)
+		if err != nil {
+			slog.Error("檢查事件去重失敗", "event_id", event.Id, "error", err)
+			entriesSkipped++
+			continue
+		}
+		if exists {
+			entriesSkipped++
+			continue
+		}
+
+		// 建立 Entry
+		title := "[GCal] " + event.Summary
+		content := buildEventContent(event)
+		tags := []string{"gcal", "meeting"}
+		source := calendarID
+
+		entry := &model.Entry{
+			ID:         uuid.New(),
+			Title:      &title,
+			Content:    &content,
+			Source:     &source,
+			SourceType: &sourceType,
+			SourceRef:  &event.Id,
+			Tags:       tags,
+			IsArchived: false,
+			CreatedAt:  time.Now(),
+			UpdatedAt:  time.Now(),
+		}
+
+		if err := s.entryRepo.Create(ctx, entry); err != nil {
+			slog.Error("建立 entry 失敗", "event_id", event.Id, "error", err)
+			entriesSkipped++
+			continue
+		}
+
+		entriesCreated++
+	}
+
+	slog.Info("Google Calendar 匯入完成",
+		"events_found", eventsFound,
+		"entries_created", entriesCreated,
+		"entries_skipped", entriesSkipped,
+	)
+
+	return eventsFound, entriesCreated, entriesSkipped, nil
+}
+
+// buildEventContent 建構事件內容
+func buildEventContent(event *calendar.Event) string {
+	content := ""
+
+	// 時間
+	start := ""
+	end := ""
+	if event.Start != nil {
+		if event.Start.DateTime != "" {
+			start = event.Start.DateTime
+		} else {
+			start = event.Start.Date
+		}
+	}
+	if event.End != nil {
+		if event.End.DateTime != "" {
+			end = event.End.DateTime
+		} else {
+			end = event.End.Date
+		}
+	}
+	if start != "" || end != "" {
+		content += fmt.Sprintf("時間: %s ~ %s\n", start, end)
+	}
+
+	// 地點
+	if event.Location != "" {
+		content += fmt.Sprintf("地點: %s\n", event.Location)
+	}
+
+	// 描述
+	if event.Description != "" {
+		content += "\n" + event.Description
+	}
+
+	return content
+}
+
+// generateRandomState 產生隨機 state 字串
+func generateRandomState() (string, error) {
+	b := make([]byte, 16)
+	if _, err := rand.Read(b); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(b), nil
+}
+
+// cleanExpiredStates 清理過期的 state（超過 10 分鐘）
+func (s *GcalService) cleanExpiredStates() {
+	s.stateMu.Lock()
+	defer s.stateMu.Unlock()
+
+	now := time.Now()
+	for state, createdAt := range s.states {
+		if now.Sub(createdAt) > 10*time.Minute {
+			delete(s.states, state)
+		}
+	}
+}

--- a/dev/src/service/git_import.go
+++ b/dev/src/service/git_import.go
@@ -1,0 +1,287 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"path/filepath"
+	"strings"
+	"time"
+	"unicode/utf8"
+
+	git "github.com/go-git/go-git/v5"
+	"github.com/go-git/go-git/v5/plumbing"
+	"github.com/go-git/go-git/v5/plumbing/object"
+	"github.com/google/uuid"
+	"github.com/gpwork4u/aibo/dto"
+	"github.com/gpwork4u/aibo/model"
+	"github.com/gpwork4u/aibo/repository"
+)
+
+const (
+	maxCommitsPerImport = 500
+	defaultSinceDays    = 7
+)
+
+// sentinel errors
+var (
+	errOverLimit  = errors.New("over_limit")
+	errBreakEarly = errors.New("break_early")
+)
+
+// GitImportService Git 匯入業務邏輯
+type GitImportService struct {
+	entryRepo *repository.EntryRepository
+}
+
+// NewGitImportService 建立新的 GitImportService
+func NewGitImportService(entryRepo *repository.EntryRepository) *GitImportService {
+	return &GitImportService{entryRepo: entryRepo}
+}
+
+// commitInfo 暫存 commit 資訊
+type commitInfo struct {
+	Hash     string
+	Short    string
+	Subject  string
+	Message  string
+	RepoName string
+	RepoPath string
+}
+
+// ImportCommits 同步匯入 Git commits 為知識條目
+func (s *GitImportService) ImportCommits(ctx context.Context, req dto.GitImportRequest) (*dto.GitImportResponse, error) {
+	// 驗證 repo_path
+	if strings.TrimSpace(req.RepoPath) == "" {
+		return nil, model.NewAppError(400, model.ErrCodeInvalidInput, "repo_path 不可為空")
+	}
+
+	// 開啟 repo
+	repo, err := git.PlainOpen(req.RepoPath)
+	if err != nil {
+		return nil, model.NewAppError(400, model.ErrCodeInvalidInput, "repo_path 不是有效的 Git repository")
+	}
+
+	// 解析時間範圍
+	since, until, err := parseTimeRange(req.Since, req.Until)
+	if err != nil {
+		return nil, err
+	}
+
+	// 決定 log 起點
+	logOpts := &git.LogOptions{
+		Order: git.LogOrderCommitterTime,
+	}
+
+	if req.Branch != nil && *req.Branch != "" {
+		ref, err := repo.Reference(plumbing.NewBranchReferenceName(*req.Branch), true)
+		if err != nil {
+			return nil, model.NewAppError(400, model.ErrCodeInvalidInput, fmt.Sprintf("分支 '%s' 不存在", *req.Branch))
+		}
+		logOpts.From = ref.Hash()
+	} else {
+		headRef, err := repo.Head()
+		if err != nil {
+			return nil, model.NewAppError(400, model.ErrCodeInvalidInput, "無法取得 repo HEAD")
+		}
+		logOpts.From = headRef.Hash()
+	}
+
+	// 取得 commit iterator
+	logIter, err := repo.Log(logOpts)
+	if err != nil {
+		return nil, model.NewAppError(400, model.ErrCodeInvalidInput, "無法讀取 commit log")
+	}
+
+	// 取 repo 名稱（路徑的最後一層）
+	repoName := filepath.Base(req.RepoPath)
+
+	// 收集 commits
+	var commits []commitInfo
+	var skippedReasons []dto.SkippedReason
+	totalFound := 0
+
+	iterErr := logIter.ForEach(func(c *object.Commit) error {
+		commitTime := c.Committer.When
+
+		// 超過 until 的跳過（因為按時間降序，較新的先出現）
+		if commitTime.After(until) {
+			return nil
+		}
+
+		// 早於 since 的停止遍歷
+		if commitTime.Before(since) {
+			return errBreakEarly
+		}
+
+		// author 過濾
+		if req.Author != nil && *req.Author != "" {
+			authorFilter := *req.Author
+			if !strings.EqualFold(c.Author.Email, authorFilter) && !strings.EqualFold(c.Author.Name, authorFilter) {
+				return nil
+			}
+		}
+
+		totalFound++
+
+		// 檢查上限
+		if totalFound > maxCommitsPerImport {
+			return errOverLimit
+		}
+
+		hash := c.Hash.String()
+		shortHash := hash[:7]
+		message := strings.TrimSpace(c.Message)
+		subject := extractSubject(message)
+
+		// 略過 merge commit
+		if c.NumParents() > 1 {
+			skippedReasons = append(skippedReasons, dto.SkippedReason{
+				CommitHash: shortHash,
+				Reason:     "merge commit",
+			})
+			return nil
+		}
+
+		// 略過短 message
+		if utf8.RuneCountInString(message) < 10 {
+			skippedReasons = append(skippedReasons, dto.SkippedReason{
+				CommitHash: shortHash,
+				Reason:     "message too short (< 10 chars)",
+			})
+			return nil
+		}
+
+		commits = append(commits, commitInfo{
+			Hash:     hash,
+			Short:    shortHash,
+			Subject:  subject,
+			Message:  message,
+			RepoName: repoName,
+			RepoPath: req.RepoPath,
+		})
+
+		return nil
+	})
+
+	// 處理遍歷結果
+	if iterErr != nil {
+		if errors.Is(iterErr, errOverLimit) {
+			return nil, model.NewAppError(400, model.ErrCodeInvalidInput,
+				fmt.Sprintf("指定範圍內的 commits 超過 %d 筆上限，請縮小日期範圍", maxCommitsPerImport))
+		}
+		if !errors.Is(iterErr, errBreakEarly) {
+			slog.Warn("遍歷 commit log 時發生錯誤", "error", iterErr)
+		}
+	}
+
+	// 建立 entries（含去重）
+	entriesCreated := 0
+
+	for _, ci := range commits {
+		// 去重：檢查 source_type="git" + source_ref=hash 是否已存在
+		exists, err := s.entryRepo.ExistsBySourceRef(ctx, "git", ci.Hash)
+		if err != nil {
+			slog.Error("檢查去重失敗", "hash", ci.Short, "error", err)
+			continue
+		}
+		if exists {
+			skippedReasons = append(skippedReasons, dto.SkippedReason{
+				CommitHash: ci.Short,
+				Reason:     "already imported",
+			})
+			continue
+		}
+
+		// 建立 entry
+		title := fmt.Sprintf("[Git] %s - %s", ci.Short, ci.Subject)
+		content := ci.Message
+		sourceType := "git"
+		sourceRef := ci.Hash
+		source := ci.RepoPath
+		tags := []string{"git", "commit", ci.RepoName}
+
+		now := time.Now().UTC()
+		entry := &model.Entry{
+			ID:         uuid.New(),
+			Title:      &title,
+			Content:    &content,
+			CategoryID: nil,
+			Source:     &source,
+			SourceType: &sourceType,
+			SourceRef:  &sourceRef,
+			Tags:       tags,
+			IsArchived: false,
+			CreatedAt:  now,
+			UpdatedAt:  now,
+		}
+
+		if err := s.entryRepo.Create(ctx, entry); err != nil {
+			slog.Error("建立 entry 失敗", "hash", ci.Short, "error", err)
+			if appErr, ok := err.(*model.AppError); ok && appErr.Code == model.ErrCodeDuplicateSource {
+				skippedReasons = append(skippedReasons, dto.SkippedReason{
+					CommitHash: ci.Short,
+					Reason:     "already imported",
+				})
+			}
+			continue
+		}
+
+		entriesCreated++
+	}
+
+	// 計算 skipped 中屬於 "already imported" 的數量
+	entriesSkipped := 0
+	for _, sr := range skippedReasons {
+		if sr.Reason == "already imported" {
+			entriesSkipped++
+		}
+	}
+
+	return &dto.GitImportResponse{
+		CommitsFound:   totalFound,
+		EntriesCreated: entriesCreated,
+		EntriesSkipped: entriesSkipped,
+		SkippedReasons: skippedReasons,
+	}, nil
+}
+
+// parseTimeRange 解析 since/until 時間參數
+func parseTimeRange(sinceStr, untilStr *string) (time.Time, time.Time, error) {
+	var since, until time.Time
+
+	if sinceStr != nil && *sinceStr != "" {
+		parsed, err := time.Parse(time.RFC3339, *sinceStr)
+		if err != nil {
+			return since, until, model.NewAppError(400, model.ErrCodeInvalidInput, "since 格式無效，須為 ISO 8601（例：2024-01-01T00:00:00Z）")
+		}
+		since = parsed
+	} else {
+		since = time.Now().UTC().AddDate(0, 0, -defaultSinceDays)
+	}
+
+	if untilStr != nil && *untilStr != "" {
+		parsed, err := time.Parse(time.RFC3339, *untilStr)
+		if err != nil {
+			return since, until, model.NewAppError(400, model.ErrCodeInvalidInput, "until 格式無效，須為 ISO 8601（例：2024-01-31T23:59:59Z）")
+		}
+		until = parsed
+	} else {
+		until = time.Now().UTC()
+	}
+
+	return since, until, nil
+}
+
+// extractSubject 從 commit message 取得第一行（subject）
+func extractSubject(message string) string {
+	lines := strings.SplitN(message, "\n", 2)
+	subject := strings.TrimSpace(lines[0])
+	// 截斷過長的 subject（title 上限 100 字，扣掉 "[Git] abc1234 - " 的 18 字）
+	if utf8.RuneCountInString(subject) > 80 {
+		runes := []rune(subject)
+		subject = string(runes[:77]) + "..."
+	}
+	return subject
+}

--- a/test/e2e/f008_git_import_test.go
+++ b/test/e2e/f008_git_import_test.go
@@ -1,0 +1,331 @@
+package e2e
+
+import (
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// ============================================================
+// F-008: Git 整合 — 匯入 Git Commits
+// ============================================================
+
+// --- Happy Path ---
+
+func TestF008_HappyPath_ImportGitCommits(t *testing.T) {
+	// TC-008-01: 匯入 Git commits
+	// GIVEN 使用者已認證 AND repo_path 是有效的 Git repo
+	// WHEN POST /api/v1/import/git with { "repo_path": "/home/user/project" }
+	// THEN 200, commits_found, entries_created, source_type = "git"
+
+	client := NewAPIClient()
+	key := BootstrapAPIKey(t, client, "git-import-key")
+	authedClient := client.WithKey(key)
+
+	status, body, err := authedClient.Do("POST", "/api/v1/import/git", map[string]interface{}{
+		"repo_path": "/tmp/test-repo",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, status)
+
+	// 驗證回應格式包含必要欄位
+	require.NotNil(t, body)
+	_, hasCommitsFound := body["commits_found"]
+	assert.True(t, hasCommitsFound, "response 應包含 commits_found")
+	_, hasEntriesCreated := body["entries_created"]
+	assert.True(t, hasEntriesCreated, "response 應包含 entries_created")
+	_, hasEntriesSkipped := body["entries_skipped"]
+	assert.True(t, hasEntriesSkipped, "response 應包含 entries_skipped")
+}
+
+func TestF008_HappyPath_ImportWithDateRange(t *testing.T) {
+	// TC-008-02: 指定日期範圍匯入
+	// WHEN POST with since / until
+	// THEN 200, 只匯入指定範圍內的 commits
+
+	client := NewAPIClient()
+	key := BootstrapAPIKey(t, client, "git-daterange-key")
+	authedClient := client.WithKey(key)
+
+	status, body, err := authedClient.Do("POST", "/api/v1/import/git", map[string]interface{}{
+		"repo_path": "/tmp/test-repo",
+		"since":     "2024-01-01T00:00:00Z",
+		"until":     "2024-01-31T23:59:59Z",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, status)
+	require.NotNil(t, body)
+
+	_, hasCommitsFound := body["commits_found"]
+	assert.True(t, hasCommitsFound, "response 應包含 commits_found")
+}
+
+func TestF008_HappyPath_ImportWithAuthorFilter(t *testing.T) {
+	// TC-008-03: 指定 author 過濾
+	// WHEN POST with author = "alice@example.com"
+	// THEN 200, 只匯入 alice 的 commits
+
+	client := NewAPIClient()
+	key := BootstrapAPIKey(t, client, "git-author-key")
+	authedClient := client.WithKey(key)
+
+	status, body, err := authedClient.Do("POST", "/api/v1/import/git", map[string]interface{}{
+		"repo_path": "/tmp/test-repo",
+		"author":    "alice@example.com",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, status)
+	require.NotNil(t, body)
+}
+
+func TestF008_HappyPath_DuplicateImportSkips(t *testing.T) {
+	// TC-008-04: 重複匯入時跳過已存在的
+	// GIVEN 第一次匯入已建立 entries
+	// WHEN POST with same params（第二次）
+	// THEN entries_created = 0, entries_skipped > 0
+
+	client := NewAPIClient()
+	key := BootstrapAPIKey(t, client, "git-dedup-key")
+	authedClient := client.WithKey(key)
+
+	payload := map[string]interface{}{
+		"repo_path": "/tmp/test-repo",
+	}
+
+	// 第一次匯入
+	status1, body1, err := authedClient.Do("POST", "/api/v1/import/git", payload)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, status1)
+
+	firstCreated, _ := body1["entries_created"].(float64)
+
+	// 第二次匯入（相同參數）
+	status2, body2, err := authedClient.Do("POST", "/api/v1/import/git", payload)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, status2)
+	require.NotNil(t, body2)
+
+	secondCreated, _ := body2["entries_created"].(float64)
+	secondSkipped, _ := body2["entries_skipped"].(float64)
+
+	// 第二次不應建立新 entries
+	assert.Equal(t, float64(0), secondCreated, "重複匯入不應建立新 entries")
+
+	// 如果第一次有建立，第二次應有 skipped
+	if firstCreated > 0 {
+		assert.True(t, secondSkipped > 0, "重複匯入應有 entries_skipped > 0")
+	}
+}
+
+// --- Error Handling ---
+
+func TestF008_Error_RepoPathEmpty(t *testing.T) {
+	// TC-008-05: repo_path 為空
+	// WHEN POST with { "repo_path": "" }
+	// THEN 400 INVALID_INPUT
+
+	client := NewAPIClient()
+	key := BootstrapAPIKey(t, client, "git-empty-path-key")
+	authedClient := client.WithKey(key)
+
+	status, body, err := authedClient.Do("POST", "/api/v1/import/git", map[string]interface{}{
+		"repo_path": "",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusBadRequest, status)
+	AssertErrorCode(t, body, "INVALID_INPUT")
+}
+
+func TestF008_Error_RepoPathNotGitRepo(t *testing.T) {
+	// TC-008-06: repo_path 不是 Git repo
+	// WHEN POST with { "repo_path": "/tmp/not-a-repo" }
+	// THEN 400 INVALID_INPUT
+
+	client := NewAPIClient()
+	key := BootstrapAPIKey(t, client, "git-notrepo-key")
+	authedClient := client.WithKey(key)
+
+	status, body, err := authedClient.Do("POST", "/api/v1/import/git", map[string]interface{}{
+		"repo_path": "/tmp/definitely-not-a-git-repo-xyz",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusBadRequest, status)
+	AssertErrorCode(t, body, "INVALID_INPUT")
+}
+
+func TestF008_Error_BranchNotFound(t *testing.T) {
+	// repo_path 有效但 branch 不存在
+	// WHEN POST with branch = "nonexistent-branch-xyz"
+	// THEN 400 INVALID_INPUT
+
+	client := NewAPIClient()
+	key := BootstrapAPIKey(t, client, "git-badbranch-key")
+	authedClient := client.WithKey(key)
+
+	status, body, err := authedClient.Do("POST", "/api/v1/import/git", map[string]interface{}{
+		"repo_path": "/tmp/test-repo",
+		"branch":    "nonexistent-branch-xyz",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusBadRequest, status)
+	AssertErrorCode(t, body, "INVALID_INPUT")
+}
+
+func TestF008_Error_ExceedsCommitLimit(t *testing.T) {
+	// TC-008-07: 超過 500 commits 上限
+	// GIVEN repo has > 500 commits in date range
+	// WHEN POST /api/v1/import/git
+	// THEN 400, message mentions 500 limit
+
+	client := NewAPIClient()
+	key := BootstrapAPIKey(t, client, "git-limit-key")
+	authedClient := client.WithKey(key)
+
+	// 使用極大日期範圍觸發超過 500 上限
+	status, body, err := authedClient.Do("POST", "/api/v1/import/git", map[string]interface{}{
+		"repo_path": "/tmp/test-repo-large",
+		"since":     "2000-01-01T00:00:00Z",
+	})
+	require.NoError(t, err)
+
+	// 若 repo 確實有超過 500 commits
+	if status == http.StatusBadRequest {
+		AssertErrorCode(t, body, "INVALID_INPUT")
+		msg, _ := body["message"].(string)
+		assert.True(t, strings.Contains(msg, "500"), "error message 應提及 500 上限")
+	} else {
+		// 若測試環境 repo 不夠大，跳過驗證
+		t.Skip("測試環境 repo commits 數量不足 500，跳過上限測試")
+	}
+}
+
+func TestF008_Error_Unauthorized(t *testing.T) {
+	// TC-008-08: 未認證
+	// WHEN POST without X-API-Key
+	// THEN 401 UNAUTHORIZED
+
+	client := NewAPIClient()
+	// 先確保非 bootstrap 模式
+	_ = BootstrapAPIKey(t, client, "git-unauth-setup-key")
+
+	noAuthClient := NewAPIClient()
+	status, body, err := noAuthClient.Do("POST", "/api/v1/import/git", map[string]interface{}{
+		"repo_path": "/tmp/test-repo",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusUnauthorized, status)
+	AssertErrorCode(t, body, "UNAUTHORIZED")
+}
+
+// --- Edge Cases ---
+
+func TestF008_Edge_SkipMergeCommits(t *testing.T) {
+	// TC-008-09: 略過 merge commits
+	// GIVEN repo has regular + merge commits
+	// WHEN POST /api/v1/import/git
+	// THEN entries_skipped 中包含 reason "merge commit"
+
+	client := NewAPIClient()
+	key := BootstrapAPIKey(t, client, "git-merge-key")
+	authedClient := client.WithKey(key)
+
+	status, body, err := authedClient.Do("POST", "/api/v1/import/git", map[string]interface{}{
+		"repo_path": "/tmp/test-repo",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, status)
+	require.NotNil(t, body)
+
+	// 驗證 skipped_reasons 結構正確（若有 merge commits）
+	if reasons, ok := body["skipped_reasons"].([]interface{}); ok {
+		for _, r := range reasons {
+			reason, ok := r.(map[string]interface{})
+			if !ok {
+				continue
+			}
+			// 每個 reason 應包含 commit_hash 和 reason
+			_, hasHash := reason["commit_hash"]
+			_, hasReason := reason["reason"]
+			assert.True(t, hasHash, "skipped_reasons item 應包含 commit_hash")
+			assert.True(t, hasReason, "skipped_reasons item 應包含 reason")
+		}
+	}
+}
+
+func TestF008_Edge_SkipShortMessageCommits(t *testing.T) {
+	// TC-008-10: 略過短 message commits（< 10 chars）
+	// GIVEN repo has commit with short message
+	// WHEN POST /api/v1/import/git
+	// THEN entries_skipped 中包含 reason "message too short (< 10 chars)"
+
+	client := NewAPIClient()
+	key := BootstrapAPIKey(t, client, "git-shortmsg-key")
+	authedClient := client.WithKey(key)
+
+	status, body, err := authedClient.Do("POST", "/api/v1/import/git", map[string]interface{}{
+		"repo_path": "/tmp/test-repo",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, status)
+	require.NotNil(t, body)
+
+	// 驗證 skipped_reasons 如有短 message，reason 正確
+	if reasons, ok := body["skipped_reasons"].([]interface{}); ok {
+		for _, r := range reasons {
+			reason, ok := r.(map[string]interface{})
+			if !ok {
+				continue
+			}
+			reasonStr, _ := reason["reason"].(string)
+			if strings.Contains(reasonStr, "message too short") {
+				assert.Contains(t, reasonStr, "10 chars",
+					"短 message 原因應包含 '10 chars'")
+			}
+		}
+	}
+}
+
+func TestF008_Edge_EntryTitleFormat(t *testing.T) {
+	// TC-008-11: Entry title 格式驗證
+	// GIVEN commit imported successfully
+	// WHEN 查詢匯入的 entries
+	// THEN entry.title = "[Git] {hash前7碼} - {commit subject}"
+	//      entry.source_type = "git"
+
+	client := NewAPIClient()
+	key := BootstrapAPIKey(t, client, "git-title-key")
+	authedClient := client.WithKey(key)
+
+	// 先匯入
+	status, body, err := authedClient.Do("POST", "/api/v1/import/git", map[string]interface{}{
+		"repo_path": "/tmp/test-repo",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, status)
+
+	created, _ := body["entries_created"].(float64)
+	if created == 0 {
+		t.Skip("無新建 entries，跳過 title 格式驗證")
+	}
+
+	// 查詢以 source_type=git 過濾的 entries
+	status, listBody, err := authedClient.Do("GET", "/api/v1/entries?tag=git&per_page=5", nil)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, status)
+
+	data := GetDataArray(t, listBody)
+	if len(data) == 0 {
+		t.Skip("無 git tag entries，跳過 title 格式驗證")
+	}
+
+	// 驗證第一筆 entry 的 title 格式
+	entry := data[0].(map[string]interface{})
+	title, _ := entry["title"].(string)
+	assert.True(t, strings.HasPrefix(title, "[Git] "),
+		"entry title 應以 '[Git] ' 開頭，實際: %s", title)
+	assert.Contains(t, title, " - ",
+		"entry title 應包含 ' - ' 分隔 hash 和 subject")
+}

--- a/test/e2e/f009_gcal_import_test.go
+++ b/test/e2e/f009_gcal_import_test.go
@@ -1,0 +1,360 @@
+package e2e
+
+import (
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// ============================================================
+// F-009: Google Calendar 整合
+// ============================================================
+//
+// 注意：實際 Google OAuth 無法在 E2E 中完整測試。
+// 以下測試驗證 API 端點的基本行為和錯誤處理，
+// OAuth callback 和實際 Calendar API 呼叫需要 mock server。
+// ============================================================
+
+// --- Happy Path ---
+
+func TestF009_HappyPath_OAuthFlowReturnsAuthURL(t *testing.T) {
+	// TC-009-01: 開始 OAuth 授權
+	// GIVEN 使用者已認證 AND OAuth client 已設定
+	// WHEN POST /api/v1/integrations/gcal/auth
+	// THEN 200, auth_url starts with "https://accounts.google.com"
+
+	client := NewAPIClient()
+	key := BootstrapAPIKey(t, client, "gcal-auth-key")
+	authedClient := client.WithKey(key)
+
+	status, body, err := authedClient.Do("POST", "/api/v1/integrations/gcal/auth", nil)
+	require.NoError(t, err)
+
+	// OAuth client 若已設定，應回 200 + auth_url
+	// 若未設定，可能回 500 INTERNAL_ERROR（這也是預期行為之一）
+	if status == http.StatusOK {
+		require.NotNil(t, body)
+		authURL, ok := body["auth_url"].(string)
+		assert.True(t, ok, "response 應包含 auth_url")
+		assert.True(t, strings.HasPrefix(authURL, "https://accounts.google.com"),
+			"auth_url 應以 https://accounts.google.com 開頭，實際: %s", authURL)
+	} else if status == http.StatusInternalServerError {
+		// OAuth client 未設定的預期錯誤
+		AssertErrorCode(t, body, "INTERNAL_ERROR")
+		t.Log("OAuth client 未設定，回傳 500 INTERNAL_ERROR（預期行為）")
+	} else {
+		t.Fatalf("非預期的 status code: %d, body: %v", status, body)
+	}
+}
+
+func TestF009_HappyPath_OAuthCallbackSuccess(t *testing.T) {
+	// TC-009-02: OAuth callback 成功
+	// GIVEN valid authorization code
+	// WHEN GET /api/v1/integrations/gcal/callback?code={code}&state={state}
+	// THEN 200, message = "Google Calendar connected"
+	//
+	// 注意：此測試需要 mock Google OAuth server，
+	// 在真實環境中使用假的 code/state 會失敗。
+	// 這裡只驗證端點存在且參數缺失時有正確錯誤。
+
+	client := NewAPIClient()
+	key := BootstrapAPIKey(t, client, "gcal-callback-key")
+	authedClient := client.WithKey(key)
+
+	// 使用假的 code 和 state，預期會回錯誤（但端點應存在）
+	status, body, err := authedClient.Do("GET", "/api/v1/integrations/gcal/callback?code=fake_code&state=fake_state", nil)
+	require.NoError(t, err)
+	require.NotNil(t, body)
+
+	// 假 code 應該觸發錯誤（token 交換失敗）
+	// 可能是 400 INVALID_INPUT 或 500 INTERNAL_ERROR
+	assert.True(t, status == http.StatusBadRequest || status == http.StatusInternalServerError,
+		"假 code 應回 400 或 500，實際: %d", status)
+}
+
+func TestF009_HappyPath_ImportGcalEvents(t *testing.T) {
+	// TC-009-03: 匯入 Calendar 事件
+	// GIVEN Google Calendar 已授權
+	// WHEN POST /api/v1/import/gcal
+	// THEN 200, events_found, entries_created
+	//
+	// 注意：若未授權，預期回 401 GCAL_NOT_CONNECTED
+
+	client := NewAPIClient()
+	key := BootstrapAPIKey(t, client, "gcal-import-key")
+	authedClient := client.WithKey(key)
+
+	status, body, err := authedClient.Do("POST", "/api/v1/import/gcal", nil)
+	require.NoError(t, err)
+	require.NotNil(t, body)
+
+	if status == http.StatusOK {
+		// 已授權情況下，驗證回應格式
+		_, hasEventsFound := body["events_found"]
+		assert.True(t, hasEventsFound, "response 應包含 events_found")
+		_, hasEntriesCreated := body["entries_created"]
+		assert.True(t, hasEntriesCreated, "response 應包含 entries_created")
+	} else if status == http.StatusUnauthorized {
+		// 未授權是預期的錯誤
+		code, _ := body["code"].(string)
+		assert.True(t, code == "GCAL_NOT_CONNECTED" || code == "GCAL_TOKEN_EXPIRED",
+			"未授權應回 GCAL_NOT_CONNECTED 或 GCAL_TOKEN_EXPIRED，實際: %s", code)
+		t.Log("Google Calendar 尚未授權，回傳 401（預期行為）")
+	}
+}
+
+func TestF009_HappyPath_ImportWithCalendarAndDateRange(t *testing.T) {
+	// TC-009-04: 指定 calendar 和日期範圍
+	// WHEN POST with calendar_id, since, until
+	// THEN 只匯入指定 calendar 和日期範圍的事件
+
+	client := NewAPIClient()
+	key := BootstrapAPIKey(t, client, "gcal-range-key")
+	authedClient := client.WithKey(key)
+
+	status, body, err := authedClient.Do("POST", "/api/v1/import/gcal", map[string]interface{}{
+		"calendar_id": "work@group.calendar.google.com",
+		"since":       "2024-01-01T00:00:00Z",
+		"until":       "2024-01-31T23:59:59Z",
+	})
+	require.NoError(t, err)
+	require.NotNil(t, body)
+
+	if status == http.StatusOK {
+		_, hasEventsFound := body["events_found"]
+		assert.True(t, hasEventsFound, "response 應包含 events_found")
+	} else if status == http.StatusUnauthorized {
+		code, _ := body["code"].(string)
+		assert.True(t, code == "GCAL_NOT_CONNECTED" || code == "GCAL_TOKEN_EXPIRED",
+			"未授權應回 GCAL_NOT_CONNECTED 或 GCAL_TOKEN_EXPIRED")
+	}
+}
+
+func TestF009_HappyPath_DuplicateImportSkips(t *testing.T) {
+	// TC-009-05: 重複匯入跳過已存在的
+	// GIVEN 第一次匯入已建立 entries
+	// WHEN POST (same params)
+	// THEN entries_created = 0, entries_skipped > 0
+	//
+	// 注意：需要 GCal 已授權才能測試
+
+	client := NewAPIClient()
+	key := BootstrapAPIKey(t, client, "gcal-dedup-key")
+	authedClient := client.WithKey(key)
+
+	// 第一次匯入
+	status1, _, err := authedClient.Do("POST", "/api/v1/import/gcal", nil)
+	require.NoError(t, err)
+
+	if status1 != http.StatusOK {
+		t.Skip("Google Calendar 未授權，跳過重複匯入測試")
+	}
+
+	// 第二次匯入
+	status2, body2, err := authedClient.Do("POST", "/api/v1/import/gcal", nil)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, status2)
+	require.NotNil(t, body2)
+
+	secondCreated, _ := body2["entries_created"].(float64)
+	assert.Equal(t, float64(0), secondCreated, "重複匯入不應建立新 entries")
+}
+
+// --- Error Handling ---
+
+func TestF009_Error_ImportWithoutGcalConnection(t *testing.T) {
+	// TC-009-06: 未授權 Google Calendar 就匯入
+	// GIVEN no GcalIntegration record
+	// WHEN POST /api/v1/import/gcal
+	// THEN 401 GCAL_NOT_CONNECTED
+
+	client := NewAPIClient()
+	key := BootstrapAPIKey(t, client, "gcal-notconn-key")
+	authedClient := client.WithKey(key)
+
+	status, body, err := authedClient.Do("POST", "/api/v1/import/gcal", nil)
+	require.NoError(t, err)
+
+	// 若從未授權過，應回 401
+	if status == http.StatusUnauthorized {
+		AssertErrorCode(t, body, "GCAL_NOT_CONNECTED")
+	} else if status == http.StatusOK {
+		t.Log("GCal 已授權，此測試案例不適用於當前環境")
+	}
+}
+
+func TestF009_Error_TokenExpired(t *testing.T) {
+	// TC-009-07: Token 過期且 refresh 失敗
+	// GIVEN GcalIntegration exists but both tokens expired
+	// WHEN POST /api/v1/import/gcal
+	// THEN 401 GCAL_TOKEN_EXPIRED
+	//
+	// 注意：此測試需要能模擬 token 過期的環境。
+	// 在 E2E 中只能驗證回應格式，實際觸發需要 mock。
+
+	client := NewAPIClient()
+	key := BootstrapAPIKey(t, client, "gcal-expired-key")
+	authedClient := client.WithKey(key)
+
+	status, body, err := authedClient.Do("POST", "/api/v1/import/gcal", nil)
+	require.NoError(t, err)
+	require.NotNil(t, body)
+
+	// 驗證如果是 token 過期，code 正確
+	if status == http.StatusUnauthorized {
+		code, _ := body["code"].(string)
+		assert.True(t, code == "GCAL_NOT_CONNECTED" || code == "GCAL_TOKEN_EXPIRED",
+			"未授權應回 GCAL_NOT_CONNECTED 或 GCAL_TOKEN_EXPIRED，實際: %s", code)
+	}
+}
+
+func TestF009_Error_OAuthClientNotConfigured(t *testing.T) {
+	// TC-009-08: OAuth client 未設定
+	// GIVEN no client_id / client_secret configured
+	// WHEN POST /api/v1/integrations/gcal/auth
+	// THEN 500 INTERNAL_ERROR
+	//
+	// 注意：此測試取決於環境是否有設定 OAuth client。
+	// 若已設定，會回 200（成功取得 auth_url）。
+
+	client := NewAPIClient()
+	key := BootstrapAPIKey(t, client, "gcal-noclient-key")
+	authedClient := client.WithKey(key)
+
+	status, body, err := authedClient.Do("POST", "/api/v1/integrations/gcal/auth", nil)
+	require.NoError(t, err)
+
+	if status == http.StatusInternalServerError {
+		AssertErrorCode(t, body, "INTERNAL_ERROR")
+	} else if status == http.StatusOK {
+		t.Log("OAuth client 已設定，回傳 200（此環境已配置 OAuth）")
+	}
+}
+
+func TestF009_Error_Unauthorized(t *testing.T) {
+	// TC-009-09: 未認證
+	// WHEN POST /api/v1/import/gcal without X-API-Key
+	// THEN 401 UNAUTHORIZED
+
+	client := NewAPIClient()
+	// 先確保非 bootstrap 模式
+	_ = BootstrapAPIKey(t, client, "gcal-unauth-setup-key")
+
+	noAuthClient := NewAPIClient()
+	status, body, err := noAuthClient.Do("POST", "/api/v1/import/gcal", nil)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusUnauthorized, status)
+	AssertErrorCode(t, body, "UNAUTHORIZED")
+}
+
+func TestF009_Error_UnauthorizedAuth(t *testing.T) {
+	// 未認證就嘗試 OAuth 授權
+	// WHEN POST /api/v1/integrations/gcal/auth without X-API-Key
+	// THEN 401 UNAUTHORIZED
+
+	client := NewAPIClient()
+	_ = BootstrapAPIKey(t, client, "gcal-unauth-auth-key")
+
+	noAuthClient := NewAPIClient()
+	status, body, err := noAuthClient.Do("POST", "/api/v1/integrations/gcal/auth", nil)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusUnauthorized, status)
+	AssertErrorCode(t, body, "UNAUTHORIZED")
+}
+
+// --- Edge Cases ---
+
+func TestF009_Edge_SkipEventsWithoutSummary(t *testing.T) {
+	// TC-009-10: 跳過無 summary 的事件
+	// GIVEN calendar has events, some without summary
+	// WHEN POST /api/v1/import/gcal
+	// THEN entries_skipped includes those without summary
+	//
+	// 注意：需要 GCal 已授權且有測試資料
+
+	client := NewAPIClient()
+	key := BootstrapAPIKey(t, client, "gcal-nosummary-key")
+	authedClient := client.WithKey(key)
+
+	status, body, err := authedClient.Do("POST", "/api/v1/import/gcal", nil)
+	require.NoError(t, err)
+	require.NotNil(t, body)
+
+	if status == http.StatusOK {
+		_, hasEntriesSkipped := body["entries_skipped"]
+		assert.True(t, hasEntriesSkipped, "response 應包含 entries_skipped")
+	} else if status == http.StatusUnauthorized {
+		t.Skip("Google Calendar 未授權，跳過無 summary 事件測試")
+	}
+}
+
+func TestF009_Edge_ReauthorizeOverwritesOldToken(t *testing.T) {
+	// TC-009-11: 重新授權覆蓋舊 token
+	// GIVEN GcalIntegration for "old@gmail.com"
+	// WHEN complete OAuth flow for "new@gmail.com"
+	// THEN email updated AND old tokens replaced
+	//
+	// 注意：完整測試需要 mock OAuth server，
+	// 這裡只驗證 auth endpoint 可以被多次呼叫。
+
+	client := NewAPIClient()
+	key := BootstrapAPIKey(t, client, "gcal-reauth-key")
+	authedClient := client.WithKey(key)
+
+	// 第一次呼叫 auth
+	status1, _, err := authedClient.Do("POST", "/api/v1/integrations/gcal/auth", nil)
+	require.NoError(t, err)
+
+	// 第二次呼叫 auth（模擬重新授權）
+	status2, _, err := authedClient.Do("POST", "/api/v1/integrations/gcal/auth", nil)
+	require.NoError(t, err)
+
+	// 兩次應該回相同 status
+	assert.Equal(t, status1, status2, "重複呼叫 auth 應有一致的行為")
+}
+
+func TestF009_Edge_EntryContentFormat(t *testing.T) {
+	// TC-009-12: Entry content 格式驗證
+	// GIVEN event imported successfully
+	// WHEN 查詢匯入的 entries
+	// THEN entry.title = "[GCal] {summary}"
+	//      entry.content 包含時間、地點、描述
+	//
+	// 注意：需要 GCal 已授權且有測試資料
+
+	client := NewAPIClient()
+	key := BootstrapAPIKey(t, client, "gcal-format-key")
+	authedClient := client.WithKey(key)
+
+	// 匯入
+	status, body, err := authedClient.Do("POST", "/api/v1/import/gcal", nil)
+	require.NoError(t, err)
+
+	if status != http.StatusOK {
+		t.Skip("Google Calendar 未授權，跳過 entry 格式驗證")
+	}
+
+	created, _ := body["entries_created"].(float64)
+	if created == 0 {
+		t.Skip("無新建 entries，跳過格式驗證")
+	}
+
+	// 查詢以 gcal tag 過濾的 entries
+	status, listBody, err := authedClient.Do("GET", "/api/v1/entries?tag=gcal&per_page=5", nil)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, status)
+
+	data := GetDataArray(t, listBody)
+	if len(data) == 0 {
+		t.Skip("無 gcal tag entries，跳過格式驗證")
+	}
+
+	// 驗證 title 格式
+	entry := data[0].(map[string]interface{})
+	title, _ := entry["title"].(string)
+	assert.True(t, strings.HasPrefix(title, "[GCal] "),
+		"entry title 應以 '[GCal] ' 開頭，實際: %s", title)
+}


### PR DESCRIPTION
## Summary
- 實作 Google OAuth2 授權流程（POST /api/v1/integrations/gcal/auth + GET callback）
- 實作 Google Calendar 事件同步匯入為 Entry（POST /api/v1/import/gcal）
- 支援日期範圍過濾、指定 calendar、recurring events 展開、event ID 去重
- Token 自動 refresh + AES-256-GCM 加密儲存
- 新增 DB migration（gcal_integrations table）
- 新增 GCAL_NOT_CONNECTED / GCAL_TOKEN_EXPIRED 錯誤碼

## 新增/修改檔案
- `dev/src/handler/gcal.go` — OAuth auth/callback + import handler
- `dev/src/service/gcal.go` — OAuth flow + Calendar API + import logic
- `dev/src/repository/gcal_integration.go` — GcalIntegration CRUD
- `dev/src/model/gcal_integration.go` — GcalIntegration struct
- `dev/src/dto/gcal.go` — request/response DTO
- `dev/src/migration/005_create_gcal_integrations.{up,down}.sql`
- `dev/src/config/config.go` — Google OAuth 環境變數
- `dev/src/model/error.go` — 新增錯誤碼
- `dev/src/router/router.go` — 註冊路由
- `dev/src/main.go` — 初始化 GcalService
- `dev/src/go.mod` — 新增 oauth2、calendar API 依賴
- `dev/src/repository/entry.go` — ExistsBySourceRef 去重方法

## Test plan
- [ ] 設定 GOOGLE_CLIENT_ID / GOOGLE_CLIENT_SECRET 環境變數
- [ ] POST /api/v1/integrations/gcal/auth 回傳 auth_url
- [ ] 完成 OAuth flow 後，GET callback 回傳 connected + email
- [ ] POST /api/v1/import/gcal 匯入事件為 Entry
- [ ] 重複匯入驗證 entries_skipped 正確
- [ ] 未授權時回傳 GCAL_NOT_CONNECTED
- [ ] 驗證 token 加密儲存

Closes #25

🤖 Generated with [Claude Code](https://claude.com/claude-code)