### PR TITLE
feat(F-011): 實作 MCP Server 模式

### DIFF
--- a/dev/__tests__/mcp/client_test.go
+++ b/dev/__tests__/mcp/client_test.go
@@ -1,0 +1,199 @@
+package mcp_test
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	aimcp "github.com/gpwork4u/aibo/mcp"
+)
+
+func TestClient_Search(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// 驗證請求
+		if r.Method != "POST" {
+			t.Errorf("期望 POST，得到 %s", r.Method)
+		}
+		if r.URL.Path != "/api/v1/search" {
+			t.Errorf("期望 /api/v1/search，得到 %s", r.URL.Path)
+		}
+		if r.Header.Get("X-API-Key") != "test-key" {
+			t.Errorf("期望 API Key test-key，得到 %s", r.Header.Get("X-API-Key"))
+		}
+
+		resp := aimcp.SearchResponse{
+			Results: []aimcp.SearchResultItem{
+				{
+					EntryID:        "abc-123",
+					Title:          strPtr("測試"),
+					ContentPreview: "測試內容",
+					Relevance:      0.9,
+				},
+			},
+			Total: 1,
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(resp)
+	}))
+	defer server.Close()
+
+	client := aimcp.NewClient(server.URL, "test-key")
+	result, err := client.Search(aimcp.SearchRequest{
+		Query: "test",
+		Limit: 5,
+	})
+	if err != nil {
+		t.Fatalf("搜尋失敗: %v", err)
+	}
+	if result.Total != 1 {
+		t.Errorf("期望 1 筆結果，得到 %d", result.Total)
+	}
+	if result.Results[0].EntryID != "abc-123" {
+		t.Errorf("期望 entry ID abc-123，得到 %s", result.Results[0].EntryID)
+	}
+}
+
+func TestClient_CreateEntry(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != "POST" || r.URL.Path != "/api/v1/entries" {
+			t.Errorf("錯誤的請求: %s %s", r.Method, r.URL.Path)
+		}
+
+		w.WriteHeader(http.StatusCreated)
+		resp := aimcp.EntryResponse{
+			ID:    "new-id",
+			Title: strPtr("新知識"),
+		}
+		json.NewEncoder(w).Encode(resp)
+	}))
+	defer server.Close()
+
+	client := aimcp.NewClient(server.URL, "test-key")
+	result, err := client.CreateEntry(aimcp.CreateEntryRequest{
+		Content: "測試內容",
+		Title:   "新知識",
+	})
+	if err != nil {
+		t.Fatalf("建立失敗: %v", err)
+	}
+	if result.ID != "new-id" {
+		t.Errorf("期望 ID new-id，得到 %s", result.ID)
+	}
+}
+
+func TestClient_Confirm(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != "POST" || r.URL.Path != "/api/v1/entries/test-id/confirm" {
+			t.Errorf("錯誤的請求: %s %s", r.Method, r.URL.Path)
+		}
+
+		resp := aimcp.ConfirmResponse{
+			EntryID:       "test-id",
+			Confidence:    0.85,
+			Confirmations: 3,
+			Message:       "已確認",
+		}
+		json.NewEncoder(w).Encode(resp)
+	}))
+	defer server.Close()
+
+	client := aimcp.NewClient(server.URL, "test-key")
+	result, err := client.Confirm("test-id")
+	if err != nil {
+		t.Fatalf("確認失敗: %v", err)
+	}
+	if result.Confidence != 0.85 {
+		t.Errorf("期望信心度 0.85，得到 %f", result.Confidence)
+	}
+}
+
+func TestClient_Flag(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != "POST" || r.URL.Path != "/api/v1/entries/test-id/flag" {
+			t.Errorf("錯誤的請求: %s %s", r.Method, r.URL.Path)
+		}
+
+		// 驗證 body
+		var body aimcp.FlagRequestBody
+		json.NewDecoder(r.Body).Decode(&body)
+		if body.Reason != "outdated" {
+			t.Errorf("期望 reason outdated，得到 %s", body.Reason)
+		}
+
+		resp := aimcp.FlagResponse{
+			EntryID:    "test-id",
+			Confidence: 0.50,
+			FlagsCount: 1,
+			Message:    "已標記",
+		}
+		json.NewEncoder(w).Encode(resp)
+	}))
+	defer server.Close()
+
+	client := aimcp.NewClient(server.URL, "test-key")
+	note := "Go 1.24 已改變"
+	result, err := client.Flag("test-id", "outdated", &note)
+	if err != nil {
+		t.Fatalf("標記失敗: %v", err)
+	}
+	if result.FlagsCount != 1 {
+		t.Errorf("期望標記數 1，得到 %d", result.FlagsCount)
+	}
+}
+
+func TestClient_GetStats(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != "GET" || r.URL.Path != "/api/v1/stats" {
+			t.Errorf("錯誤的請求: %s %s", r.Method, r.URL.Path)
+		}
+
+		resp := aimcp.StatsResponse{
+			TotalEntries:    150,
+			TotalCategories: 12,
+			AvgConfidence:   0.72,
+			EntriesByCategory: []aimcp.CategoryCountItem{
+				{Category: "golang", Count: 30},
+			},
+		}
+		json.NewEncoder(w).Encode(resp)
+	}))
+	defer server.Close()
+
+	client := aimcp.NewClient(server.URL, "test-key")
+	result, err := client.GetStats()
+	if err != nil {
+		t.Fatalf("取得統計失敗: %v", err)
+	}
+	if result.TotalEntries != 150 {
+		t.Errorf("期望 150 筆，得到 %d", result.TotalEntries)
+	}
+}
+
+func TestClient_APIError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+		json.NewEncoder(w).Encode(map[string]string{
+			"code":    "UNAUTHORIZED",
+			"message": "API Key 無效",
+		})
+	}))
+	defer server.Close()
+
+	client := aimcp.NewClient(server.URL, "bad-key")
+	_, err := client.Search(aimcp.SearchRequest{Query: "test"})
+	if err == nil {
+		t.Fatal("期望錯誤但沒有")
+	}
+	if err.Error() == "" {
+		t.Error("錯誤訊息不應為空")
+	}
+}
+
+func TestClient_ConnectionError(t *testing.T) {
+	client := aimcp.NewClient("http://localhost:1", "test-key")
+	_, err := client.Search(aimcp.SearchRequest{Query: "test"})
+	if err == nil {
+		t.Fatal("期望連線錯誤但沒有")
+	}
+}

--- a/dev/__tests__/mcp/formatter_test.go
+++ b/dev/__tests__/mcp/formatter_test.go
@@ -1,0 +1,144 @@
+package mcp_test
+
+import (
+	"strings"
+	"testing"
+
+	aimcp "github.com/gpwork4u/aibo/mcp"
+)
+
+func strPtr(s string) *string {
+	return &s
+}
+
+func TestFormatSearchResults_Empty(t *testing.T) {
+	result := aimcp.FormatSearchResults(nil, 0)
+	if result != "知識庫中未找到相關條目。" {
+		t.Errorf("期望空結果提示，得到: %s", result)
+	}
+}
+
+func TestFormatSearchResults_WithResults(t *testing.T) {
+	items := []aimcp.SearchResultItem{
+		{
+			EntryID:        "abc-123",
+			Title:          strPtr("Go 錯誤處理"),
+			Summary:        strPtr("Go 使用 error interface 進行錯誤處理"),
+			ContentPreview: "Go 使用 error interface...",
+			Tags:           []string{"golang", "error"},
+			Relevance:      0.85,
+		},
+		{
+			EntryID:        "def-456",
+			Title:          nil,
+			Summary:        nil,
+			ContentPreview: "一些內容預覽",
+			Tags:           nil,
+			Relevance:      0.60,
+		},
+	}
+
+	result := aimcp.FormatSearchResults(items, 2)
+
+	// 檢查基本結構
+	if !strings.Contains(result, "找到 2 筆相關知識") {
+		t.Error("缺少總數資訊")
+	}
+	if !strings.Contains(result, "ID: abc-123") {
+		t.Error("缺少第一筆 entry ID")
+	}
+	if !strings.Contains(result, "標題: Go 錯誤處理") {
+		t.Error("缺少標題")
+	}
+	if !strings.Contains(result, "摘要: Go 使用 error interface 進行錯誤處理") {
+		t.Error("缺少摘要")
+	}
+	if !strings.Contains(result, "golang, error") {
+		t.Error("缺少標籤")
+	}
+	if !strings.Contains(result, "85%") {
+		t.Error("缺少相關度")
+	}
+	// 第二筆無 title/summary，應顯示 content preview
+	if !strings.Contains(result, "內容: 一些內容預覽") {
+		t.Error("缺少 content preview fallback")
+	}
+}
+
+func TestFormatEntryCreated(t *testing.T) {
+	entry := &aimcp.EntryResponse{
+		ID:    "new-entry-id",
+		Title: strPtr("新知識"),
+	}
+
+	result := aimcp.FormatEntryCreated(entry)
+	if !strings.Contains(result, "已成功建立知識條目") {
+		t.Error("缺少成功訊息")
+	}
+	if !strings.Contains(result, "new-entry-id") {
+		t.Error("缺少 entry ID")
+	}
+	if !strings.Contains(result, "新知識") {
+		t.Error("缺少標題")
+	}
+}
+
+func TestFormatConfirmResult(t *testing.T) {
+	result := aimcp.FormatConfirmResult(&aimcp.ConfirmResponse{
+		EntryID:       "test-id",
+		Confidence:    0.85,
+		Confirmations: 3,
+	})
+	if !strings.Contains(result, "test-id") {
+		t.Error("缺少 entry ID")
+	}
+	if !strings.Contains(result, "85%") {
+		t.Error("缺少信心度")
+	}
+	if !strings.Contains(result, "3") {
+		t.Error("缺少確認次數")
+	}
+}
+
+func TestFormatFlagResult(t *testing.T) {
+	result := aimcp.FormatFlagResult(&aimcp.FlagResponse{
+		EntryID:    "test-id",
+		Confidence: 0.50,
+		FlagsCount: 2,
+	})
+	if !strings.Contains(result, "test-id") {
+		t.Error("缺少 entry ID")
+	}
+	if !strings.Contains(result, "50%") {
+		t.Error("缺少信心度")
+	}
+}
+
+func TestFormatStats(t *testing.T) {
+	stats := &aimcp.StatsResponse{
+		TotalEntries:    150,
+		TotalCategories: 12,
+		AvgConfidence:   0.72,
+		EntriesByCategory: []aimcp.CategoryCountItem{
+			{Category: "golang", Count: 30},
+			{Category: "devops", Count: 25},
+		},
+	}
+
+	result := aimcp.FormatStats(stats)
+	if !strings.Contains(result, "150") {
+		t.Error("缺少條目總數")
+	}
+	if !strings.Contains(result, "12") {
+		t.Error("缺少分類總數")
+	}
+	if !strings.Contains(result, "72%") {
+		t.Error("缺少平均信心度")
+	}
+	if !strings.Contains(result, "golang: 30 筆") {
+		t.Error("缺少分類分布")
+	}
+	if !strings.Contains(result, "devops: 25 筆") {
+		t.Error("缺少分類分布")
+	}
+}

