### PR TITLE
feat(F-012): 知識結構升級 - summary/detail/action

### DIFF
--- a/dev/src/dto/entry.go
+++ b/dev/src/dto/entry.go
@@ -10,6 +10,9 @@ import (
 type CreateEntryRequest struct {
 	Title      *string    `json:"title"`
 	Content    *string    `json:"content"`
+	Summary    *string    `json:"summary"`
+	Detail     *string    `json:"detail"`
+	Action     *string    `json:"action"`
 	CategoryID *uuid.UUID `json:"category_id"`
 	Source     *string    `json:"source"`
 	SourceType *string    `json:"source_type"`
@@ -22,6 +25,9 @@ type CreateEntryRequest struct {
 type UpdateEntryRequest struct {
 	Title      *string    `json:"title"`
 	Content    *string    `json:"content"`
+	Summary    *string    `json:"summary"`
+	Detail     *string    `json:"detail"`
+	Action     *string    `json:"action"`
 	CategoryID *uuid.UUID `json:"category_id"`
 	Source     *string    `json:"source"`
 	SourceType *string    `json:"source_type"`
@@ -35,11 +41,14 @@ type UpdateEntryRequest struct {
 	HasCategoryID bool `json:"-"`
 }
 
-// EntryResponse 單筆知識條目回應（完整 content）
+// EntryResponse 單筆知識條目回應（完整 content + summary/detail/action）
 type EntryResponse struct {
 	ID         uuid.UUID  `json:"id"`
 	Title      *string    `json:"title"`
 	Content    *string    `json:"content"`
+	Summary    *string    `json:"summary"`
+	Detail     *string    `json:"detail"`
+	Action     *string    `json:"action"`
 	CategoryID *uuid.UUID `json:"category_id"`
 	Source     *string    `json:"source"`
 	SourceType *string    `json:"source_type"`
@@ -50,10 +59,11 @@ type EntryResponse struct {
 	UpdatedAt  time.Time  `json:"updated_at"`
 }
 
-// EntryListItemResponse 列表中的知識條目（content_preview，不含 source 欄位）
+// EntryListItemResponse 列表中的知識條目（含 summary，不含 detail/action/source）
 type EntryListItemResponse struct {
 	ID             uuid.UUID  `json:"id"`
 	Title          *string    `json:"title"`
+	Summary        *string    `json:"summary"`
 	ContentPreview *string    `json:"content_preview"`
 	CategoryID     *uuid.UUID `json:"category_id"`
 	Tags           []string   `json:"tags"`

--- a/dev/src/dto/llm.go
+++ b/dev/src/dto/llm.go
@@ -7,6 +7,9 @@ type ClassifyResult struct {
 	Category string   `json:"category"`
 	Tags     []string `json:"tags"`
 	Title    string   `json:"title"`
+	Summary  string   `json:"summary"` // 一句話摘要
+	Detail   string   `json:"detail"`  // 詳細說明
+	Action   string   `json:"action"`  // 可執行的建議/行動
 }
 
 // ClassifyResponse 手動觸發分類的回應

--- a/dev/src/dto/search.go
+++ b/dev/src/dto/search.go
@@ -13,6 +13,7 @@ type SmartSearchRequest struct {
 type SearchResultItem struct {
 	EntryID         uuid.UUID `json:"entry_id"`
 	Title           *string   `json:"title"`
+	Summary         *string   `json:"summary"`
 	ContentPreview  string    `json:"content_preview"`
 	Tags            []string  `json:"tags"`
 	Relevance       float64   `json:"relevance"`
@@ -31,6 +32,7 @@ type SmartSearchResponse struct {
 type SimpleSearchResultItem struct {
 	EntryID        uuid.UUID `json:"entry_id"`
 	Title          *string   `json:"title"`
+	Summary        *string   `json:"summary"`
 	ContentPreview string    `json:"content_preview"`
 	Tags           []string  `json:"tags"`
 	Relevance      float64   `json:"relevance"`

--- a/dev/src/handler/entry.go
+++ b/dev/src/handler/entry.go
@@ -131,6 +131,7 @@ func (h *EntryHandler) List(c *gin.Context) {
 		items = append(items, dto.EntryListItemResponse{
 			ID:             item.ID,
 			Title:          item.Title,
+			Summary:        item.Summary,
 			ContentPreview: item.ContentPreview,
 			CategoryID:     item.CategoryID,
 			Tags:           tags,
@@ -297,6 +298,39 @@ func (h *EntryHandler) Update(c *gin.Context) {
 		}
 	}
 
+	if v, ok := rawMap["summary"]; ok {
+		if string(v) == "null" {
+			updates["summary"] = nil
+		} else {
+			var s string
+			if err := json.Unmarshal(v, &s); err == nil {
+				updates["summary"] = s
+			}
+		}
+	}
+
+	if v, ok := rawMap["detail"]; ok {
+		if string(v) == "null" {
+			updates["detail"] = nil
+		} else {
+			var s string
+			if err := json.Unmarshal(v, &s); err == nil {
+				updates["detail"] = s
+			}
+		}
+	}
+
+	if v, ok := rawMap["action"]; ok {
+		if string(v) == "null" {
+			updates["action"] = nil
+		} else {
+			var s string
+			if err := json.Unmarshal(v, &s); err == nil {
+				updates["action"] = s
+			}
+		}
+	}
+
 	if v, ok := rawMap["tags"]; ok {
 		if string(v) == "null" {
 			updates["tags"] = nil
@@ -360,6 +394,9 @@ func toEntryResponse(entry *model.Entry) dto.EntryResponse {
 		ID:         entry.ID,
 		Title:      entry.Title,
 		Content:    entry.Content,
+		Summary:    entry.Summary,
+		Detail:     entry.Detail,
+		Action:     entry.Action,
 		CategoryID: entry.CategoryID,
 		Source:     entry.Source,
 		SourceType: entry.SourceType,

--- a/dev/src/handler/search.go
+++ b/dev/src/handler/search.go
@@ -92,6 +92,7 @@ func (h *SearchHandler) SmartSearch(c *gin.Context) {
 		items = append(items, dto.SearchResultItem{
 			EntryID:         r.EntryID,
 			Title:           r.Title,
+			Summary:         r.Summary,
 			ContentPreview:  r.ContentPreview,
 			Tags:            tags,
 			Relevance:       r.Relevance,
@@ -191,6 +192,7 @@ func (h *SearchHandler) SimpleSearch(c *gin.Context) {
 		items = append(items, dto.SimpleSearchResultItem{
 			EntryID:        r.EntryID,
 			Title:          r.Title,
+			Summary:        r.Summary,
 			ContentPreview: r.ContentPreview,
 			Tags:           tags,
 			Relevance:      r.Relevance,

--- a/dev/src/migration/006_add_knowledge_structure.down.sql
+++ b/dev/src/migration/006_add_knowledge_structure.down.sql
@@ -1,0 +1,16 @@
+-- 還原全文搜尋索引
+DROP INDEX IF EXISTS idx_entries_fts;
+CREATE INDEX idx_entries_fts ON entries USING GIN (
+  (setweight(to_tsvector('simple', coalesce(title, '')), 'A') ||
+   setweight(to_tsvector('simple', coalesce(array_to_string(tags, ' '), '')), 'A') ||
+   setweight(to_tsvector('simple', coalesce(content, '')), 'B'))
+);
+
+DROP INDEX IF EXISTS idx_entries_trgm;
+CREATE INDEX idx_entries_trgm ON entries USING GIN (
+  (coalesce(title,'') || ' ' || coalesce(content,'')) gin_trgm_ops
+);
+
+ALTER TABLE entries DROP COLUMN IF EXISTS action;
+ALTER TABLE entries DROP COLUMN IF EXISTS detail;
+ALTER TABLE entries DROP COLUMN IF EXISTS summary;

--- a/dev/src/migration/006_add_knowledge_structure.up.sql
+++ b/dev/src/migration/006_add_knowledge_structure.up.sql
@@ -1,0 +1,19 @@
+-- 新增知識結構欄位
+ALTER TABLE entries ADD COLUMN summary TEXT NULL;
+ALTER TABLE entries ADD COLUMN detail TEXT NULL;
+ALTER TABLE entries ADD COLUMN action TEXT NULL;
+
+-- 更新全文搜尋索引：summary 權重最高 (A)
+DROP INDEX IF EXISTS idx_entries_fts;
+CREATE INDEX idx_entries_fts ON entries USING GIN (
+  (setweight(to_tsvector('simple', coalesce(summary, '')), 'A') ||
+   setweight(to_tsvector('simple', coalesce(title, '')), 'A') ||
+   setweight(to_tsvector('simple', coalesce(array_to_string(tags, ' '), '')), 'A') ||
+   setweight(to_tsvector('simple', coalesce(content, '')), 'B'))
+);
+
+-- 更新 pg_trgm 索引：加入 summary
+DROP INDEX IF EXISTS idx_entries_trgm;
+CREATE INDEX idx_entries_trgm ON entries USING GIN (
+  (coalesce(summary,'') || ' ' || coalesce(title,'') || ' ' || coalesce(content,'')) gin_trgm_ops
+);

--- a/dev/src/model/entry.go
+++ b/dev/src/model/entry.go
@@ -11,6 +11,9 @@ type Entry struct {
 	ID         uuid.UUID  `json:"id"`
 	Title      *string    `json:"title"`
 	Content    *string    `json:"content"`
+	Summary    *string    `json:"summary"`
+	Detail     *string    `json:"detail"`
+	Action     *string    `json:"action"`
 	CategoryID *uuid.UUID `json:"category_id"`
 	Source     *string    `json:"source"`
 	SourceType *string    `json:"source_type"`
@@ -25,6 +28,7 @@ type Entry struct {
 type EntryListItem struct {
 	ID             uuid.UUID  `json:"id"`
 	Title          *string    `json:"title"`
+	Summary        *string    `json:"summary"`
 	ContentPreview *string    `json:"content_preview"`
 	CategoryID     *uuid.UUID `json:"category_id"`
 	Tags           []string   `json:"tags"`

--- a/dev/src/repository/entry.go
+++ b/dev/src/repository/entry.go
@@ -25,10 +25,10 @@ func NewEntryRepository(pool *pgxpool.Pool) *EntryRepository {
 // Create 建立新知識條目
 func (r *EntryRepository) Create(ctx context.Context, entry *model.Entry) error {
 	_, err := r.pool.Exec(ctx,
-		`INSERT INTO entries (id, title, content, category_id, source, source_type, source_ref, tags, is_archived, created_at, updated_at)
-		 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)`,
-		entry.ID, entry.Title, entry.Content, entry.CategoryID,
-		entry.Source, entry.SourceType, entry.SourceRef,
+		`INSERT INTO entries (id, title, content, summary, detail, action, category_id, source, source_type, source_ref, tags, is_archived, created_at, updated_at)
+		 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14)`,
+		entry.ID, entry.Title, entry.Content, entry.Summary, entry.Detail, entry.Action,
+		entry.CategoryID, entry.Source, entry.SourceType, entry.SourceRef,
 		entry.Tags, entry.IsArchived, entry.CreatedAt, entry.UpdatedAt,
 	)
 	if err != nil {
@@ -47,12 +47,12 @@ func (r *EntryRepository) Create(ctx context.Context, entry *model.Entry) error 
 func (r *EntryRepository) FindByID(ctx context.Context, id uuid.UUID) (*model.Entry, error) {
 	entry := &model.Entry{}
 	err := r.pool.QueryRow(ctx,
-		`SELECT id, title, content, category_id, source, source_type, source_ref, tags, is_archived, created_at, updated_at
+		`SELECT id, title, content, summary, detail, action, category_id, source, source_type, source_ref, tags, is_archived, created_at, updated_at
 		 FROM entries WHERE id = $1`,
 		id,
 	).Scan(
-		&entry.ID, &entry.Title, &entry.Content, &entry.CategoryID,
-		&entry.Source, &entry.SourceType, &entry.SourceRef,
+		&entry.ID, &entry.Title, &entry.Content, &entry.Summary, &entry.Detail, &entry.Action,
+		&entry.CategoryID, &entry.Source, &entry.SourceType, &entry.SourceRef,
 		&entry.Tags, &entry.IsArchived, &entry.CreatedAt, &entry.UpdatedAt,
 	)
 	if errors.Is(err, pgx.ErrNoRows) {
@@ -108,11 +108,12 @@ func (r *EntryRepository) List(ctx context.Context, filter model.EntryFilter) (*
 		searchArgIdx = argIdx
 		// 加權 tsvector 全文搜尋 + pg_trgm 模糊搜尋 + tag ILIKE
 		searchCondition := fmt.Sprintf(
-			`((setweight(to_tsvector('simple', coalesce(e.title, '')), 'A') ||
+			`((setweight(to_tsvector('simple', coalesce(e.summary, '')), 'A') ||
+			   setweight(to_tsvector('simple', coalesce(e.title, '')), 'A') ||
 			   setweight(to_tsvector('simple', coalesce(array_to_string(e.tags, ' '), '')), 'A') ||
 			   setweight(to_tsvector('simple', coalesce(e.content, '')), 'B'))
 			  @@ plainto_tsquery('simple', $%d)
-			 OR (coalesce(e.title,'') || ' ' || coalesce(e.content,'')) %% $%d
+			 OR (coalesce(e.summary,'') || ' ' || coalesce(e.title,'') || ' ' || coalesce(e.content,'')) %% $%d
 			 OR EXISTS (SELECT 1 FROM unnest(e.tags) AS t WHERE t ILIKE '%%' || $%d || '%%'))`,
 			argIdx, argIdx, argIdx,
 		)
@@ -132,6 +133,7 @@ func (r *EntryRepository) List(ctx context.Context, filter model.EntryFilter) (*
 	if hasSearch {
 		orderClause = fmt.Sprintf(
 			`ts_rank(
+			   setweight(to_tsvector('simple', coalesce(e.summary, '')), 'A') ||
 			   setweight(to_tsvector('simple', coalesce(e.title, '')), 'A') ||
 			   setweight(to_tsvector('simple', coalesce(array_to_string(e.tags, ' '), '')), 'A') ||
 			   setweight(to_tsvector('simple', coalesce(e.content, '')), 'B'),
@@ -171,7 +173,7 @@ func (r *EntryRepository) List(ctx context.Context, filter model.EntryFilter) (*
 
 	// 查詢資料（content_preview 用 LEFT(content, 200)，列表不含 source/source_type/source_ref）
 	dataQuery := fmt.Sprintf(
-		`SELECT e.id, e.title, LEFT(e.content, 200) AS content_preview, e.category_id,
+		`SELECT e.id, e.title, e.summary, LEFT(e.content, 200) AS content_preview, e.category_id,
 		        e.tags, e.is_archived, e.created_at, e.updated_at
 		 FROM entries e
 		 %s
@@ -191,7 +193,7 @@ func (r *EntryRepository) List(ctx context.Context, filter model.EntryFilter) (*
 	for rows.Next() {
 		var item model.EntryListItem
 		if err := rows.Scan(
-			&item.ID, &item.Title, &item.ContentPreview, &item.CategoryID,
+			&item.ID, &item.Title, &item.Summary, &item.ContentPreview, &item.CategoryID,
 			&item.Tags, &item.IsArchived, &item.CreatedAt, &item.UpdatedAt,
 		); err != nil {
 			return nil, err
@@ -217,11 +219,12 @@ func (r *EntryRepository) List(ctx context.Context, filter model.EntryFilter) (*
 func (r *EntryRepository) Update(ctx context.Context, entry *model.Entry) error {
 	tag, err := r.pool.Exec(ctx,
 		`UPDATE entries
-		 SET title = $1, content = $2, category_id = $3, source = $4, source_type = $5,
-		     source_ref = $6, tags = $7, is_archived = $8, updated_at = NOW()
-		 WHERE id = $9`,
-		entry.Title, entry.Content, entry.CategoryID,
-		entry.Source, entry.SourceType, entry.SourceRef,
+		 SET title = $1, content = $2, summary = $3, detail = $4, action = $5,
+		     category_id = $6, source = $7, source_type = $8,
+		     source_ref = $9, tags = $10, is_archived = $11, updated_at = NOW()
+		 WHERE id = $12`,
+		entry.Title, entry.Content, entry.Summary, entry.Detail, entry.Action,
+		entry.CategoryID, entry.Source, entry.SourceType, entry.SourceRef,
 		entry.Tags, entry.IsArchived, entry.ID,
 	)
 	if err != nil {

--- a/dev/src/repository/search.go
+++ b/dev/src/repository/search.go
@@ -21,6 +21,7 @@ func escapeLikePattern(s string) string {
 type SearchResult struct {
 	EntryID        uuid.UUID
 	Title          *string
+	Summary        *string
 	ContentPreview *string
 	Tags           []string
 	Relevance      float64
@@ -66,11 +67,12 @@ func (r *SearchRepository) Search(ctx context.Context, params SearchParams) ([]S
 		escapedKwIdx := argIdx + 1
 		keywordArgIndices = append(keywordArgIndices, kwIdx)
 		searchConditions = append(searchConditions, fmt.Sprintf(
-			`((setweight(to_tsvector('simple', coalesce(e.title, '')), 'A') ||
+			`((setweight(to_tsvector('simple', coalesce(e.summary, '')), 'A') ||
+			   setweight(to_tsvector('simple', coalesce(e.title, '')), 'A') ||
 			   setweight(to_tsvector('simple', coalesce(array_to_string(e.tags, ' '), '')), 'A') ||
 			   setweight(to_tsvector('simple', coalesce(e.content, '')), 'B'))
 			  @@ plainto_tsquery('simple', $%d)
-			 OR (coalesce(e.title,'') || ' ' || coalesce(e.content,'')) %% $%d
+			 OR (coalesce(e.summary,'') || ' ' || coalesce(e.title,'') || ' ' || coalesce(e.content,'')) %% $%d
 			 OR EXISTS (SELECT 1 FROM unnest(e.tags) AS t WHERE t ILIKE '%%' || $%d || '%%' ESCAPE '\\'))`,
 			kwIdx, kwIdx, escapedKwIdx,
 		))
@@ -100,6 +102,7 @@ func (r *SearchRepository) Search(ctx context.Context, params SearchParams) ([]S
 	for _, kwIdx := range keywordArgIndices {
 		rankExprs = append(rankExprs, fmt.Sprintf(
 			`ts_rank(
+			   setweight(to_tsvector('simple', coalesce(e.summary, '')), 'A') ||
 			   setweight(to_tsvector('simple', coalesce(e.title, '')), 'A') ||
 			   setweight(to_tsvector('simple', coalesce(array_to_string(e.tags, ' '), '')), 'A') ||
 			   setweight(to_tsvector('simple', coalesce(e.content, '')), 'B'),
@@ -123,7 +126,7 @@ func (r *SearchRepository) Search(ctx context.Context, params SearchParams) ([]S
 
 	// 查詢資料
 	dataQuery := fmt.Sprintf(
-		`SELECT e.id, e.title, LEFT(e.content, 200) AS content_preview,
+		`SELECT e.id, e.title, e.summary, LEFT(e.content, 200) AS content_preview,
 		        e.tags, %s AS relevance
 		 FROM entries e
 		 %s
@@ -143,7 +146,7 @@ func (r *SearchRepository) Search(ctx context.Context, params SearchParams) ([]S
 	for rows.Next() {
 		var item SearchResult
 		if err := rows.Scan(
-			&item.EntryID, &item.Title, &item.ContentPreview,
+			&item.EntryID, &item.Title, &item.Summary, &item.ContentPreview,
 			&item.Tags, &item.Relevance,
 		); err != nil {
 			return nil, 0, err

--- a/dev/src/service/classifier.go
+++ b/dev/src/service/classifier.go
@@ -98,6 +98,17 @@ func (s *ClassifierService) ClassifyEntry(ctx context.Context, entryID uuid.UUID
 		entry.Title = &result.Title
 	}
 
+	// summary/detail/action：LLM 產生時覆蓋（向下相容：空字串不覆蓋）
+	if result.Summary != "" {
+		entry.Summary = &result.Summary
+	}
+	if result.Detail != "" {
+		entry.Detail = &result.Detail
+	}
+	if result.Action != "" {
+		entry.Action = &result.Action
+	}
+
 	if err := s.entryRepo.Update(ctx, entry); err != nil {
 		return fmt.Errorf("更新 entry 失敗: %w", err)
 	}

--- a/dev/src/service/entry.go
+++ b/dev/src/service/entry.go
@@ -215,6 +215,33 @@ func (s *EntryService) Update(ctx context.Context, id uuid.UUID, updates map[str
 		}
 	}
 
+	if v, ok := updates["summary"]; ok {
+		if v == nil {
+			existing.Summary = nil
+		} else {
+			s := v.(string)
+			existing.Summary = &s
+		}
+	}
+
+	if v, ok := updates["detail"]; ok {
+		if v == nil {
+			existing.Detail = nil
+		} else {
+			s := v.(string)
+			existing.Detail = &s
+		}
+	}
+
+	if v, ok := updates["action"]; ok {
+		if v == nil {
+			existing.Action = nil
+		} else {
+			s := v.(string)
+			existing.Action = &s
+		}
+	}
+
 	if v, ok := updates["tags"]; ok {
 		if v == nil {
 			existing.Tags = []string{}

--- a/dev/src/service/llm.go
+++ b/dev/src/service/llm.go
@@ -36,12 +36,22 @@ func NewLlmService(providerSvc *LlmProviderService, aesCrypto *crypto.AESCrypto)
 const classifySystemPrompt = `你是一個知識分類助手。根據使用者提供的內容，分析其主題並回傳 JSON 格式的分類結果。
 
 回傳格式必須嚴格為：
-{"category": "分類名稱", "tags": ["tag1", "tag2"], "title": "建議標題"}
+{
+  "category": "分類名稱",
+  "tags": ["tag1", "tag2"],
+  "title": "建議標題",
+  "summary": "一句話摘要（30字以內）",
+  "detail": "詳細說明（保留原始內容的關鍵資訊，100-300字）",
+  "action": "可執行的建議或行動（如：使用 X 來解決 Y；在 Z 場景下採用此方案）"
+}
 
 規則：
 1. category：選擇最適合的分類名稱，簡潔明確
 2. tags：提取 2-5 個關鍵字作為標籤，使用小寫英文或中文
 3. title：根據內容產生一個簡潔的標題（不超過 50 字）
+4. summary：用一句話概括這則知識的核心觀點
+5. detail：萃取內容中的關鍵資訊、步驟或論點
+6. action：如果內容包含可操作的建議，提取為行動指引；如果是純知識性內容，寫「供參考」
 
 只回傳 JSON，不要包含任何其他文字、說明或 markdown 格式。`
 

--- a/dev/src/service/search.go
+++ b/dev/src/service/search.go
@@ -43,6 +43,7 @@ type SmartSearchOutput struct {
 type SearchResultOutput struct {
 	EntryID         uuid.UUID
 	Title           *string
+	Summary         *string
 	ContentPreview  string
 	Tags            []string
 	Relevance       float64
@@ -69,6 +70,7 @@ type SimpleSearchOutput struct {
 type SimpleSearchResultOutput struct {
 	EntryID        uuid.UUID
 	Title          *string
+	Summary        *string
 	ContentPreview string
 	Tags           []string
 	Relevance      float64
@@ -149,6 +151,7 @@ func (s *SearchService) SmartSearch(ctx context.Context, input SmartSearchInput)
 		item := SearchResultOutput{
 			EntryID:        r.EntryID,
 			Title:          r.Title,
+			Summary:        r.Summary,
 			ContentPreview: preview,
 			Tags:           tags,
 			Relevance:      r.Relevance,
@@ -208,6 +211,7 @@ func (s *SearchService) SimpleSearch(ctx context.Context, input SimpleSearchInpu
 		output.Results = append(output.Results, SimpleSearchResultOutput{
 			EntryID:        r.EntryID,
 			Title:          r.Title,
+			Summary:        r.Summary,
 			ContentPreview: preview,
 			Tags:           tags,
 			Relevance:      r.Relevance,


### PR DESCRIPTION
## Summary
- 為 Entry model 新增 `summary`、`detail`、`action` 三個結構化欄位
- LLM 自動分類 prompt 更新，同時產生 category/tags/title/summary/detail/action
- 搜尋索引更新：summary 權重 A（與 title 同級），參與 FTS 和 trgm 模糊搜尋

## 變更檔案
| 檔案 | 變更 |
|------|------|
| `migration/006_*.sql` | ALTER TABLE + FTS/trgm 索引更新 |
| `model/entry.go` | Entry/EntryListItem 新增欄位 |
| `dto/entry.go` | EntryResponse/EntryListItemResponse 新增欄位 |
| `dto/llm.go` | ClassifyResult 新增 Summary/Detail/Action |
| `dto/search.go` | SearchResultItem 新增 Summary |
| `repository/entry.go` | CRUD SQL 更新 |
| `repository/search.go` | 搜尋 tsvector/trgm 加入 summary |
| `service/llm.go` | classify prompt 更新 |
| `service/classifier.go` | 處理 LLM 回傳新欄位（向下相容） |
| `service/entry.go` | Update 支援 summary/detail/action |
| `service/search.go` | 搜尋輸出新增 Summary |
| `handler/entry.go` | PATCH 支援 + 回應新增欄位 |
| `handler/search.go` | 搜尋回應新增 Summary |

## 向下相容
- 所有新欄位為 `NULL`，不影響現有 entries
- LLM 回傳缺少 summary/detail/action 時不報錯
- 搜尋索引更新為包含 summary，現有搜尋行為不受影響

## Test plan
- [ ] 執行 migration 006 up，驗證 entries table 新增三欄位
- [ ] 建立新 entry，驗證 LLM 分類同時產生 summary/detail/action
- [ ] PATCH entry 手動更新 summary，驗證不影響 detail/action
- [ ] GET /entries 列表包含 summary，不包含 detail/action
- [ ] GET /entries/:id 詳情包含完整 summary/detail/action
- [ ] 搜尋結果包含 summary 欄位
- [ ] 執行 migration 006 down，驗證還原正常

Closes #34

🤖 Generated with [Claude Code](https://claude.com/claude-code)