### PR TITLE
test: Sprint 5 E2E 測試（F-014、F-015、F-016）

### DIFF
--- a/test/e2e/f014_tags_hierarchy_test.go
+++ b/test/e2e/f014_tags_hierarchy_test.go
@@ -1,0 +1,408 @@
+package e2e
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// ============================================================
+// F-014: Tags 分層 + 多維度搜尋
+// ============================================================
+
+// setupF014Client 建立認證客戶端
+func setupF014Client(t *testing.T) *APIClient {
+	t.Helper()
+
+	client := NewAPIClient()
+	key := BootstrapAPIKey(t, client, "f014-"+t.Name())
+	return client.WithKey(key)
+}
+
+// --- S-014-1: 建立 Entry 帶 domains + context ---
+
+func TestF014_S01_CreateEntryWithDomainsAndContext(t *testing.T) {
+	// WHEN POST /api/v1/entries
+	//   {"content": "...", "domains": ["golang"], "context": {"languages": ["go"], "frameworks": ["gin"], "pattern": "middleware"}}
+	// THEN 201 AND domains = ["golang"] AND context 正確
+
+	authedClient := setupF014Client(t)
+
+	payload := map[string]interface{}{
+		"title":   "Using Gin middleware for JWT auth",
+		"content": "Using Gin middleware for JWT authentication in Go applications",
+		"domains": []string{"golang"},
+		"context": map[string]interface{}{
+			"languages":  []string{"go"},
+			"frameworks": []string{"gin"},
+			"pattern":    "middleware",
+		},
+	}
+
+	status, body, err := authedClient.Do("POST", "/api/v1/entries", payload)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusCreated, status, "建立 entry 帶 domains/context 應回傳 201")
+
+	// 驗證 domains
+	domains, ok := body["domains"].([]interface{})
+	require.True(t, ok, "回應應包含 domains 陣列")
+	require.Equal(t, 1, len(domains), "domains 應有 1 個元素")
+	assert.Equal(t, "golang", domains[0], "domains[0] 應為 golang")
+
+	// 驗證 context
+	context, ok := body["context"].(map[string]interface{})
+	require.True(t, ok, "回應應包含 context 物件")
+
+	languages, ok := context["languages"].([]interface{})
+	require.True(t, ok, "context 應包含 languages")
+	assert.Equal(t, "go", languages[0], "context.languages[0] 應為 go")
+
+	frameworks, ok := context["frameworks"].([]interface{})
+	require.True(t, ok, "context 應包含 frameworks")
+	assert.Equal(t, "gin", frameworks[0], "context.frameworks[0] 應為 gin")
+
+	pattern, ok := context["pattern"].(string)
+	require.True(t, ok, "context 應包含 pattern")
+	assert.Equal(t, "middleware", pattern, "context.pattern 應為 middleware")
+}
+
+// --- S-014-2: 按 domain 過濾搜尋 ---
+
+func TestF014_S02_SearchFilterByDomain(t *testing.T) {
+	// GIVEN 有 3 筆 entries，其中 2 筆 domains 包含 "golang"
+	// WHEN GET /api/v1/search/simple?q=middleware&domain=golang
+	// THEN 只回傳 domains 包含 "golang" 的結果
+
+	authedClient := setupF014Client(t)
+
+	// 使用唯一關鍵字避免干擾
+	keyword := "zqdomain014"
+
+	// 2 筆 golang entries
+	CreateEntry(t, authedClient, map[string]interface{}{
+		"title":   keyword + " Gin middleware handler",
+		"content": keyword + " Gin middleware for request handling",
+		"domains": []string{"golang"},
+		"tags":    []string{keyword},
+	})
+	CreateEntry(t, authedClient, map[string]interface{}{
+		"title":   keyword + " Go HTTP middleware",
+		"content": keyword + " Go HTTP middleware patterns",
+		"domains": []string{"golang"},
+		"tags":    []string{keyword},
+	})
+
+	// 1 筆非 golang entry
+	CreateEntry(t, authedClient, map[string]interface{}{
+		"title":   keyword + " Python middleware",
+		"content": keyword + " Python WSGI middleware implementation",
+		"domains": []string{"python"},
+		"tags":    []string{keyword},
+	})
+
+	// 按 domain=golang 過濾搜尋
+	status, body, err := authedClient.Do("GET", "/api/v1/search/simple?q="+keyword+"&domain=golang", nil)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, status, "按 domain 搜尋應回傳 200")
+
+	results, ok := body["results"].([]interface{})
+	require.True(t, ok, "results 應為陣列")
+	assert.Equal(t, 2, len(results), "domain=golang 應回傳 2 筆結果")
+
+	// 驗證所有結果的 title 不包含 Python
+	for _, r := range results {
+		result := r.(map[string]interface{})
+		title, _ := result["title"].(string)
+		assert.NotContains(t, title, "Python", "domain=golang 過濾後不應包含 Python 的結果")
+	}
+}
+
+// --- S-014-3: 按 context 子欄位過濾 ---
+
+func TestF014_S03_SearchFilterByContext(t *testing.T) {
+	// GIVEN context.frameworks 包含 "gin" 的 entries
+	// WHEN GET /api/v1/search/simple?q=auth&context.frameworks=gin
+	// THEN 只回傳 context.frameworks 包含 "gin" 的結果
+
+	authedClient := setupF014Client(t)
+
+	keyword := "zqctx014"
+
+	// gin entry
+	CreateEntry(t, authedClient, map[string]interface{}{
+		"title":   keyword + " Gin auth handler",
+		"content": keyword + " Authentication with Gin framework",
+		"domains": []string{"golang"},
+		"context": map[string]interface{}{
+			"languages":  []string{"go"},
+			"frameworks": []string{"gin"},
+		},
+		"tags": []string{keyword},
+	})
+
+	// echo entry
+	CreateEntry(t, authedClient, map[string]interface{}{
+		"title":   keyword + " Echo auth handler",
+		"content": keyword + " Authentication with Echo framework",
+		"domains": []string{"golang"},
+		"context": map[string]interface{}{
+			"languages":  []string{"go"},
+			"frameworks": []string{"echo"},
+		},
+		"tags": []string{keyword},
+	})
+
+	// 按 context.frameworks=gin 過濾
+	status, body, err := authedClient.Do("GET", "/api/v1/search/simple?q="+keyword+"&context.frameworks=gin", nil)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, status, "按 context 過濾搜尋應回傳 200")
+
+	results, ok := body["results"].([]interface{})
+	require.True(t, ok, "results 應為陣列")
+	require.Greater(t, len(results), 0, "按 context.frameworks=gin 應有結果")
+
+	// 所有結果都不應包含 Echo
+	for _, r := range results {
+		result := r.(map[string]interface{})
+		title, _ := result["title"].(string)
+		assert.NotContains(t, title, "Echo", "context.frameworks=gin 過濾後不應包含 Echo 結果")
+	}
+}
+
+// --- S-014-4: LLM 分類自動產生 domains + context ---
+
+func TestF014_S04_LLMClassifyProducesDomainsAndContext(t *testing.T) {
+	// WHEN POST /api/v1/entries/:id/classify
+	// THEN entry 的 domains 和 context 被更新
+
+	authedClient := setupF014Client(t)
+
+	// 建立 LLM provider
+	_ = setupSearchLLMProvider(t, authedClient)
+
+	entryID := CreateEntry(t, authedClient, map[string]interface{}{
+		"title":   "Using Gin middleware for JWT authentication in Go",
+		"content": "This article explains how to implement JWT authentication using Gin middleware in Go applications",
+	})
+
+	// 呼叫 classify
+	status, _, err := authedClient.Do("POST", "/api/v1/entries/"+entryID+"/classify", nil)
+	require.NoError(t, err)
+	// classify 可能回傳 200 或 202（非同步）
+	assert.True(t, status == http.StatusOK || status == http.StatusAccepted,
+		"classify 應回傳 200 或 202，實際 %d", status)
+
+	// 取得 entry 驗證 domains/context 已更新
+	status, body, err := authedClient.Do("GET", "/api/v1/entries/"+entryID, nil)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, status)
+
+	// 驗證 domains 已產生（LLM 可能需要時間，這裡驗證欄位存在）
+	_, hasDomains := body["domains"]
+	assert.True(t, hasDomains, "classify 後 entry 應包含 domains 欄位")
+
+	_, hasContext := body["context"]
+	assert.True(t, hasContext, "classify 後 entry 應包含 context 欄位")
+}
+
+// --- S-014-5: 向下相容 ---
+
+func TestF014_S05_BackwardCompatibility(t *testing.T) {
+	// GIVEN 舊 entry 沒有 domains/context
+	// WHEN GET /api/v1/entries/:id
+	// THEN domains = [] AND context = null AND tags 保持原值
+
+	authedClient := setupF014Client(t)
+
+	// 建立不帶 domains/context 的 entry
+	entryID := CreateEntry(t, authedClient, map[string]interface{}{
+		"title":   "向下相容測試 entry",
+		"content": "這是一個不帶 domains 和 context 的舊格式 entry",
+		"tags":    []string{"legacy", "test"},
+	})
+
+	status, body, err := authedClient.Do("GET", "/api/v1/entries/"+entryID, nil)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, status)
+
+	// domains 應為空陣列
+	domains, ok := body["domains"].([]interface{})
+	if ok {
+		assert.Equal(t, 0, len(domains), "舊 entry 的 domains 應為空陣列")
+	} else {
+		// 也接受 null
+		assert.Nil(t, body["domains"], "舊 entry 的 domains 應為空陣列或 null")
+	}
+
+	// context 應為 null
+	assert.Nil(t, body["context"], "舊 entry 的 context 應為 null")
+
+	// tags 保持原值
+	tags, ok := body["tags"].([]interface{})
+	require.True(t, ok, "回應應包含 tags 陣列")
+	assert.Equal(t, 2, len(tags), "tags 應保持原本的 2 個值")
+}
+
+// --- S-014-6: 多 domain 過濾（AND 邏輯） ---
+
+func TestF014_S06_MultiDomainFilterAND(t *testing.T) {
+	// GIVEN Entry A: domains=["golang","docker"], Entry B: domains=["golang"]
+	// WHEN GET /api/v1/entries?domain=golang&domain=docker
+	// THEN 只回傳 Entry A
+
+	authedClient := setupF014Client(t)
+
+	entryA := CreateEntry(t, authedClient, map[string]interface{}{
+		"title":   "多 domain 過濾 A - Golang + Docker",
+		"content": "使用 Golang 建立 Docker 容器化應用",
+		"domains": []string{"golang", "docker"},
+	})
+
+	CreateEntry(t, authedClient, map[string]interface{}{
+		"title":   "多 domain 過濾 B - 只有 Golang",
+		"content": "純 Golang 應用程式開發",
+		"domains": []string{"golang"},
+	})
+
+	// 多 domain 過濾
+	status, body, err := authedClient.Do("GET", "/api/v1/entries?domain=golang&domain=docker", nil)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, status)
+
+	data := GetDataArray(t, body)
+
+	// 驗證只回傳 entry A
+	foundA := false
+	for _, item := range data {
+		entry := item.(map[string]interface{})
+		if entry["id"] == entryA {
+			foundA = true
+		}
+		// 所有回傳的 entry 都應同時包含 golang 和 docker domains
+		entryDomains, ok := entry["domains"].([]interface{})
+		if ok {
+			hasGolang := false
+			hasDocker := false
+			for _, d := range entryDomains {
+				if d == "golang" {
+					hasGolang = true
+				}
+				if d == "docker" {
+					hasDocker = true
+				}
+			}
+			assert.True(t, hasGolang && hasDocker,
+				"多 domain 過濾結果的 entry 應同時包含 golang 和 docker")
+		}
+	}
+	assert.True(t, foundA, "多 domain 過濾應回傳 Entry A")
+}
+
+// --- S-014-7: 智慧搜尋 context_filter ---
+
+func TestF014_S07_SmartSearchContextFilter(t *testing.T) {
+	// WHEN POST /api/v1/search {"query": "auth", "context_filter": {"languages": ["go"]}}
+	// THEN 只回傳 context.languages 包含 "go" 的結果
+
+	authedClient := setupF014Client(t)
+
+	keyword := "zqsmartctx014"
+
+	// Go entry
+	CreateEntry(t, authedClient, map[string]interface{}{
+		"title":   keyword + " Go authentication",
+		"content": keyword + " JWT authentication implementation in Go",
+		"domains": []string{"golang"},
+		"context": map[string]interface{}{
+			"languages": []string{"go"},
+		},
+		"tags": []string{keyword},
+	})
+
+	// Python entry
+	CreateEntry(t, authedClient, map[string]interface{}{
+		"title":   keyword + " Python authentication",
+		"content": keyword + " JWT authentication implementation in Python",
+		"domains": []string{"python"},
+		"context": map[string]interface{}{
+			"languages": []string{"python"},
+		},
+		"tags": []string{keyword},
+	})
+
+	// 智慧搜尋帶 context_filter
+	status, body, err := authedClient.Do("POST", "/api/v1/search", map[string]interface{}{
+		"query": keyword,
+		"context_filter": map[string]interface{}{
+			"languages": []string{"go"},
+		},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, status, "智慧搜尋帶 context_filter 應回傳 200")
+
+	results, ok := body["results"].([]interface{})
+	require.True(t, ok, "results 應為陣列")
+	require.Greater(t, len(results), 0, "context_filter languages=go 應有結果")
+
+	// 驗證結果不包含 Python
+	for _, r := range results {
+		result := r.(map[string]interface{})
+		title, _ := result["title"].(string)
+		assert.NotContains(t, title, "Python",
+			"context_filter languages=go 過濾後不應包含 Python 結果")
+	}
+}
+
+// --- 回歸測試：不帶 domains/context 建立 entry 仍正常 ---
+
+func TestF014_Regression_CreateEntryWithoutDomainsContext(t *testing.T) {
+	// 不帶 domains/context 也能正常建立 entry（向下相容）
+
+	authedClient := setupF014Client(t)
+
+	status, body, err := authedClient.Do("POST", "/api/v1/entries", map[string]interface{}{
+		"title":   "無 domains/context 的 entry",
+		"content": "這是一個傳統格式的 entry，不帶 domains 和 context",
+		"tags":    []string{"legacy"},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusCreated, status, "不帶 domains/context 建立 entry 應回傳 201")
+
+	id, ok := body["id"].(string)
+	require.True(t, ok, "回應應包含 id")
+	assert.NotEmpty(t, id, "id 不應為空")
+}
+
+// --- 回歸測試：Entry CRUD 向下相容 ---
+
+func TestF014_Regression_EntryCRUDBackwardCompatible(t *testing.T) {
+	// 更新 entry 時不帶 domains/context，原有欄位不受影響
+
+	authedClient := setupF014Client(t)
+
+	// 建立帶 domains 的 entry
+	entryID := CreateEntry(t, authedClient, map[string]interface{}{
+		"title":   "CRUD 向下相容測試",
+		"content": "原始內容",
+		"domains": []string{"golang"},
+		"context": map[string]interface{}{
+			"languages": []string{"go"},
+		},
+	})
+
+	// 只更新 content，不帶 domains/context
+	status, body, err := authedClient.Do("PATCH", "/api/v1/entries/"+entryID, map[string]interface{}{
+		"content": "更新後的內容",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, status, "更新 entry 應回傳 200")
+
+	// 驗證 domains 仍然存在
+	domains, ok := body["domains"].([]interface{})
+	if ok {
+		assert.Equal(t, 1, len(domains), "更新後 domains 應保持不變")
+		assert.Equal(t, "golang", domains[0], "domains[0] 應仍為 golang")
+	}
+}

--- a/test/e2e/f015_knowledge_lifecycle_test.go
+++ b/test/e2e/f015_knowledge_lifecycle_test.go
@@ -1,0 +1,421 @@
+package e2e
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// ============================================================
+// F-015: 知識生命週期
+// ============================================================
+
+// setupF015Client 建立認證客戶端
+func setupF015Client(t *testing.T) *APIClient {
+	t.Helper()
+
+	client := NewAPIClient()
+	key := BootstrapAPIKey(t, client, "f015-"+t.Name())
+	return client.WithKey(key)
+}
+
+// createF015Entry 建立測試用 entry，回傳 ID
+func createF015Entry(t *testing.T, client *APIClient, title, content string) string {
+	t.Helper()
+	return CreateEntry(t, client, map[string]interface{}{
+		"title":   title,
+		"content": content,
+		"tags":    []string{"lifecycle-test"},
+	})
+}
+
+// --- S-015-1: 設定 Supersede 關係 ---
+
+func TestF015_S01_SupersedeEntry(t *testing.T) {
+	// GIVEN Entry A 和 Entry B 存在
+	// WHEN POST /api/v1/entries/{A}/supersede {"new_entry_id": "{B}"}
+	// THEN 200 AND A.superseded_by = B.id AND A.confidence <= 0.2
+
+	authedClient := setupF015Client(t)
+
+	entryA := createF015Entry(t, authedClient, "舊版知識 v1", "這是舊版知識內容")
+	entryB := createF015Entry(t, authedClient, "新版知識 v2", "這是新版知識內容")
+
+	status, body, err := authedClient.Do("POST", "/api/v1/entries/"+entryA+"/supersede", map[string]interface{}{
+		"new_entry_id": entryB,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, status, "設定 supersede 應回傳 200")
+
+	// 驗證 old_entry
+	oldEntry, ok := body["old_entry"].(map[string]interface{})
+	require.True(t, ok, "回應應包含 old_entry")
+	assert.Equal(t, entryA, oldEntry["id"], "old_entry.id 應為 A")
+	assert.Equal(t, entryB, oldEntry["superseded_by"], "old_entry.superseded_by 應為 B")
+
+	confidence, ok := oldEntry["confidence"].(float64)
+	require.True(t, ok, "old_entry 應包含 confidence")
+	assert.LessOrEqual(t, confidence, 0.2, "supersede 後 confidence 應 <= 0.2")
+
+	// 驗證 new_entry
+	newEntry, ok := body["new_entry"].(map[string]interface{})
+	require.True(t, ok, "回應應包含 new_entry")
+	assert.Equal(t, entryB, newEntry["id"], "new_entry.id 應為 B")
+}
+
+// --- S-015-2: 循環引用檢測 ---
+
+func TestF015_S02_CircularSupersedeDetection(t *testing.T) {
+	// GIVEN A superseded_by B
+	// WHEN POST /api/v1/entries/{B}/supersede {"new_entry_id": "{A}"}
+	// THEN 409 AND error.code = "CIRCULAR_SUPERSEDE"
+
+	authedClient := setupF015Client(t)
+
+	entryA := createF015Entry(t, authedClient, "循環測試 A", "循環測試 A 內容")
+	entryB := createF015Entry(t, authedClient, "循環測試 B", "循環測試 B 內容")
+
+	// A -> B
+	status, _, err := authedClient.Do("POST", "/api/v1/entries/"+entryA+"/supersede", map[string]interface{}{
+		"new_entry_id": entryB,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, status, "第一次 supersede 應成功")
+
+	// B -> A（循環引用）
+	status, body, err := authedClient.Do("POST", "/api/v1/entries/"+entryB+"/supersede", map[string]interface{}{
+		"new_entry_id": entryA,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusConflict, status, "循環引用應回傳 409")
+	AssertErrorCode(t, body, "CIRCULAR_SUPERSEDE")
+}
+
+// --- S-015-3: 不能 supersede 自己 ---
+
+func TestF015_S03_CannotSupersedeItself(t *testing.T) {
+	// WHEN POST /api/v1/entries/{A}/supersede {"new_entry_id": "{A}"}
+	// THEN 400 AND error.code = "INVALID_INPUT"
+
+	authedClient := setupF015Client(t)
+
+	entryA := createF015Entry(t, authedClient, "自我 supersede 測試", "自我 supersede 內容")
+
+	status, body, err := authedClient.Do("POST", "/api/v1/entries/"+entryA+"/supersede", map[string]interface{}{
+		"new_entry_id": entryA,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusBadRequest, status, "supersede 自己應回傳 400")
+	AssertErrorCode(t, body, "INVALID_INPUT")
+}
+
+// --- S-015-4: 查詢版本鏈 ---
+
+func TestF015_S04_VersionChain(t *testing.T) {
+	// GIVEN A -> B -> C（A superseded_by B, B superseded_by C）
+	// WHEN GET /api/v1/entries/{A}/history
+	// THEN chain = [A, B, C] AND latest = C
+
+	authedClient := setupF015Client(t)
+
+	entryA := createF015Entry(t, authedClient, "版本鏈 v1", "第一版知識")
+	entryB := createF015Entry(t, authedClient, "版本鏈 v2", "第二版知識")
+	entryC := createF015Entry(t, authedClient, "版本鏈 v3", "第三版知識")
+
+	// A -> B
+	status, _, err := authedClient.Do("POST", "/api/v1/entries/"+entryA+"/supersede", map[string]interface{}{
+		"new_entry_id": entryB,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, status)
+
+	// B -> C
+	status, _, err = authedClient.Do("POST", "/api/v1/entries/"+entryB+"/supersede", map[string]interface{}{
+		"new_entry_id": entryC,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, status)
+
+	// 查詢版本鏈
+	status, body, err := authedClient.Do("GET", "/api/v1/entries/"+entryA+"/history", nil)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, status, "查詢版本鏈應回傳 200")
+
+	// 驗證 chain
+	chain, ok := body["chain"].([]interface{})
+	require.True(t, ok, "回應應包含 chain 陣列")
+	require.Equal(t, 3, len(chain), "chain 應包含 3 個節點 (A -> B -> C)")
+
+	// 驗證順序：從最舊到最新
+	chainNode0 := chain[0].(map[string]interface{})
+	chainNode1 := chain[1].(map[string]interface{})
+	chainNode2 := chain[2].(map[string]interface{})
+
+	assert.Equal(t, entryA, chainNode0["id"], "chain[0] 應為 A")
+	assert.Equal(t, entryB, chainNode1["id"], "chain[1] 應為 B")
+	assert.Equal(t, entryC, chainNode2["id"], "chain[2] 應為 C")
+
+	// 驗證狀態
+	assert.Equal(t, "superseded", chainNode0["status"], "A 的 status 應為 superseded")
+	assert.Equal(t, "superseded", chainNode1["status"], "B 的 status 應為 superseded")
+	assert.Equal(t, "active", chainNode2["status"], "C 的 status 應為 active")
+
+	// 驗證 latest
+	latest, ok := body["latest"].(map[string]interface{})
+	require.True(t, ok, "回應應包含 latest 物件")
+	assert.Equal(t, entryC, latest["id"], "latest 應為 C")
+}
+
+// --- S-015-5: 搜尋結果中 superseded entry 排名降低 ---
+
+func TestF015_S05_SupersededEntryRankedLower(t *testing.T) {
+	// GIVEN Entry A (active, confidence=0.8) 和 Entry B (superseded, confidence=0.2)
+	// WHEN POST /api/v1/search {"query": "..."}
+	// THEN A 排在 B 前面 AND B.lifecycle_status = "superseded"
+
+	authedClient := setupF015Client(t)
+
+	// 使用唯一的關鍵字避免干擾
+	keyword := "zqwlifecycle"
+
+	entryActive := CreateEntry(t, authedClient, map[string]interface{}{
+		"title":   keyword + " 有效知識條目",
+		"content": keyword + " 這是目前有效的知識",
+		"tags":    []string{keyword},
+	})
+
+	entryOld := CreateEntry(t, authedClient, map[string]interface{}{
+		"title":   keyword + " 舊版知識條目",
+		"content": keyword + " 這是舊版的知識",
+		"tags":    []string{keyword},
+	})
+
+	// 提升 active entry 的 confidence
+	for i := 0; i < 6; i++ {
+		_, _, err := authedClient.Do("POST", "/api/v1/entries/"+entryActive+"/confirm", nil)
+		require.NoError(t, err)
+	}
+
+	// 將 old entry supersede 為 active entry（confidence 降至 <= 0.2）
+	status, _, err := authedClient.Do("POST", "/api/v1/entries/"+entryOld+"/supersede", map[string]interface{}{
+		"new_entry_id": entryActive,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, status)
+
+	// 搜尋
+	status, body, err := authedClient.Do("POST", "/api/v1/search", map[string]interface{}{
+		"query": keyword,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, status)
+
+	results, ok := body["results"].([]interface{})
+	require.True(t, ok, "results 應為陣列")
+
+	if len(results) >= 2 {
+		r0 := results[0].(map[string]interface{})
+		assert.Equal(t, entryActive, r0["entry_id"],
+			"active entry 應排在 superseded entry 前面")
+
+		// 找到 superseded entry 並驗證 lifecycle_status
+		for _, r := range results {
+			result := r.(map[string]interface{})
+			if result["entry_id"] == entryOld {
+				assert.Equal(t, "superseded", result["lifecycle_status"],
+					"被 supersede 的 entry 的 lifecycle_status 應為 superseded")
+				break
+			}
+		}
+	}
+}
+
+// --- S-015-6: 取消 Supersede ---
+
+func TestF015_S06_CancelSupersede(t *testing.T) {
+	// GIVEN A superseded_by B
+	// WHEN DELETE /api/v1/entries/{A}/supersede
+	// THEN A.superseded_by = null
+
+	authedClient := setupF015Client(t)
+
+	entryA := createF015Entry(t, authedClient, "取消 supersede A", "取消測試 A 內容")
+	entryB := createF015Entry(t, authedClient, "取消 supersede B", "取消測試 B 內容")
+
+	// 先設定 supersede
+	status, _, err := authedClient.Do("POST", "/api/v1/entries/"+entryA+"/supersede", map[string]interface{}{
+		"new_entry_id": entryB,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, status)
+
+	// 取消 supersede
+	status, body, err := authedClient.Do("DELETE", "/api/v1/entries/"+entryA+"/supersede", nil)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, status, "取消 supersede 應回傳 200")
+
+	assert.Equal(t, entryA, body["id"], "回應的 id 應為 A")
+	assert.Nil(t, body["superseded_by"], "取消後 superseded_by 應為 null")
+
+	// 驗證 GET entry 也反映變更
+	status, entryBody, err := authedClient.Do("GET", "/api/v1/entries/"+entryA, nil)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, status)
+	assert.Nil(t, entryBody["superseded_by"], "GET entry 後 superseded_by 應為 null")
+}
+
+// --- S-015-7: 按 lifecycle_status 過濾列表 ---
+
+func TestF015_S07_FilterByLifecycleStatus(t *testing.T) {
+	// GIVEN 有 active 和 superseded 的 entries
+	// WHEN GET /api/v1/entries?lifecycle_status=active
+	// THEN 只回傳 lifecycle_status 為 "active" 的 entries
+
+	authedClient := setupF015Client(t)
+
+	entryActive := createF015Entry(t, authedClient, "Active 知識", "Active 知識內容")
+	entryOld := createF015Entry(t, authedClient, "Superseded 知識", "Superseded 知識內容")
+
+	// 將 old entry supersede
+	status, _, err := authedClient.Do("POST", "/api/v1/entries/"+entryOld+"/supersede", map[string]interface{}{
+		"new_entry_id": entryActive,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, status)
+
+	// 過濾 active
+	status, body, err := authedClient.Do("GET", "/api/v1/entries?lifecycle_status=active", nil)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, status)
+
+	data := GetDataArray(t, body)
+	for _, item := range data {
+		entry := item.(map[string]interface{})
+		lifecycleStatus, ok := entry["lifecycle_status"].(string)
+		if ok {
+			assert.Equal(t, "active", lifecycleStatus,
+				"過濾 active 時所有結果的 lifecycle_status 應為 active")
+		}
+		// 被 supersede 的 entry 不應出現
+		assert.NotEqual(t, entryOld, entry["id"],
+			"過濾 active 時不應出現被 supersede 的 entry")
+	}
+
+	// 過濾 superseded
+	status, body, err = authedClient.Do("GET", "/api/v1/entries?lifecycle_status=superseded", nil)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, status)
+
+	data = GetDataArray(t, body)
+	foundOld := false
+	for _, item := range data {
+		entry := item.(map[string]interface{})
+		lifecycleStatus, ok := entry["lifecycle_status"].(string)
+		if ok {
+			assert.Equal(t, "superseded", lifecycleStatus,
+				"過濾 superseded 時所有結果的 lifecycle_status 應為 superseded")
+		}
+		if entry["id"] == entryOld {
+			foundOld = true
+		}
+	}
+	assert.True(t, foundOld, "過濾 superseded 時應包含被 supersede 的 entry")
+}
+
+// --- S-015-8: new_entry_id 不存在 ---
+
+func TestF015_S08_SupersedeNonExistentEntry(t *testing.T) {
+	// WHEN POST /api/v1/entries/{A}/supersede {"new_entry_id": "non-existent"}
+	// THEN 404 AND error.code = "NOT_FOUND"
+
+	authedClient := setupF015Client(t)
+
+	entryA := createF015Entry(t, authedClient, "Supersede 不存在 entry", "測試內容")
+
+	status, body, err := authedClient.Do("POST", "/api/v1/entries/"+entryA+"/supersede", map[string]interface{}{
+		"new_entry_id": "00000000-0000-0000-0000-000000000000",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusNotFound, status, "supersede 不存在的 entry 應回傳 404")
+	AssertErrorCode(t, body, "NOT_FOUND")
+}
+
+// --- 額外測試：supersede 未認證 ---
+
+func TestF015_Error_SupersedeUnauthorized(t *testing.T) {
+	// WHEN POST /api/v1/entries/:id/supersede 無 API Key
+	// THEN 401
+
+	client := NewAPIClient()
+	key := BootstrapAPIKey(t, client, "f015-unauth")
+	authedClient := client.WithKey(key)
+
+	entryA := createF015Entry(t, authedClient, "未認證 supersede A", "內容 A")
+	entryB := createF015Entry(t, authedClient, "未認證 supersede B", "內容 B")
+
+	noAuthClient := NewAPIClient()
+	status, body, err := noAuthClient.Do("POST", "/api/v1/entries/"+entryA+"/supersede", map[string]interface{}{
+		"new_entry_id": entryB,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusUnauthorized, status, "無 API Key 應回傳 401")
+	AssertErrorCode(t, body, "UNAUTHORIZED")
+}
+
+// --- 額外測試：三層循環引用檢測 ---
+
+func TestF015_Edge_ThreeLevelCircularDetection(t *testing.T) {
+	// GIVEN A -> B -> C
+	// WHEN POST /api/v1/entries/{C}/supersede {"new_entry_id": "{A}"}
+	// THEN 409 CIRCULAR_SUPERSEDE
+
+	authedClient := setupF015Client(t)
+
+	entryA := createF015Entry(t, authedClient, "三層循環 A", "三層循環 A 內容")
+	entryB := createF015Entry(t, authedClient, "三層循環 B", "三層循環 B 內容")
+	entryC := createF015Entry(t, authedClient, "三層循環 C", "三層循環 C 內容")
+
+	// A -> B
+	status, _, err := authedClient.Do("POST", "/api/v1/entries/"+entryA+"/supersede", map[string]interface{}{
+		"new_entry_id": entryB,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, status)
+
+	// B -> C
+	status, _, err = authedClient.Do("POST", "/api/v1/entries/"+entryB+"/supersede", map[string]interface{}{
+		"new_entry_id": entryC,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, status)
+
+	// C -> A（三層循環引用）
+	status, body, err := authedClient.Do("POST", "/api/v1/entries/"+entryC+"/supersede", map[string]interface{}{
+		"new_entry_id": entryA,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusConflict, status, "三層循環引用應回傳 409")
+	AssertErrorCode(t, body, "CIRCULAR_SUPERSEDE")
+}
+
+// --- 額外測試：entry 回應包含 lifecycle_status ---
+
+func TestF015_EntryResponseIncludesLifecycleStatus(t *testing.T) {
+	// WHEN GET /api/v1/entries/:id
+	// THEN 回應包含 lifecycle_status 欄位
+
+	authedClient := setupF015Client(t)
+
+	entryID := createF015Entry(t, authedClient, "lifecycle_status 測試", "測試內容")
+
+	status, body, err := authedClient.Do("GET", "/api/v1/entries/"+entryID, nil)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, status)
+
+	lifecycleStatus, ok := body["lifecycle_status"].(string)
+	require.True(t, ok, "回應應包含 lifecycle_status 欄位")
+	assert.Equal(t, "active", lifecycleStatus, "新 entry 的 lifecycle_status 應為 active")
+	assert.Nil(t, body["superseded_by"], "新 entry 的 superseded_by 應為 null")
+}

--- a/test/e2e/f016_chinese_tokenizer_test.go
+++ b/test/e2e/f016_chinese_tokenizer_test.go
@@ -1,0 +1,260 @@
+package e2e
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// ============================================================
+// F-016: 中文分詞優化
+// ============================================================
+
+// setupF016Client 建立認證客戶端
+func setupF016Client(t *testing.T) *APIClient {
+	t.Helper()
+
+	client := NewAPIClient()
+	key := BootstrapAPIKey(t, client, "f016-"+t.Name())
+	return client.WithKey(key)
+}
+
+// --- S-016-1: 中文關鍵字搜尋 ---
+
+func TestF016_S01_ChineseKeywordSearch(t *testing.T) {
+	// GIVEN Entry 內容為 "PostgreSQL資料庫效能調優指南"
+	// WHEN GET /api/v1/search/simple?q=資料庫
+	// THEN 回傳該 entry AND relevance > 0
+
+	authedClient := setupF016Client(t)
+
+	entryID := CreateEntry(t, authedClient, map[string]interface{}{
+		"title":   "PostgreSQL資料庫效能調優指南",
+		"content": "PostgreSQL資料庫效能調優指南，涵蓋索引策略與查詢最佳化",
+		"tags":    []string{"postgresql", "database"},
+	})
+
+	status, body, err := authedClient.Do("GET", "/api/v1/search/simple?q=資料庫", nil)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, status, "中文關鍵字搜尋應回傳 200")
+
+	results, ok := body["results"].([]interface{})
+	require.True(t, ok, "results 應為陣列")
+	require.Greater(t, len(results), 0, "搜尋「資料庫」應有結果")
+
+	// 驗證回傳的結果包含我們建立的 entry
+	found := false
+	for _, r := range results {
+		result := r.(map[string]interface{})
+		if result["entry_id"] == entryID {
+			found = true
+			relevance, ok := result["relevance"].(float64)
+			if ok {
+				assert.Greater(t, relevance, float64(0), "relevance 應大於 0")
+			}
+			break
+		}
+	}
+	assert.True(t, found, "搜尋結果應包含建立的 entry (id=%s)", entryID)
+}
+
+// --- S-016-2: 中文部分匹配 ---
+
+func TestF016_S02_ChinesePartialMatch(t *testing.T) {
+	// GIVEN Entry 內容為 "使用Docker部署微服務架構"
+	// WHEN GET /api/v1/search/simple?q=微服務
+	// THEN 回傳該 entry
+
+	authedClient := setupF016Client(t)
+
+	entryID := CreateEntry(t, authedClient, map[string]interface{}{
+		"title":   "使用Docker部署微服務架構",
+		"content": "使用Docker部署微服務架構的完整指南",
+		"tags":    []string{"docker", "microservices"},
+	})
+
+	status, body, err := authedClient.Do("GET", "/api/v1/search/simple?q=微服務", nil)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, status, "中文部分匹配搜尋應回傳 200")
+
+	results, ok := body["results"].([]interface{})
+	require.True(t, ok, "results 應為陣列")
+	require.Greater(t, len(results), 0, "搜尋「微服務」應有結果")
+
+	found := false
+	for _, r := range results {
+		result := r.(map[string]interface{})
+		if result["entry_id"] == entryID {
+			found = true
+			break
+		}
+	}
+	assert.True(t, found, "搜尋結果應包含建立的 entry (id=%s)", entryID)
+}
+
+// --- S-016-3: 英文搜尋不受影響 ---
+
+func TestF016_S03_EnglishSearchUnaffected(t *testing.T) {
+	// GIVEN Entry 內容為 "Using Gin middleware for authentication"
+	// WHEN GET /api/v1/search/simple?q=middleware
+	// THEN 回傳該 entry
+
+	authedClient := setupF016Client(t)
+
+	entryID := CreateEntry(t, authedClient, map[string]interface{}{
+		"title":   "Using Gin middleware for authentication",
+		"content": "Using Gin middleware for authentication in Go applications",
+		"tags":    []string{"gin", "middleware"},
+	})
+
+	status, body, err := authedClient.Do("GET", "/api/v1/search/simple?q=middleware", nil)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, status, "英文搜尋應回傳 200")
+
+	results, ok := body["results"].([]interface{})
+	require.True(t, ok, "results 應為陣列")
+	require.Greater(t, len(results), 0, "搜尋 middleware 應有結果")
+
+	found := false
+	for _, r := range results {
+		result := r.(map[string]interface{})
+		if result["entry_id"] == entryID {
+			found = true
+			break
+		}
+	}
+	assert.True(t, found, "英文搜尋結果應包含建立的 entry (id=%s)", entryID)
+}
+
+// --- S-016-4: 中英混合搜尋 ---
+
+func TestF016_S04_MixedChineseEnglishSearch(t *testing.T) {
+	// GIVEN Entry 內容為 "Golang 效能優化最佳實踐"
+	// WHEN GET /api/v1/search/simple?q=Golang效能
+	// THEN 回傳該 entry
+
+	authedClient := setupF016Client(t)
+
+	entryID := CreateEntry(t, authedClient, map[string]interface{}{
+		"title":   "Golang 效能優化最佳實踐",
+		"content": "Golang 效能優化最佳實踐，包括 goroutine 管理與記憶體分配策略",
+		"tags":    []string{"golang", "performance"},
+	})
+
+	status, body, err := authedClient.Do("GET", "/api/v1/search/simple?q=Golang效能", nil)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, status, "中英混合搜尋應回傳 200")
+
+	results, ok := body["results"].([]interface{})
+	require.True(t, ok, "results 應為陣列")
+	require.Greater(t, len(results), 0, "搜尋「Golang效能」應有結果")
+
+	found := false
+	for _, r := range results {
+		result := r.(map[string]interface{})
+		if result["entry_id"] == entryID {
+			found = true
+			break
+		}
+	}
+	assert.True(t, found, "中英混合搜尋結果應包含建立的 entry (id=%s)", entryID)
+}
+
+// --- S-016-5: pg_bigm 擴展已安裝 ---
+
+func TestF016_S05_PgBigmExtensionInstalled(t *testing.T) {
+	// WHEN GET /api/v1/system/search-config
+	// THEN response.extensions.pg_bigm = true
+
+	authedClient := setupF016Client(t)
+
+	status, body, err := authedClient.Do("GET", "/api/v1/system/search-config", nil)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, status, "search-config 應回傳 200")
+
+	extensions, ok := body["extensions"].(map[string]interface{})
+	require.True(t, ok, "回應應包含 extensions 物件")
+
+	pgBigm, ok := extensions["pg_bigm"].(bool)
+	require.True(t, ok, "extensions 應包含 pg_bigm 欄位")
+	assert.True(t, pgBigm, "pg_bigm 擴展應為 true（已安裝）")
+
+	// 額外驗證 chinese_support 欄位
+	chineseSupport, ok := body["chinese_support"].(string)
+	if ok {
+		assert.Equal(t, "pg_bigm (2-gram)", chineseSupport,
+			"chinese_support 應為 pg_bigm (2-gram)")
+	}
+}
+
+// --- 回歸測試：英文搜尋效果不退化 ---
+
+func TestF016_Regression_EnglishSearchNotDegraded(t *testing.T) {
+	// 確認中文分詞優化後，英文搜尋仍正常運作
+	// GIVEN 多筆英文 entries
+	// WHEN 搜尋英文關鍵字
+	// THEN 正確回傳匹配結果
+
+	authedClient := setupF016Client(t)
+
+	entryID := CreateEntry(t, authedClient, map[string]interface{}{
+		"title":   "Docker container orchestration best practices",
+		"content": "Docker container orchestration with Kubernetes and Docker Compose",
+		"tags":    []string{"docker", "kubernetes"},
+	})
+
+	status, body, err := authedClient.Do("GET", "/api/v1/search/simple?q=orchestration", nil)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, status)
+
+	results, ok := body["results"].([]interface{})
+	require.True(t, ok, "results 應為陣列")
+	require.Greater(t, len(results), 0, "英文搜尋應有結果")
+
+	found := false
+	for _, r := range results {
+		result := r.(map[string]interface{})
+		if result["entry_id"] == entryID {
+			found = true
+			break
+		}
+	}
+	assert.True(t, found, "英文搜尋回歸測試：應找到建立的 entry")
+}
+
+// --- 回歸測試：中文長句搜尋 ---
+
+func TestF016_Edge_ChineseLongPhraseSearch(t *testing.T) {
+	// 較長的中文片語也能正確搜尋
+	// GIVEN Entry 內容包含多個中文技術詞彙
+	// WHEN 搜尋其中一段中文片語
+	// THEN 回傳該 entry
+
+	authedClient := setupF016Client(t)
+
+	entryID := CreateEntry(t, authedClient, map[string]interface{}{
+		"title":   "分散式系統的一致性協議實作",
+		"content": "本文介紹分散式系統中常見的一致性協議，包括 Raft 和 Paxos 演算法的實作細節",
+		"tags":    []string{"distributed-systems"},
+	})
+
+	status, body, err := authedClient.Do("GET", "/api/v1/search/simple?q=一致性協議", nil)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, status)
+
+	results, ok := body["results"].([]interface{})
+	require.True(t, ok, "results 應為陣列")
+	require.Greater(t, len(results), 0, "搜尋「一致性協議」應有結果")
+
+	found := false
+	for _, r := range results {
+		result := r.(map[string]interface{})
+		if result["entry_id"] == entryID {
+			found = true
+			break
+		}
+	}
+	assert.True(t, found, "中文長片語搜尋應找到建立的 entry")
+}


### PR DESCRIPTION
## Summary
- 新增 F-014 Tags 分層 + 多維度搜尋 E2E 測試（S-014-1 ~ S-014-7 + 回歸測試）
- 新增 F-015 知識生命週期 E2E 測試（S-015-1 ~ S-015-8 + 額外邊界測試）
- 新增 F-016 中文分詞優化 E2E 測試（S-016-1 ~ S-016-5 + 回歸測試）

Closes #45

## 測試涵蓋範圍

### F-014: Tags 分層 + 多維度搜尋
- 建立 Entry 帶 domains + context
- 按 domain 過濾搜尋
- 按 context 子欄位過濾（context.frameworks）
- LLM 分類自動產生 domains + context
- 向下相容（舊 entry 無 domains/context）
- 多 domain 過濾（AND 邏輯）
- 智慧搜尋 context_filter
- 回歸：不帶 domains/context 建立 entry 仍正常
- 回歸：Entry CRUD 向下相容

### F-015: 知識生命週期
- 設定 Supersede 關係
- 循環引用檢測（二層 + 三層）
- 不能 supersede 自己
- 查詢版本鏈（A -> B -> C）
- superseded entry 搜尋排名降低
- 取消 Supersede
- 按 lifecycle_status 過濾列表
- supersede 不存在的 entry -> 404
- 未認證 -> 401
- Entry 回應包含 lifecycle_status

### F-016: 中文分詞優化
- 中文關鍵字搜尋（「資料庫」）
- 中文部分匹配（「微服務」）
- 英文搜尋不受影響
- 中英混合搜尋（「Golang效能」）
- pg_bigm 擴展已安裝
- 回歸：英文搜尋不退化
- 邊界：中文長片語搜尋

## Test plan
- [ ] docker compose up 啟動測試環境
- [ ] `go test ./test/e2e/ -run TestF014` 驗證 Tags 分層測試
- [ ] `go test ./test/e2e/ -run TestF015` 驗證知識生命週期測試
- [ ] `go test ./test/e2e/ -run TestF016` 驗證中文分詞測試
- [ ] 確認既有 Sprint 1-4 測試不受影響

🤖 Generated with [Claude Code](https://claude.com/claude-code)