--- a/dev/__tests__/mcp/tools_test.go
+++ b/dev/__tests__/mcp/tools_test.go
@@ -1,0 +1,253 @@
+package mcp_test
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/mark3labs/mcp-go/mcp"
+
+	aimcp "github.com/gpwork4u/aibo/mcp"
+)
+
+// newMockServer 建立模擬 API server
+func newMockServer(handler http.HandlerFunc) (*httptest.Server, *aimcp.Client) {
+	server := httptest.NewServer(handler)
+	client := aimcp.NewClient(server.URL, "test-key")
+	return server, client
+}
+
+// makeCallToolRequest 建立 CallToolRequest
+func makeCallToolRequest(name string, args map[string]interface{}) mcp.CallToolRequest {
+	return mcp.CallToolRequest{
+		Params: mcp.CallToolParams{
+			Name:      name,
+			Arguments: args,
+		},
+	}
+}
+
+func TestHandleQuery_Success(t *testing.T) {
+	server, client := newMockServer(func(w http.ResponseWriter, r *http.Request) {
+		resp := aimcp.SearchResponse{
+			Results: []aimcp.SearchResultItem{
+				{
+					EntryID:        "abc-123",
+					Title:          strPtr("Go 錯誤處理"),
+					Summary:        strPtr("Go 的錯誤處理方式"),
+					ContentPreview: "內容預覽",
+					Tags:           []string{"golang"},
+					Relevance:      0.9,
+				},
+			},
+			Total: 1,
+		}
+		json.NewEncoder(w).Encode(resp)
+	})
+	defer server.Close()
+
+	handlers := aimcp.NewToolHandlers(client)
+	req := makeCallToolRequest("aibo_query", map[string]interface{}{
+		"query": "golang error handling",
+		"limit": float64(5),
+	})
+
+	result, err := handlers.HandleQuery(context.Background(), req)
+	if err != nil {
+		t.Fatalf("handler 錯誤: %v", err)
+	}
+	if result.IsError {
+		t.Error("不應為錯誤結果")
+	}
+	// 檢查結果包含內容
+	if len(result.Content) == 0 {
+		t.Fatal("結果不應為空")
+	}
+	text := result.Content[0].(mcp.TextContent).Text
+	if !strings.Contains(text, "Go 錯誤處理") {
+		t.Error("結果應包含搜尋內容")
+	}
+}
+
+func TestHandleQuery_EmptyQuery(t *testing.T) {
+	_, client := newMockServer(func(w http.ResponseWriter, r *http.Request) {})
+	handlers := aimcp.NewToolHandlers(client)
+
+	req := makeCallToolRequest("aibo_query", map[string]interface{}{})
+	result, err := handlers.HandleQuery(context.Background(), req)
+	if err != nil {
+		t.Fatalf("handler 錯誤: %v", err)
+	}
+	if !result.IsError {
+		t.Error("空 query 應回傳錯誤")
+	}
+}
+
+func TestHandlePropose_Success(t *testing.T) {
+	server, client := newMockServer(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusCreated)
+		resp := aimcp.EntryResponse{
+			ID:    "new-id",
+			Title: strPtr("新知識"),
+		}
+		json.NewEncoder(w).Encode(resp)
+	})
+	defer server.Close()
+
+	handlers := aimcp.NewToolHandlers(client)
+	req := makeCallToolRequest("aibo_propose", map[string]interface{}{
+		"content": "Go 1.23 range over func",
+		"title":   "Go 1.23 新功能",
+		"tags":    []interface{}{"golang", "go1.23"},
+	})
+
+	result, err := handlers.HandlePropose(context.Background(), req)
+	if err != nil {
+		t.Fatalf("handler 錯誤: %v", err)
+	}
+	if result.IsError {
+		t.Error("不應為錯誤結果")
+	}
+}
+
+func TestHandlePropose_EmptyContent(t *testing.T) {
+	_, client := newMockServer(func(w http.ResponseWriter, r *http.Request) {})
+	handlers := aimcp.NewToolHandlers(client)
+
+	req := makeCallToolRequest("aibo_propose", map[string]interface{}{})
+	result, err := handlers.HandlePropose(context.Background(), req)
+	if err != nil {
+		t.Fatalf("handler 錯誤: %v", err)
+	}
+	if !result.IsError {
+		t.Error("空 content 應回傳錯誤")
+	}
+}
+
+func TestHandleConfirm_Success(t *testing.T) {
+	server, client := newMockServer(func(w http.ResponseWriter, r *http.Request) {
+		resp := aimcp.ConfirmResponse{
+			EntryID:       "test-id",
+			Confidence:    0.85,
+			Confirmations: 3,
+		}
+		json.NewEncoder(w).Encode(resp)
+	})
+	defer server.Close()
+
+	handlers := aimcp.NewToolHandlers(client)
+	req := makeCallToolRequest("aibo_confirm", map[string]interface{}{
+		"entry_id": "test-id",
+	})
+
+	result, err := handlers.HandleConfirm(context.Background(), req)
+	if err != nil {
+		t.Fatalf("handler 錯誤: %v", err)
+	}
+	if result.IsError {
+		t.Error("不應為錯誤結果")
+	}
+}
+
+func TestHandleFlag_Success(t *testing.T) {
+	server, client := newMockServer(func(w http.ResponseWriter, r *http.Request) {
+		resp := aimcp.FlagResponse{
+			EntryID:    "test-id",
+			Confidence: 0.50,
+			FlagsCount: 1,
+		}
+		json.NewEncoder(w).Encode(resp)
+	})
+	defer server.Close()
+
+	handlers := aimcp.NewToolHandlers(client)
+	req := makeCallToolRequest("aibo_flag", map[string]interface{}{
+		"entry_id": "test-id",
+		"reason":   "outdated",
+		"note":     "Go 1.24 已改變",
+	})
+
+	result, err := handlers.HandleFlag(context.Background(), req)
+	if err != nil {
+		t.Fatalf("handler 錯誤: %v", err)
+	}
+	if result.IsError {
+		t.Error("不應為錯誤結果")
+	}
+}
+
+func TestHandleFlag_MissingRequired(t *testing.T) {
+	_, client := newMockServer(func(w http.ResponseWriter, r *http.Request) {})
+	handlers := aimcp.NewToolHandlers(client)
+
+	// 缺少 entry_id
+	req := makeCallToolRequest("aibo_flag", map[string]interface{}{
+		"reason": "outdated",
+	})
+	result, _ := handlers.HandleFlag(context.Background(), req)
+	if !result.IsError {
+		t.Error("缺少 entry_id 應回傳錯誤")
+	}
+
+	// 缺少 reason
+	req = makeCallToolRequest("aibo_flag", map[string]interface{}{
+		"entry_id": "test-id",
+	})
+	result, _ = handlers.HandleFlag(context.Background(), req)
+	if !result.IsError {
+		t.Error("缺少 reason 應回傳錯誤")
+	}
+}
+
+func TestHandleStatus_Success(t *testing.T) {
+	server, client := newMockServer(func(w http.ResponseWriter, r *http.Request) {
+		resp := aimcp.StatsResponse{
+			TotalEntries:    150,
+			TotalCategories: 12,
+			AvgConfidence:   0.72,
+			EntriesByCategory: []aimcp.CategoryCountItem{
+				{Category: "golang", Count: 30},
+			},
+		}
+		json.NewEncoder(w).Encode(resp)
+	})
+	defer server.Close()
+
+	handlers := aimcp.NewToolHandlers(client)
+	req := makeCallToolRequest("aibo_status", map[string]interface{}{})
+
+	result, err := handlers.HandleStatus(context.Background(), req)
+	if err != nil {
+		t.Fatalf("handler 錯誤: %v", err)
+	}
+	if result.IsError {
+		t.Error("不應為錯誤結果")
+	}
+}
+
+func TestHandleQuery_APIError(t *testing.T) {
+	server, client := newMockServer(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+		json.NewEncoder(w).Encode(map[string]string{
+			"code":    "UNAUTHORIZED",
+			"message": "API Key 無效或未設定",
+		})
+	})
+	defer server.Close()
+
+	handlers := aimcp.NewToolHandlers(client)
+	req := makeCallToolRequest("aibo_query", map[string]interface{}{
+		"query": "test",
+	})
+
+	result, err := handlers.HandleQuery(context.Background(), req)
+	if err != nil {
+		t.Fatalf("handler 不應回傳 Go error: %v", err)
+	}
+	if !result.IsError {
+		t.Error("API 錯誤應回傳 MCP error result")
+	}
+}

--- a/dev/mcp-config.example.json
+++ b/dev/mcp-config.example.json
@@ -1,0 +1,11 @@
+{
+  "mcpServers": {
+    "aibo": {
+      "command": "./aibo-mcp",
+      "env": {
+        "AIBO_API_URL": "http://localhost:8080",
+        "AIBO_API_KEY": "aibo_your_key_here"
+      }
+    }
+  }
+}

--- a/dev/src/Dockerfile
+++ b/dev/src/Dockerfile
@@ -13,8 +13,11 @@ RUN go mod download
 # 複製原始碼
 COPY . .
 
-# 編譯
+# 編譯 API server
 RUN CGO_ENABLED=0 GOOS=linux go build -o /api-server .
+
+# 編譯 MCP server
+RUN CGO_ENABLED=0 GOOS=linux go build -o /aibo-mcp ./cmd/mcp
 
 ## Runtime stage
 FROM alpine:3.20
@@ -26,6 +29,7 @@ RUN apk add --no-cache ca-certificates tzdata
 
 # 複製編譯好的執行檔
 COPY --from=builder /api-server .
+COPY --from=builder /aibo-mcp .
 
 EXPOSE 8080
 

--- a/dev/src/cmd/mcp/main.go
+++ b/dev/src/cmd/mcp/main.go
@@ -1,0 +1,35 @@
+package main
+
+import (
+	"fmt"
+	"os"
+
+	aimcp "github.com/gpwork4u/aibo/mcp"
+	"github.com/mark3labs/mcp-go/server"
+)
+
+func main() {
+	// 從環境變數讀取設定
+	apiURL := os.Getenv("AIBO_API_URL")
+	if apiURL == "" {
+		apiURL = "http://localhost:8080"
+	}
+
+	apiKey := os.Getenv("AIBO_API_KEY")
+	if apiKey == "" {
+		fmt.Fprintln(os.Stderr, "錯誤: AIBO_API_KEY 環境變數未設定")
+		os.Exit(1)
+	}
+
+	// 建立 HTTP client
+	client := aimcp.NewClient(apiURL, apiKey)
+
+	// 建立 MCP server
+	s := aimcp.NewServer(client)
+
+	// 使用 stdio transport 啟動
+	if err := server.ServeStdio(s); err != nil {
+		fmt.Fprintf(os.Stderr, "MCP server 錯誤: %v\n", err)
+		os.Exit(1)
+	}
+}

--- a/dev/src/dto/stats.go
+++ b/dev/src/dto/stats.go
@@ -6,6 +6,14 @@ type StatsResponse struct {
 	TotalCategories   int                 `json:"total_categories"`
 	EntriesByCategory []CategoryCountItem `json:"entries_by_category"`
 	AvgConfidence     float64             `json:"avg_confidence"`
+	RecentEntries     []RecentEntryItem   `json:"recent_entries"`
+}
+
+// RecentEntryItem 最近條目項目
+type RecentEntryItem struct {
+	ID        string `json:"id"`
+	Title     string `json:"title"`
+	CreatedAt string `json:"created_at"`
 }
 
 // CategoryCountItem 分類計數項目

--- a/dev/src/dto/stats.go
+++ b/dev/src/dto/stats.go
@@ -1,0 +1,15 @@
+package dto
+
+// StatsResponse 知識庫統計回應
+type StatsResponse struct {
+	TotalEntries      int                 `json:"total_entries"`
+	TotalCategories   int                 `json:"total_categories"`
+	EntriesByCategory []CategoryCountItem `json:"entries_by_category"`
+	AvgConfidence     float64             `json:"avg_confidence"`
+}
+
+// CategoryCountItem 分類計數項目
+type CategoryCountItem struct {
+	Category string `json:"category"`
+	Count    int    `json:"count"`
+}

--- a/dev/src/go.mod
+++ b/dev/src/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/google/uuid v1.6.0
 	github.com/jackc/pgx/v5 v5.5.5
 	github.com/joho/godotenv v1.5.1
+	github.com/mark3labs/mcp-go v0.49.0
 	github.com/sashabaranov/go-openai v1.36.1
 	golang.org/x/oauth2 v0.25.0
 	golang.org/x/time v0.9.0

--- a/dev/src/handler/stats.go
+++ b/dev/src/handler/stats.go
@@ -38,10 +38,20 @@ func (h *StatsHandler) GetStats(c *gin.Context) {
 		})
 	}
 
+	recentEntries := make([]dto.RecentEntryItem, 0, len(result.RecentEntries))
+	for _, re := range result.RecentEntries {
+		recentEntries = append(recentEntries, dto.RecentEntryItem{
+			ID:        re.ID,
+			Title:     re.Title,
+			CreatedAt: re.CreatedAt,
+		})
+	}
+
 	c.JSON(http.StatusOK, dto.StatsResponse{
 		TotalEntries:      result.TotalEntries,
 		TotalCategories:   result.TotalCategories,
 		EntriesByCategory: byCategory,
 		AvgConfidence:     result.AvgConfidence,
+		RecentEntries:     recentEntries,
 	})
 }

--- a/dev/src/handler/stats.go
+++ b/dev/src/handler/stats.go
@@ -1,0 +1,47 @@
+package handler
+
+import (
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+	"github.com/gpwork4u/aibo/dto"
+	"github.com/gpwork4u/aibo/service"
+)
+
+// StatsHandler 統計 HTTP handler
+type StatsHandler struct {
+	svc *service.StatsService
+}
+
+// NewStatsHandler 建立新的 StatsHandler
+func NewStatsHandler(svc *service.StatsService) *StatsHandler {
+	return &StatsHandler{svc: svc}
+}
+
+// GetStats 取得知識庫統計
+// GET /api/v1/stats
+func (h *StatsHandler) GetStats(c *gin.Context) {
+	result, err := h.svc.GetStats(c.Request.Context())
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, dto.ErrorResponse{
+			Code:    "INTERNAL_ERROR",
+			Message: "取得統計資訊失敗",
+		})
+		return
+	}
+
+	byCategory := make([]dto.CategoryCountItem, 0, len(result.EntriesByCategory))
+	for _, cc := range result.EntriesByCategory {
+		byCategory = append(byCategory, dto.CategoryCountItem{
+			Category: cc.Category,
+			Count:    cc.Count,
+		})
+	}
+
+	c.JSON(http.StatusOK, dto.StatsResponse{
+		TotalEntries:      result.TotalEntries,
+		TotalCategories:   result.TotalCategories,
+		EntriesByCategory: byCategory,
+		AvgConfidence:     result.AvgConfidence,
+	})
+}

--- a/dev/src/main.go
+++ b/dev/src/main.go
@@ -109,8 +109,13 @@ func main() {
 	searchSvc := service.NewSearchService(llmSvc, searchRepo)
 	searchHandler := handler.NewSearchHandler(searchSvc)
 
+	// 初始化統計服務
+	statsRepo := repository.NewStatsRepository(pool)
+	statsSvc := service.NewStatsService(statsRepo)
+	statsHandler := handler.NewStatsHandler(statsSvc)
+
 	// 設定路由
-	r := router.Setup(apiKeySvc, apiKeyHandler, categoryHandler, llmProviderHandler, entryHandler, classifyHandler, searchHandler, gitImportHandler, gcalHandler, confidenceHandler)
+	r := router.Setup(apiKeySvc, apiKeyHandler, categoryHandler, llmProviderHandler, entryHandler, classifyHandler, searchHandler, gitImportHandler, gcalHandler, confidenceHandler, statsHandler)
 
 	// 啟動 HTTP server（graceful shutdown）
 	srv := &http.Server{

--- a/dev/src/mcp/client.go
+++ b/dev/src/mcp/client.go
@@ -45,6 +45,8 @@ type SearchResultItem struct {
 	EntryID        string   `json:"entry_id"`
 	Title          *string  `json:"title"`
 	Summary        *string  `json:"summary"`
+	Detail         *string  `json:"detail,omitempty"`
+	Action         *string  `json:"action,omitempty"`
 	ContentPreview string   `json:"content_preview"`
 	Tags           []string `json:"tags"`
 	Relevance      float64  `json:"relevance"`
@@ -87,12 +89,20 @@ type FlagResponse struct {
 	Message    string  `json:"message"`
 }
 
+// RecentEntryItem 最近條目項目
+type RecentEntryItem struct {
+	ID        string `json:"id"`
+	Title     string `json:"title"`
+	CreatedAt string `json:"created_at"`
+}
+
 // StatsResponse 統計回應
 type StatsResponse struct {
 	TotalEntries      int                    `json:"total_entries"`
 	TotalCategories   int                    `json:"total_categories"`
 	EntriesByCategory []CategoryCountItem    `json:"entries_by_category"`
 	AvgConfidence     float64                `json:"avg_confidence"`
+	RecentEntries     []RecentEntryItem      `json:"recent_entries"`
 }
 
 // CategoryCountItem 分類計數項目

--- a/dev/src/mcp/client.go
+++ b/dev/src/mcp/client.go
@@ -1,0 +1,279 @@
+package mcp
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+)
+
+// Client 封裝 aibo REST API 的 HTTP client
+type Client struct {
+	baseURL    string
+	apiKey     string
+	httpClient *http.Client
+}
+
+// NewClient 建立新的 API client
+func NewClient(baseURL, apiKey string) *Client {
+	return &Client{
+		baseURL: baseURL,
+		apiKey:  apiKey,
+		httpClient: &http.Client{
+			Timeout: 30 * time.Second,
+		},
+	}
+}
+
+// SearchRequest 搜尋請求
+type SearchRequest struct {
+	Query      string `json:"query"`
+	CategoryID string `json:"category_id,omitempty"`
+	Limit      int    `json:"limit,omitempty"`
+}
+
+// SearchResponse 搜尋回應
+type SearchResponse struct {
+	Results []SearchResultItem `json:"results"`
+	Total   int                `json:"total"`
+}
+
+// SearchResultItem 搜尋結果項目
+type SearchResultItem struct {
+	EntryID        string   `json:"entry_id"`
+	Title          *string  `json:"title"`
+	Summary        *string  `json:"summary"`
+	ContentPreview string   `json:"content_preview"`
+	Tags           []string `json:"tags"`
+	Relevance      float64  `json:"relevance"`
+}
+
+// CreateEntryRequest 建立知識條目請求
+type CreateEntryRequest struct {
+	Content string   `json:"content"`
+	Title   string   `json:"title,omitempty"`
+	Tags    []string `json:"tags,omitempty"`
+	Source  string   `json:"source,omitempty"`
+}
+
+// EntryResponse 知識條目回應
+type EntryResponse struct {
+	ID         string  `json:"id"`
+	Title      *string `json:"title"`
+	Confidence float64 `json:"confidence"`
+}
+
+// ConfirmResponse 確認回應
+type ConfirmResponse struct {
+	EntryID       string  `json:"entry_id"`
+	Confidence    float64 `json:"confidence"`
+	Confirmations int     `json:"confirmations"`
+	Message       string  `json:"message"`
+}
+
+// FlagRequest 標記請求
+type FlagRequestBody struct {
+	Reason string  `json:"reason"`
+	Note   *string `json:"note,omitempty"`
+}
+
+// FlagResponse 標記回應
+type FlagResponse struct {
+	EntryID    string  `json:"entry_id"`
+	Confidence float64 `json:"confidence"`
+	FlagsCount int     `json:"flags_count"`
+	Message    string  `json:"message"`
+}
+
+// StatsResponse 統計回應
+type StatsResponse struct {
+	TotalEntries      int                    `json:"total_entries"`
+	TotalCategories   int                    `json:"total_categories"`
+	EntriesByCategory []CategoryCountItem    `json:"entries_by_category"`
+	AvgConfidence     float64                `json:"avg_confidence"`
+}
+
+// CategoryCountItem 分類計數項目
+type CategoryCountItem struct {
+	Category string `json:"category"`
+	Count    int    `json:"count"`
+}
+
+// ListEntriesResponse 列表回應（用於統計）
+type ListEntriesResponse struct {
+	Data       []json.RawMessage `json:"data"`
+	Pagination PaginationInfo    `json:"pagination"`
+}
+
+// PaginationInfo 分頁資訊
+type PaginationInfo struct {
+	Total int `json:"total"`
+}
+
+// ListCategoriesResponse 分類列表回應
+type ListCategoriesResponse struct {
+	Data []CategoryItem `json:"data"`
+}
+
+// CategoryItem 分類項目
+type CategoryItem struct {
+	ID         string `json:"id"`
+	Name       string `json:"name"`
+	EntryCount int    `json:"entry_count"`
+}
+
+// Search 搜尋知識庫
+func (c *Client) Search(req SearchRequest) (*SearchResponse, error) {
+	body, err := json.Marshal(req)
+	if err != nil {
+		return nil, fmt.Errorf("序列化請求失敗: %w", err)
+	}
+
+	resp, err := c.doRequest("POST", "/api/v1/search", body)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, c.parseError(resp)
+	}
+
+	var result SearchResponse
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return nil, fmt.Errorf("解析回應失敗: %w", err)
+	}
+	return &result, nil
+}
+
+// CreateEntry 建立知識條目
+func (c *Client) CreateEntry(req CreateEntryRequest) (*EntryResponse, error) {
+	body, err := json.Marshal(req)
+	if err != nil {
+		return nil, fmt.Errorf("序列化請求失敗: %w", err)
+	}
+
+	resp, err := c.doRequest("POST", "/api/v1/entries", body)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusCreated {
+		return nil, c.parseError(resp)
+	}
+
+	var result EntryResponse
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return nil, fmt.Errorf("解析回應失敗: %w", err)
+	}
+	return &result, nil
+}
+
+// Confirm 確認知識條目有用
+func (c *Client) Confirm(entryID string) (*ConfirmResponse, error) {
+	resp, err := c.doRequest("POST", fmt.Sprintf("/api/v1/entries/%s/confirm", entryID), nil)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, c.parseError(resp)
+	}
+
+	var result ConfirmResponse
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return nil, fmt.Errorf("解析回應失敗: %w", err)
+	}
+	return &result, nil
+}
+
+// Flag 標記知識條目問題
+func (c *Client) Flag(entryID, reason string, note *string) (*FlagResponse, error) {
+	reqBody := FlagRequestBody{
+		Reason: reason,
+		Note:   note,
+	}
+	body, err := json.Marshal(reqBody)
+	if err != nil {
+		return nil, fmt.Errorf("序列化請求失敗: %w", err)
+	}
+
+	resp, err := c.doRequest("POST", fmt.Sprintf("/api/v1/entries/%s/flag", entryID), body)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, c.parseError(resp)
+	}
+
+	var result FlagResponse
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return nil, fmt.Errorf("解析回應失敗: %w", err)
+	}
+	return &result, nil
+}
+
+// GetStats 取得知識庫統計（透過 GET /api/v1/stats）
+func (c *Client) GetStats() (*StatsResponse, error) {
+	resp, err := c.doRequest("GET", "/api/v1/stats", nil)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, c.parseError(resp)
+	}
+
+	var result StatsResponse
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return nil, fmt.Errorf("解析回應失敗: %w", err)
+	}
+	return &result, nil
+}
+
+// doRequest 執行 HTTP 請求
+func (c *Client) doRequest(method, path string, body []byte) (*http.Response, error) {
+	url := c.baseURL + path
+
+	var bodyReader io.Reader
+	if body != nil {
+		bodyReader = bytes.NewReader(body)
+	}
+
+	req, err := http.NewRequest(method, url, bodyReader)
+	if err != nil {
+		return nil, fmt.Errorf("建立請求失敗: %w", err)
+	}
+
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-API-Key", c.apiKey)
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("無法連線到 aibo API server (%s): %w", c.baseURL, err)
+	}
+
+	return resp, nil
+}
+
+// parseError 解析錯誤回應
+func (c *Client) parseError(resp *http.Response) error {
+	body, _ := io.ReadAll(resp.Body)
+
+	var errResp struct {
+		Code    string `json:"code"`
+		Message string `json:"message"`
+	}
+	if err := json.Unmarshal(body, &errResp); err == nil && errResp.Message != "" {
+		return fmt.Errorf("API 錯誤 (%d): %s", resp.StatusCode, errResp.Message)
+	}
+
+	return fmt.Errorf("API 錯誤 (%d): %s", resp.StatusCode, string(body))
+}

--- a/dev/src/mcp/client_test.go
+++ b/dev/src/mcp/client_test.go
@@ -1,0 +1,199 @@
+package mcp_test
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	aimcp "github.com/gpwork4u/aibo/mcp"
+)
+
+func TestClient_Search(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// 驗證請求
+		if r.Method != "POST" {
+			t.Errorf("期望 POST，得到 %s", r.Method)
+		}
+		if r.URL.Path != "/api/v1/search" {
+			t.Errorf("期望 /api/v1/search，得到 %s", r.URL.Path)
+		}
+		if r.Header.Get("X-API-Key") != "test-key" {
+			t.Errorf("期望 API Key test-key，得到 %s", r.Header.Get("X-API-Key"))
+		}
+
+		resp := aimcp.SearchResponse{
+			Results: []aimcp.SearchResultItem{
+				{
+					EntryID:        "abc-123",
+					Title:          strPtr("測試"),
+					ContentPreview: "測試內容",
+					Relevance:      0.9,
+				},
+			},
+			Total: 1,
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(resp)
+	}))
+	defer server.Close()
+
+	client := aimcp.NewClient(server.URL, "test-key")
+	result, err := client.Search(aimcp.SearchRequest{
+		Query: "test",
+		Limit: 5,
+	})
+	if err != nil {
+		t.Fatalf("搜尋失敗: %v", err)
+	}
+	if result.Total != 1 {
+		t.Errorf("期望 1 筆結果，得到 %d", result.Total)
+	}
+	if result.Results[0].EntryID != "abc-123" {
+		t.Errorf("期望 entry ID abc-123，得到 %s", result.Results[0].EntryID)
+	}
+}
+
+func TestClient_CreateEntry(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != "POST" || r.URL.Path != "/api/v1/entries" {
+			t.Errorf("錯誤的請求: %s %s", r.Method, r.URL.Path)
+		}
+
+		w.WriteHeader(http.StatusCreated)
+		resp := aimcp.EntryResponse{
+			ID:    "new-id",
+			Title: strPtr("新知識"),
+		}
+		json.NewEncoder(w).Encode(resp)
+	}))
+	defer server.Close()
+
+	client := aimcp.NewClient(server.URL, "test-key")
+	result, err := client.CreateEntry(aimcp.CreateEntryRequest{
+		Content: "測試內容",
+		Title:   "新知識",
+	})
+	if err != nil {
+		t.Fatalf("建立失敗: %v", err)
+	}
+	if result.ID != "new-id" {
+		t.Errorf("期望 ID new-id，得到 %s", result.ID)
+	}
+}
+
+func TestClient_Confirm(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != "POST" || r.URL.Path != "/api/v1/entries/test-id/confirm" {
+			t.Errorf("錯誤的請求: %s %s", r.Method, r.URL.Path)
+		}
+
+		resp := aimcp.ConfirmResponse{
+			EntryID:       "test-id",
+			Confidence:    0.85,
+			Confirmations: 3,
+			Message:       "已確認",
+		}
+		json.NewEncoder(w).Encode(resp)
+	}))
+	defer server.Close()
+
+	client := aimcp.NewClient(server.URL, "test-key")
+	result, err := client.Confirm("test-id")
+	if err != nil {
+		t.Fatalf("確認失敗: %v", err)
+	}
+	if result.Confidence != 0.85 {
+		t.Errorf("期望信心度 0.85，得到 %f", result.Confidence)
+	}
+}
+
+func TestClient_Flag(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != "POST" || r.URL.Path != "/api/v1/entries/test-id/flag" {
+			t.Errorf("錯誤的請求: %s %s", r.Method, r.URL.Path)
+		}
+
+		// 驗證 body
+		var body aimcp.FlagRequestBody
+		json.NewDecoder(r.Body).Decode(&body)
+		if body.Reason != "outdated" {
+			t.Errorf("期望 reason outdated，得到 %s", body.Reason)
+		}
+
+		resp := aimcp.FlagResponse{
+			EntryID:    "test-id",
+			Confidence: 0.50,
+			FlagsCount: 1,
+			Message:    "已標記",
+		}
+		json.NewEncoder(w).Encode(resp)
+	}))
+	defer server.Close()
+
+	client := aimcp.NewClient(server.URL, "test-key")
+	note := "Go 1.24 已改變"
+	result, err := client.Flag("test-id", "outdated", &note)
+	if err != nil {
+		t.Fatalf("標記失敗: %v", err)
+	}
+	if result.FlagsCount != 1 {
+		t.Errorf("期望標記數 1，得到 %d", result.FlagsCount)
+	}
+}
+
+func TestClient_GetStats(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != "GET" || r.URL.Path != "/api/v1/stats" {
+			t.Errorf("錯誤的請求: %s %s", r.Method, r.URL.Path)
+		}
+
+		resp := aimcp.StatsResponse{
+			TotalEntries:    150,
+			TotalCategories: 12,
+			AvgConfidence:   0.72,
+			EntriesByCategory: []aimcp.CategoryCountItem{
+				{Category: "golang", Count: 30},
+			},
+		}
+		json.NewEncoder(w).Encode(resp)
+	}))
+	defer server.Close()
+
+	client := aimcp.NewClient(server.URL, "test-key")
+	result, err := client.GetStats()
+	if err != nil {
+		t.Fatalf("取得統計失敗: %v", err)
+	}
+	if result.TotalEntries != 150 {
+		t.Errorf("期望 150 筆，得到 %d", result.TotalEntries)
+	}
+}
+
+func TestClient_APIError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+		json.NewEncoder(w).Encode(map[string]string{
+			"code":    "UNAUTHORIZED",
+			"message": "API Key 無效",
+		})
+	}))
+	defer server.Close()
+
+	client := aimcp.NewClient(server.URL, "bad-key")
+	_, err := client.Search(aimcp.SearchRequest{Query: "test"})
+	if err == nil {
+		t.Fatal("期望錯誤但沒有")
+	}
+	if err.Error() == "" {
+		t.Error("錯誤訊息不應為空")
+	}
+}
+
+func TestClient_ConnectionError(t *testing.T) {
+	client := aimcp.NewClient("http://localhost:1", "test-key")
+	_, err := client.Search(aimcp.SearchRequest{Query: "test"})
+	if err == nil {
+		t.Fatal("期望連線錯誤但沒有")
+	}
+}

--- a/dev/src/mcp/formatter.go
+++ b/dev/src/mcp/formatter.go
@@ -1,0 +1,88 @@
+package mcp
+
+import (
+	"fmt"
+	"strings"
+)
+
+// FormatSearchResults 格式化搜尋結果為 LLM 友好的文字
+func FormatSearchResults(results []SearchResultItem, total int) string {
+	if total == 0 || len(results) == 0 {
+		return "知識庫中未找到相關條目。"
+	}
+
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("找到 %d 筆相關知識：\n\n", total))
+
+	for i, r := range results {
+		sb.WriteString(fmt.Sprintf("--- [%d] ---\n", i+1))
+
+		// entry_id
+		sb.WriteString(fmt.Sprintf("ID: %s\n", r.EntryID))
+
+		// title
+		if r.Title != nil && *r.Title != "" {
+			sb.WriteString(fmt.Sprintf("標題: %s\n", *r.Title))
+		}
+
+		// summary（優先顯示）
+		if r.Summary != nil && *r.Summary != "" {
+			sb.WriteString(fmt.Sprintf("摘要: %s\n", *r.Summary))
+		} else if r.ContentPreview != "" {
+			sb.WriteString(fmt.Sprintf("內容: %s\n", r.ContentPreview))
+		}
+
+		// tags
+		if len(r.Tags) > 0 {
+			sb.WriteString(fmt.Sprintf("標籤: %s\n", strings.Join(r.Tags, ", ")))
+		}
+
+		// relevance
+		sb.WriteString(fmt.Sprintf("相關度: %.0f%%\n", r.Relevance*100))
+
+		sb.WriteString("\n")
+	}
+
+	return sb.String()
+}
+
+// FormatEntryCreated 格式化建立結果
+func FormatEntryCreated(entry *EntryResponse) string {
+	var sb strings.Builder
+	sb.WriteString("已成功建立知識條目。\n")
+	sb.WriteString(fmt.Sprintf("ID: %s\n", entry.ID))
+	if entry.Title != nil && *entry.Title != "" {
+		sb.WriteString(fmt.Sprintf("標題: %s\n", *entry.Title))
+	}
+	return sb.String()
+}
+
+// FormatConfirmResult 格式化確認結果
+func FormatConfirmResult(result *ConfirmResponse) string {
+	return fmt.Sprintf("已確認知識條目 %s。\n信心度: %.0f%%\n確認次數: %d",
+		result.EntryID, result.Confidence*100, result.Confirmations)
+}
+
+// FormatFlagResult 格式化標記結果
+func FormatFlagResult(result *FlagResponse) string {
+	return fmt.Sprintf("已標記知識條目 %s。\n信心度: %.0f%%\n標記次數: %d",
+		result.EntryID, result.Confidence*100, result.FlagsCount)
+}
+
+// FormatStats 格式化統計資訊
+func FormatStats(stats *StatsResponse) string {
+	var sb strings.Builder
+	sb.WriteString("=== aibo 知識庫統計 ===\n\n")
+	sb.WriteString(fmt.Sprintf("條目總數: %d\n", stats.TotalEntries))
+	sb.WriteString(fmt.Sprintf("分類總數: %d\n", stats.TotalCategories))
+	sb.WriteString(fmt.Sprintf("平均信心度: %.0f%%\n", stats.AvgConfidence*100))
+
+	if len(stats.EntriesByCategory) > 0 {
+		sb.WriteString("\n分類分布:\n")
+		for _, cat := range stats.EntriesByCategory {
+			sb.WriteString(fmt.Sprintf("  - %s: %d 筆\n", cat.Category, cat.Count))
+		}
+	}
+
+	return sb.String()
+}

--- a/dev/src/mcp/formatter.go
+++ b/dev/src/mcp/formatter.go
@@ -32,6 +32,16 @@ func FormatSearchResults(results []SearchResultItem, total int) string {
 			sb.WriteString(fmt.Sprintf("內容: %s\n", r.ContentPreview))
 		}
 
+		// detail（如有）
+		if r.Detail != nil && *r.Detail != "" {
+			sb.WriteString(fmt.Sprintf("詳情: %s\n", *r.Detail))
+		}
+
+		// action（如有）
+		if r.Action != nil && *r.Action != "" {
+			sb.WriteString(fmt.Sprintf("行動: %s\n", *r.Action))
+		}
+
 		// tags
 		if len(r.Tags) > 0 {
 			sb.WriteString(fmt.Sprintf("標籤: %s\n", strings.Join(r.Tags, ", ")))
@@ -81,6 +91,17 @@ func FormatStats(stats *StatsResponse) string {
 		sb.WriteString("\n分類分布:\n")
 		for _, cat := range stats.EntriesByCategory {
 			sb.WriteString(fmt.Sprintf("  - %s: %d 筆\n", cat.Category, cat.Count))
+		}
+	}
+
+	if len(stats.RecentEntries) > 0 {
+		sb.WriteString("\n最近條目:\n")
+		for _, re := range stats.RecentEntries {
+			title := re.Title
+			if title == "" {
+				title = "(無標題)"
+			}
+			sb.WriteString(fmt.Sprintf("  - [%s] %s (%s)\n", re.ID, title, re.CreatedAt))
 		}
 	}
 

--- a/dev/src/mcp/formatter_test.go
+++ b/dev/src/mcp/formatter_test.go
@@ -123,6 +123,10 @@ func TestFormatStats(t *testing.T) {
 			{Category: "golang", Count: 30},
 			{Category: "devops", Count: 25},
 		},
+		RecentEntries: []aimcp.RecentEntryItem{
+			{ID: "entry-1", Title: "Go 入門", CreatedAt: "2026-04-20T10:00:00Z"},
+			{ID: "entry-2", Title: "", CreatedAt: "2026-04-19T09:00:00Z"},
+		},
 	}
 
 	result := aimcp.FormatStats(stats)
@@ -140,5 +144,58 @@ func TestFormatStats(t *testing.T) {
 	}
 	if !strings.Contains(result, "devops: 25 筆") {
 		t.Error("缺少分類分布")
+	}
+	if !strings.Contains(result, "最近條目") {
+		t.Error("缺少最近條目區塊")
+	}
+	if !strings.Contains(result, "entry-1") {
+		t.Error("缺少最近條目 ID")
+	}
+	if !strings.Contains(result, "Go 入門") {
+		t.Error("缺少最近條目標題")
+	}
+	if !strings.Contains(result, "(無標題)") {
+		t.Error("空標題應顯示 (無標題)")
+	}
+}
+
+func TestFormatSearchResults_WithDetailAndAction(t *testing.T) {
+	detail := "詳細的錯誤處理說明"
+	action := "使用 errors.Is 進行比較"
+	items := []aimcp.SearchResultItem{
+		{
+			EntryID:        "abc-123",
+			Title:          strPtr("Go 錯誤處理"),
+			Summary:        strPtr("Go 使用 error interface 進行錯誤處理"),
+			Detail:         &detail,
+			Action:         &action,
+			ContentPreview: "Go 使用 error interface...",
+			Tags:           []string{"golang"},
+			Relevance:      0.85,
+		},
+		{
+			EntryID:        "def-456",
+			Title:          strPtr("基本知識"),
+			Summary:        strPtr("簡單摘要"),
+			Detail:         nil,
+			Action:         nil,
+			ContentPreview: "內容",
+			Tags:           nil,
+			Relevance:      0.60,
+		},
+	}
+
+	result := aimcp.FormatSearchResults(items, 2)
+
+	if !strings.Contains(result, "詳情: 詳細的錯誤處理說明") {
+		t.Error("缺少 detail 欄位")
+	}
+	if !strings.Contains(result, "行動: 使用 errors.Is 進行比較") {
+		t.Error("缺少 action 欄位")
+	}
+	// 第二筆沒有 detail/action，不應出現
+	parts := strings.Split(result, "--- [2] ---")
+	if len(parts) > 1 && strings.Contains(parts[1], "詳情:") {
+		t.Error("空 detail 不應顯示")
 	}
 }

--- a/dev/src/mcp/formatter_test.go
+++ b/dev/src/mcp/formatter_test.go
@@ -1,0 +1,144 @@
+package mcp_test
+
+import (
+	"strings"
+	"testing"
+
+	aimcp "github.com/gpwork4u/aibo/mcp"
+)
+
+func strPtr(s string) *string {
+	return &s
+}
+
+func TestFormatSearchResults_Empty(t *testing.T) {
+	result := aimcp.FormatSearchResults(nil, 0)
+	if result != "知識庫中未找到相關條目。" {
+		t.Errorf("期望空結果提示，得到: %s", result)
+	}
+}
+
+func TestFormatSearchResults_WithResults(t *testing.T) {
+	items := []aimcp.SearchResultItem{
+		{
+			EntryID:        "abc-123",
+			Title:          strPtr("Go 錯誤處理"),
+			Summary:        strPtr("Go 使用 error interface 進行錯誤處理"),
+			ContentPreview: "Go 使用 error interface...",
+			Tags:           []string{"golang", "error"},
+			Relevance:      0.85,
+		},
+		{
+			EntryID:        "def-456",
+			Title:          nil,
+			Summary:        nil,
+			ContentPreview: "一些內容預覽",
+			Tags:           nil,
+			Relevance:      0.60,
+		},
+	}
+
+	result := aimcp.FormatSearchResults(items, 2)
+
+	// 檢查基本結構
+	if !strings.Contains(result, "找到 2 筆相關知識") {
+		t.Error("缺少總數資訊")
+	}
+	if !strings.Contains(result, "ID: abc-123") {
+		t.Error("缺少第一筆 entry ID")
+	}
+	if !strings.Contains(result, "標題: Go 錯誤處理") {
+		t.Error("缺少標題")
+	}
+	if !strings.Contains(result, "摘要: Go 使用 error interface 進行錯誤處理") {
+		t.Error("缺少摘要")
+	}
+	if !strings.Contains(result, "golang, error") {
+		t.Error("缺少標籤")
+	}
+	if !strings.Contains(result, "85%") {
+		t.Error("缺少相關度")
+	}
+	// 第二筆無 title/summary，應顯示 content preview
+	if !strings.Contains(result, "內容: 一些內容預覽") {
+		t.Error("缺少 content preview fallback")
+	}
+}
+
+func TestFormatEntryCreated(t *testing.T) {
+	entry := &aimcp.EntryResponse{
+		ID:    "new-entry-id",
+		Title: strPtr("新知識"),
+	}
+
+	result := aimcp.FormatEntryCreated(entry)
+	if !strings.Contains(result, "已成功建立知識條目") {
+		t.Error("缺少成功訊息")
+	}
+	if !strings.Contains(result, "new-entry-id") {
+		t.Error("缺少 entry ID")
+	}
+	if !strings.Contains(result, "新知識") {
+		t.Error("缺少標題")
+	}
+}
+
+func TestFormatConfirmResult(t *testing.T) {
+	result := aimcp.FormatConfirmResult(&aimcp.ConfirmResponse{
+		EntryID:       "test-id",
+		Confidence:    0.85,
+		Confirmations: 3,
+	})
+	if !strings.Contains(result, "test-id") {
+		t.Error("缺少 entry ID")
+	}
+	if !strings.Contains(result, "85%") {
+		t.Error("缺少信心度")
+	}
+	if !strings.Contains(result, "3") {
+		t.Error("缺少確認次數")
+	}
+}
+
+func TestFormatFlagResult(t *testing.T) {
+	result := aimcp.FormatFlagResult(&aimcp.FlagResponse{
+		EntryID:    "test-id",
+		Confidence: 0.50,
+		FlagsCount: 2,
+	})
+	if !strings.Contains(result, "test-id") {
+		t.Error("缺少 entry ID")
+	}
+	if !strings.Contains(result, "50%") {
+		t.Error("缺少信心度")
+	}
+}
+
+func TestFormatStats(t *testing.T) {
+	stats := &aimcp.StatsResponse{
+		TotalEntries:    150,
+		TotalCategories: 12,
+		AvgConfidence:   0.72,
+		EntriesByCategory: []aimcp.CategoryCountItem{
+			{Category: "golang", Count: 30},
+			{Category: "devops", Count: 25},
+		},
+	}
+
+	result := aimcp.FormatStats(stats)
+	if !strings.Contains(result, "150") {
+		t.Error("缺少條目總數")
+	}
+	if !strings.Contains(result, "12") {
+		t.Error("缺少分類總數")
+	}
+	if !strings.Contains(result, "72%") {
+		t.Error("缺少平均信心度")
+	}
+	if !strings.Contains(result, "golang: 30 筆") {
+		t.Error("缺少分類分布")
+	}
+	if !strings.Contains(result, "devops: 25 筆") {
+		t.Error("缺少分類分布")
+	}
+}

--- a/dev/src/mcp/server.go
+++ b/dev/src/mcp/server.go
@@ -1,0 +1,26 @@
+package mcp
+
+import (
+	"github.com/mark3labs/mcp-go/server"
+)
+
+// NewServer 建立並設定 MCP server，註冊所有 tools
+func NewServer(client *Client) *server.MCPServer {
+	s := server.NewMCPServer(
+		"aibo",
+		"1.0.0",
+		server.WithToolCapabilities(false),
+		server.WithRecovery(),
+	)
+
+	handlers := NewToolHandlers(client)
+
+	// 註冊 5 個 tools
+	s.AddTool(QueryTool(), handlers.HandleQuery)
+	s.AddTool(ProposeTool(), handlers.HandlePropose)
+	s.AddTool(ConfirmTool(), handlers.HandleConfirm)
+	s.AddTool(FlagTool(), handlers.HandleFlag)
+	s.AddTool(StatusTool(), handlers.HandleStatus)
+
+	return s
+}

--- a/dev/src/mcp/tools.go
+++ b/dev/src/mcp/tools.go
@@ -1,0 +1,212 @@
+package mcp
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/mark3labs/mcp-go/mcp"
+)
+
+// ToolHandlers 封裝所有 MCP tool handler
+type ToolHandlers struct {
+	client *Client
+}
+
+// NewToolHandlers 建立新的 ToolHandlers
+func NewToolHandlers(client *Client) *ToolHandlers {
+	return &ToolHandlers{client: client}
+}
+
+// QueryTool 定義 aibo_query tool
+func QueryTool() mcp.Tool {
+	return mcp.NewTool("aibo_query",
+		mcp.WithDescription("搜尋使用者的個人知識庫。回傳最相關的知識條目，包含 summary、detail、action。用這些知識來代表使用者回答問題。"),
+		mcp.WithString("query",
+			mcp.Required(),
+			mcp.Description("搜尋查詢字串"),
+		),
+		mcp.WithString("category",
+			mcp.Description("限定分類名稱（可選）"),
+		),
+		mcp.WithNumber("limit",
+			mcp.Description("回傳數量上限（預設 5，最大 20）"),
+		),
+	)
+}
+
+// HandleQuery 處理 aibo_query tool 呼叫
+func (h *ToolHandlers) HandleQuery(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	query := mcp.ParseString(req, "query", "")
+	if query == "" {
+		return mcp.NewToolResultError("query 參數為必填"), nil
+	}
+
+	category := mcp.ParseString(req, "category", "")
+	limit := int(mcp.ParseInt64(req, "limit", 5))
+
+	if limit < 1 {
+		limit = 1
+	}
+	if limit > 20 {
+		limit = 20
+	}
+
+	searchReq := SearchRequest{
+		Query:      query,
+		CategoryID: category,
+		Limit:      limit,
+	}
+
+	result, err := h.client.Search(searchReq)
+	if err != nil {
+		return mcp.NewToolResultError(fmt.Sprintf("搜尋失敗: %s", err.Error())), nil
+	}
+
+	return mcp.NewToolResultText(FormatSearchResults(result.Results, result.Total)), nil
+}
+
+// ProposeTool 定義 aibo_propose tool
+func ProposeTool() mcp.Tool {
+	return mcp.NewTool("aibo_propose",
+		mcp.WithDescription("向使用者的知識庫提出新的知識條目。會自動進行 LLM 分類。"),
+		mcp.WithString("content",
+			mcp.Required(),
+			mcp.Description("知識內容"),
+		),
+		mcp.WithString("title",
+			mcp.Description("標題（可選，LLM 會自動產生）"),
+		),
+		mcp.WithArray("tags",
+			mcp.Description("標籤（可選）"),
+		),
+		mcp.WithString("source",
+			mcp.Description("知識來源（可選）"),
+		),
+	)
+}
+
+// HandlePropose 處理 aibo_propose tool 呼叫
+func (h *ToolHandlers) HandlePropose(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	content := mcp.ParseString(req, "content", "")
+	if content == "" {
+		return mcp.NewToolResultError("content 參數為必填"), nil
+	}
+
+	title := mcp.ParseString(req, "title", "")
+	source := mcp.ParseString(req, "source", "")
+
+	// 解析 tags
+	var tags []string
+	if args := req.GetArguments(); args != nil {
+		if rawTags, ok := args["tags"]; ok {
+			if tagSlice, ok := rawTags.([]interface{}); ok {
+				for _, t := range tagSlice {
+					if s, ok := t.(string); ok {
+						tags = append(tags, s)
+					}
+				}
+			}
+		}
+	}
+
+	createReq := CreateEntryRequest{
+		Content: content,
+		Title:   title,
+		Tags:    tags,
+		Source:  source,
+	}
+
+	result, err := h.client.CreateEntry(createReq)
+	if err != nil {
+		return mcp.NewToolResultError(fmt.Sprintf("建立知識條目失敗: %s", err.Error())), nil
+	}
+
+	return mcp.NewToolResultText(FormatEntryCreated(result)), nil
+}
+
+// ConfirmTool 定義 aibo_confirm tool
+func ConfirmTool() mcp.Tool {
+	return mcp.NewTool("aibo_confirm",
+		mcp.WithDescription("確認某筆知識條目有用且正確，提升其信心度。"),
+		mcp.WithString("entry_id",
+			mcp.Required(),
+			mcp.Description("知識條目 UUID"),
+		),
+	)
+}
+
+// HandleConfirm 處理 aibo_confirm tool 呼叫
+func (h *ToolHandlers) HandleConfirm(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	entryID := mcp.ParseString(req, "entry_id", "")
+	if entryID == "" {
+		return mcp.NewToolResultError("entry_id 參數為必填"), nil
+	}
+
+	result, err := h.client.Confirm(entryID)
+	if err != nil {
+		return mcp.NewToolResultError(fmt.Sprintf("確認知識條目失敗: %s", err.Error())), nil
+	}
+
+	return mcp.NewToolResultText(FormatConfirmResult(result)), nil
+}
+
+// FlagTool 定義 aibo_flag tool
+func FlagTool() mcp.Tool {
+	return mcp.NewTool("aibo_flag",
+		mcp.WithDescription("標記某筆知識條目有問題（過時、不正確、需更新）。"),
+		mcp.WithString("entry_id",
+			mcp.Required(),
+			mcp.Description("知識條目 UUID"),
+		),
+		mcp.WithString("reason",
+			mcp.Required(),
+			mcp.Description("標記原因"),
+			mcp.Enum("outdated", "inaccurate", "incomplete", "duplicate"),
+		),
+		mcp.WithString("note",
+			mcp.Description("補充說明（可選）"),
+		),
+	)
+}
+
+// HandleFlag 處理 aibo_flag tool 呼叫
+func (h *ToolHandlers) HandleFlag(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	entryID := mcp.ParseString(req, "entry_id", "")
+	if entryID == "" {
+		return mcp.NewToolResultError("entry_id 參數為必填"), nil
+	}
+
+	reason := mcp.ParseString(req, "reason", "")
+	if reason == "" {
+		return mcp.NewToolResultError("reason 參數為必填"), nil
+	}
+
+	var note *string
+	if n := mcp.ParseString(req, "note", ""); n != "" {
+		note = &n
+	}
+
+	result, err := h.client.Flag(entryID, reason, note)
+	if err != nil {
+		return mcp.NewToolResultError(fmt.Sprintf("標記知識條目失敗: %s", err.Error())), nil
+	}
+
+	return mcp.NewToolResultText(FormatFlagResult(result)), nil
+}
+
+// StatusTool 定義 aibo_status tool
+func StatusTool() mcp.Tool {
+	return mcp.NewTool("aibo_status",
+		mcp.WithDescription("查看知識庫統計資訊：條目總數、分類分布、平均信心度。"),
+	)
+}
+
+// HandleStatus 處理 aibo_status tool 呼叫
+func (h *ToolHandlers) HandleStatus(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	result, err := h.client.GetStats()
+	if err != nil {
+		return mcp.NewToolResultError(fmt.Sprintf("取得統計資訊失敗: %s", err.Error())), nil
+	}
+
+	return mcp.NewToolResultText(FormatStats(result)), nil
+}

--- a/dev/src/mcp/tools_test.go
+++ b/dev/src/mcp/tools_test.go
@@ -1,0 +1,253 @@
+package mcp_test
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/mark3labs/mcp-go/mcp"
+
+	aimcp "github.com/gpwork4u/aibo/mcp"
+)
+
+// newMockServer 建立模擬 API server
+func newMockServer(handler http.HandlerFunc) (*httptest.Server, *aimcp.Client) {
+	server := httptest.NewServer(handler)
+	client := aimcp.NewClient(server.URL, "test-key")
+	return server, client
+}
+
+// makeCallToolRequest 建立 CallToolRequest
+func makeCallToolRequest(name string, args map[string]interface{}) mcp.CallToolRequest {
+	return mcp.CallToolRequest{
+		Params: mcp.CallToolParams{
+			Name:      name,
+			Arguments: args,
+		},
+	}
+}
+
+func TestHandleQuery_Success(t *testing.T) {
+	server, client := newMockServer(func(w http.ResponseWriter, r *http.Request) {
+		resp := aimcp.SearchResponse{
+			Results: []aimcp.SearchResultItem{
+				{
+					EntryID:        "abc-123",
+					Title:          strPtr("Go 錯誤處理"),
+					Summary:        strPtr("Go 的錯誤處理方式"),
+					ContentPreview: "內容預覽",
+					Tags:           []string{"golang"},
+					Relevance:      0.9,
+				},
+			},
+			Total: 1,
+		}
+		json.NewEncoder(w).Encode(resp)
+	})
+	defer server.Close()
+
+	handlers := aimcp.NewToolHandlers(client)
+	req := makeCallToolRequest("aibo_query", map[string]interface{}{
+		"query": "golang error handling",
+		"limit": float64(5),
+	})
+
+	result, err := handlers.HandleQuery(context.Background(), req)
+	if err != nil {
+		t.Fatalf("handler 錯誤: %v", err)
+	}
+	if result.IsError {
+		t.Error("不應為錯誤結果")
+	}
+	// 檢查結果包含內容
+	if len(result.Content) == 0 {
+		t.Fatal("結果不應為空")
+	}
+	text := result.Content[0].(mcp.TextContent).Text
+	if !strings.Contains(text, "Go 錯誤處理") {
+		t.Error("結果應包含搜尋內容")
+	}
+}
+
+func TestHandleQuery_EmptyQuery(t *testing.T) {
+	_, client := newMockServer(func(w http.ResponseWriter, r *http.Request) {})
+	handlers := aimcp.NewToolHandlers(client)
+
+	req := makeCallToolRequest("aibo_query", map[string]interface{}{})
+	result, err := handlers.HandleQuery(context.Background(), req)
+	if err != nil {
+		t.Fatalf("handler 錯誤: %v", err)
+	}
+	if !result.IsError {
+		t.Error("空 query 應回傳錯誤")
+	}
+}
+
+func TestHandlePropose_Success(t *testing.T) {
+	server, client := newMockServer(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusCreated)
+		resp := aimcp.EntryResponse{
+			ID:    "new-id",
+			Title: strPtr("新知識"),
+		}
+		json.NewEncoder(w).Encode(resp)
+	})
+	defer server.Close()
+
+	handlers := aimcp.NewToolHandlers(client)
+	req := makeCallToolRequest("aibo_propose", map[string]interface{}{
+		"content": "Go 1.23 range over func",
+		"title":   "Go 1.23 新功能",
+		"tags":    []interface{}{"golang", "go1.23"},
+	})
+
+	result, err := handlers.HandlePropose(context.Background(), req)
+	if err != nil {
+		t.Fatalf("handler 錯誤: %v", err)
+	}
+	if result.IsError {
+		t.Error("不應為錯誤結果")
+	}
+}
+
+func TestHandlePropose_EmptyContent(t *testing.T) {
+	_, client := newMockServer(func(w http.ResponseWriter, r *http.Request) {})
+	handlers := aimcp.NewToolHandlers(client)
+
+	req := makeCallToolRequest("aibo_propose", map[string]interface{}{})
+	result, err := handlers.HandlePropose(context.Background(), req)
+	if err != nil {
+		t.Fatalf("handler 錯誤: %v", err)
+	}
+	if !result.IsError {
+		t.Error("空 content 應回傳錯誤")
+	}
+}
+
+func TestHandleConfirm_Success(t *testing.T) {
+	server, client := newMockServer(func(w http.ResponseWriter, r *http.Request) {
+		resp := aimcp.ConfirmResponse{
+			EntryID:       "test-id",
+			Confidence:    0.85,
+			Confirmations: 3,
+		}
+		json.NewEncoder(w).Encode(resp)
+	})
+	defer server.Close()
+
+	handlers := aimcp.NewToolHandlers(client)
+	req := makeCallToolRequest("aibo_confirm", map[string]interface{}{
+		"entry_id": "test-id",
+	})
+
+	result, err := handlers.HandleConfirm(context.Background(), req)
+	if err != nil {
+		t.Fatalf("handler 錯誤: %v", err)
+	}
+	if result.IsError {
+		t.Error("不應為錯誤結果")
+	}
+}
+
+func TestHandleFlag_Success(t *testing.T) {
+	server, client := newMockServer(func(w http.ResponseWriter, r *http.Request) {
+		resp := aimcp.FlagResponse{
+			EntryID:    "test-id",
+			Confidence: 0.50,
+			FlagsCount: 1,
+		}
+		json.NewEncoder(w).Encode(resp)
+	})
+	defer server.Close()
+
+	handlers := aimcp.NewToolHandlers(client)
+	req := makeCallToolRequest("aibo_flag", map[string]interface{}{
+		"entry_id": "test-id",
+		"reason":   "outdated",
+		"note":     "Go 1.24 已改變",
+	})
+
+	result, err := handlers.HandleFlag(context.Background(), req)
+	if err != nil {
+		t.Fatalf("handler 錯誤: %v", err)
+	}
+	if result.IsError {
+		t.Error("不應為錯誤結果")
+	}
+}
+
+func TestHandleFlag_MissingRequired(t *testing.T) {
+	_, client := newMockServer(func(w http.ResponseWriter, r *http.Request) {})
+	handlers := aimcp.NewToolHandlers(client)
+
+	// 缺少 entry_id
+	req := makeCallToolRequest("aibo_flag", map[string]interface{}{
+		"reason": "outdated",
+	})
+	result, _ := handlers.HandleFlag(context.Background(), req)
+	if !result.IsError {
+		t.Error("缺少 entry_id 應回傳錯誤")
+	}
+
+	// 缺少 reason
+	req = makeCallToolRequest("aibo_flag", map[string]interface{}{
+		"entry_id": "test-id",
+	})
+	result, _ = handlers.HandleFlag(context.Background(), req)
+	if !result.IsError {
+		t.Error("缺少 reason 應回傳錯誤")
+	}
+}
+
+func TestHandleStatus_Success(t *testing.T) {
+	server, client := newMockServer(func(w http.ResponseWriter, r *http.Request) {
+		resp := aimcp.StatsResponse{
+			TotalEntries:    150,
+			TotalCategories: 12,
+			AvgConfidence:   0.72,
+			EntriesByCategory: []aimcp.CategoryCountItem{
+				{Category: "golang", Count: 30},
+			},
+		}
+		json.NewEncoder(w).Encode(resp)
+	})
+	defer server.Close()
+
+	handlers := aimcp.NewToolHandlers(client)
+	req := makeCallToolRequest("aibo_status", map[string]interface{}{})
+
+	result, err := handlers.HandleStatus(context.Background(), req)
+	if err != nil {
+		t.Fatalf("handler 錯誤: %v", err)
+	}
+	if result.IsError {
+		t.Error("不應為錯誤結果")
+	}
+}
+
+func TestHandleQuery_APIError(t *testing.T) {
+	server, client := newMockServer(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+		json.NewEncoder(w).Encode(map[string]string{
+			"code":    "UNAUTHORIZED",
+			"message": "API Key 無效或未設定",
+		})
+	})
+	defer server.Close()
+
+	handlers := aimcp.NewToolHandlers(client)
+	req := makeCallToolRequest("aibo_query", map[string]interface{}{
+		"query": "test",
+	})
+
+	result, err := handlers.HandleQuery(context.Background(), req)
+	if err != nil {
+		t.Fatalf("handler 不應回傳 Go error: %v", err)
+	}
+	if !result.IsError {
+		t.Error("API 錯誤應回傳 MCP error result")
+	}
+}

--- a/dev/src/repository/stats.go
+++ b/dev/src/repository/stats.go
@@ -2,6 +2,7 @@ package repository
 
 import (
 	"context"
+	"time"
 
 	"github.com/jackc/pgx/v5/pgxpool"
 )
@@ -61,6 +62,34 @@ func (r *StatsRepository) GetEntriesByCategory(ctx context.Context) ([]CategoryC
 			return nil, err
 		}
 		result = append(result, cc)
+	}
+	return result, rows.Err()
+}
+
+// RecentEntry 最近條目
+type RecentEntry struct {
+	ID        string
+	Title     string
+	CreatedAt time.Time
+}
+
+// GetRecentEntries 取得最近 5 筆條目
+func (r *StatsRepository) GetRecentEntries(ctx context.Context) ([]RecentEntry, error) {
+	rows, err := r.pool.Query(ctx,
+		`SELECT id, COALESCE(title, ''), created_at FROM entries ORDER BY created_at DESC LIMIT 5`,
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var result []RecentEntry
+	for rows.Next() {
+		var re RecentEntry
+		if err := rows.Scan(&re.ID, &re.Title, &re.CreatedAt); err != nil {
+			return nil, err
+		}
+		result = append(result, re)
 	}
 	return result, rows.Err()
 }

--- a/dev/src/repository/stats.go
+++ b/dev/src/repository/stats.go
@@ -1,0 +1,81 @@
+package repository
+
+import (
+	"context"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+// StatsRepository 統計資料庫操作
+type StatsRepository struct {
+	pool *pgxpool.Pool
+}
+
+// NewStatsRepository 建立新的 StatsRepository
+func NewStatsRepository(pool *pgxpool.Pool) *StatsRepository {
+	return &StatsRepository{pool: pool}
+}
+
+// CategoryCount 分類計數
+type CategoryCount struct {
+	CategoryName string
+	Count        int
+}
+
+// GetTotalEntries 取得知識條目總數
+func (r *StatsRepository) GetTotalEntries(ctx context.Context) (int, error) {
+	var count int
+	err := r.pool.QueryRow(ctx,
+		`SELECT COUNT(*) FROM entries WHERE is_archived = false`,
+	).Scan(&count)
+	return count, err
+}
+
+// GetTotalCategories 取得分類總數
+func (r *StatsRepository) GetTotalCategories(ctx context.Context) (int, error) {
+	var count int
+	err := r.pool.QueryRow(ctx,
+		`SELECT COUNT(*) FROM categories`,
+	).Scan(&count)
+	return count, err
+}
+
+// GetEntriesByCategory 取得各分類的條目數量
+func (r *StatsRepository) GetEntriesByCategory(ctx context.Context) ([]CategoryCount, error) {
+	rows, err := r.pool.Query(ctx,
+		`SELECT c.name, COUNT(e.id) as entry_count
+		 FROM categories c
+		 LEFT JOIN entries e ON e.category_id = c.id AND e.is_archived = false
+		 GROUP BY c.id, c.name
+		 ORDER BY entry_count DESC`,
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var result []CategoryCount
+	for rows.Next() {
+		var cc CategoryCount
+		if err := rows.Scan(&cc.CategoryName, &cc.Count); err != nil {
+			return nil, err
+		}
+		result = append(result, cc)
+	}
+	return result, rows.Err()
+}
+
+// GetAvgConfidence 取得平均信心度
+func (r *StatsRepository) GetAvgConfidence(ctx context.Context) (float64, error) {
+	var avg *float64
+	err := r.pool.QueryRow(ctx,
+		`SELECT AVG(confidence) FROM entries WHERE is_archived = false`,
+	).Scan(&avg)
+	if err != nil {
+		return 0, err
+	}
+	if avg == nil {
+		return 0, nil
+	}
+	return *avg, nil
+}

--- a/dev/src/router/router.go
+++ b/dev/src/router/router.go
@@ -10,7 +10,7 @@ import (
 )
 
 // Setup 設定路由
-func Setup(apiKeySvc *service.ApiKeyService, apiKeyHandler *handler.ApiKeyHandler, categoryHandler *handler.CategoryHandler, llmProviderHandler *handler.LlmProviderHandler, entryHandler *handler.EntryHandler, classifyHandler *handler.ClassifyHandler, searchHandler *handler.SearchHandler, gitImportHandler *handler.GitImportHandler, gcalHandler *handler.GcalHandler, confidenceHandler *handler.ConfidenceHandler) *gin.Engine {
+func Setup(apiKeySvc *service.ApiKeyService, apiKeyHandler *handler.ApiKeyHandler, categoryHandler *handler.CategoryHandler, llmProviderHandler *handler.LlmProviderHandler, entryHandler *handler.EntryHandler, classifyHandler *handler.ClassifyHandler, searchHandler *handler.SearchHandler, gitImportHandler *handler.GitImportHandler, gcalHandler *handler.GcalHandler, confidenceHandler *handler.ConfidenceHandler, statsHandler *handler.StatsHandler) *gin.Engine {
 	r := gin.Default()
 
 	// 健康檢查（不需認證）
@@ -90,6 +90,9 @@ func Setup(apiKeySvc *service.ApiKeyService, apiKeyHandler *handler.ApiKeyHandle
 			search.POST("", searchHandler.SmartSearch)
 			search.GET("/simple", searchHandler.SimpleSearch)
 		}
+
+		// 統計
+		v1.GET("/stats", statsHandler.GetStats)
 	}
 
 	return r

--- a/dev/src/service/stats.go
+++ b/dev/src/service/stats.go
@@ -12,12 +12,20 @@ type StatsResult struct {
 	TotalCategories   int
 	EntriesByCategory []CategoryCountResult
 	AvgConfidence     float64
+	RecentEntries     []RecentEntryResult
 }
 
 // CategoryCountResult 分類計數結果
 type CategoryCountResult struct {
 	Category string
 	Count    int
+}
+
+// RecentEntryResult 最近條目結果
+type RecentEntryResult struct {
+	ID        string
+	Title     string
+	CreatedAt string
 }
 
 // StatsService 統計業務邏輯
@@ -52,6 +60,20 @@ func (s *StatsService) GetStats(ctx context.Context) (*StatsResult, error) {
 		return nil, err
 	}
 
+	recentEntries, err := s.repo.GetRecentEntries(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	recent := make([]RecentEntryResult, 0, len(recentEntries))
+	for _, re := range recentEntries {
+		recent = append(recent, RecentEntryResult{
+			ID:        re.ID,
+			Title:     re.Title,
+			CreatedAt: re.CreatedAt.Format("2006-01-02T15:04:05Z07:00"),
+		})
+	}
+
 	byCategory := make([]CategoryCountResult, 0, len(categoryCounts))
 	for _, cc := range categoryCounts {
 		byCategory = append(byCategory, CategoryCountResult{
@@ -65,5 +87,6 @@ func (s *StatsService) GetStats(ctx context.Context) (*StatsResult, error) {
 		TotalCategories:   totalCategories,
 		EntriesByCategory: byCategory,
 		AvgConfidence:     avgConfidence,
+		RecentEntries:     recent,
 	}, nil
 }

--- a/dev/src/service/stats.go
+++ b/dev/src/service/stats.go
@@ -1,0 +1,69 @@
+package service
+
+import (
+	"context"
+
+	"github.com/gpwork4u/aibo/repository"
+)
+
+// StatsResult 統計結果
+type StatsResult struct {
+	TotalEntries      int
+	TotalCategories   int
+	EntriesByCategory []CategoryCountResult
+	AvgConfidence     float64
+}
+
+// CategoryCountResult 分類計數結果
+type CategoryCountResult struct {
+	Category string
+	Count    int
+}
+
+// StatsService 統計業務邏輯
+type StatsService struct {
+	repo *repository.StatsRepository
+}
+
+// NewStatsService 建立新的 StatsService
+func NewStatsService(repo *repository.StatsRepository) *StatsService {
+	return &StatsService{repo: repo}
+}
+
+// GetStats 取得知識庫統計
+func (s *StatsService) GetStats(ctx context.Context) (*StatsResult, error) {
+	totalEntries, err := s.repo.GetTotalEntries(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	totalCategories, err := s.repo.GetTotalCategories(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	categoryCounts, err := s.repo.GetEntriesByCategory(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	avgConfidence, err := s.repo.GetAvgConfidence(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	byCategory := make([]CategoryCountResult, 0, len(categoryCounts))
+	for _, cc := range categoryCounts {
+		byCategory = append(byCategory, CategoryCountResult{
+			Category: cc.CategoryName,
+			Count:    cc.Count,
+		})
+	}
+
+	return &StatsResult{
+		TotalEntries:      totalEntries,
+		TotalCategories:   totalCategories,
+		EntriesByCategory: byCategory,
+		AvgConfidence:     avgConfidence,
+	}, nil
+}


### PR DESCRIPTION
## Summary

- 使用 mark3labs/mcp-go SDK 實作獨立 MCP Server binary（`aibo-mcp`），透過 stdio transport 提供 5 個 MCP tools：`aibo_query`、`aibo_propose`、`aibo_confirm`、`aibo_flag`、`aibo_status`
- MCP Server 經由 HTTP 呼叫既有 Gin API server，不修改現有架構，僅作為客戶端包裝
- 新增 `GET /api/v1/stats` 統計端點（handler/service/repository 三層）
- 更新 Dockerfile 同時 build `api-server` 和 `aibo-mcp` 兩個 binary
- 提供 `dev/mcp-config.example.json` 供 Claude Code / Cursor 設定參考

## 新增檔案

| 檔案 | 用途 |
|------|------|
| `dev/src/cmd/mcp/main.go` | MCP server 進入點（讀取 AIBO_API_URL / AIBO_API_KEY） |
| `dev/src/mcp/server.go` | MCP server 設定 + tool 註冊 |
| `dev/src/mcp/tools.go` | 5 個 tool handler 實作 |
| `dev/src/mcp/client.go` | aibo REST API HTTP client |
| `dev/src/mcp/formatter.go` | 搜尋結果 LLM 友好格式化 |
| `dev/src/handler/stats.go` | GET /api/v1/stats handler |
| `dev/src/service/stats.go` | 統計 service |
| `dev/src/repository/stats.go` | 統計 SQL 查詢 |
| `dev/src/dto/stats.go` | 統計 DTO |

## 修改檔案

- `dev/src/go.mod` — 新增 mcp-go v0.49.0 依賴
- `dev/src/main.go` — 初始化 stats 服務
- `dev/src/router/router.go` — 註冊 /api/v1/stats 路由
- `dev/src/Dockerfile` — 新增 aibo-mcp binary build

## Test plan

- [ ] `go test ./mcp/...` — client/formatter/tools unit tests
- [ ] 啟動 API server 後執行 `AIBO_API_KEY=xxx ./aibo-mcp`，驗證 stdio MCP 通訊
- [ ] Claude Code 設定 mcp-config.json 後驗證 5 個 tools 可正常呼叫
- [ ] 驗證 API Key 未設定時 MCP server 顯示錯誤訊息並退出
- [ ] 驗證 API server 未啟動時各 tool 回傳 MCP error result 而非 crash

> **注意**：需要 Go 1.23+ 才能執行 `go mod tidy` 更新 go.sum。目前開發環境為 Go 1.21，go.sum 尚未更新，Docker build 環境（golang:1.23-alpine）可正常編譯。

Closes #36

🤖 Generated with [Claude Code](https://claude.com/claude-code)