### PR TITLE
feat(search): integrate pg_bigm for Chinese full-text search

### DIFF
--- a/dev/docker-compose.yml
+++ b/dev/docker-compose.yml
@@ -1,6 +1,8 @@
 services:
   db:
-    image: postgres:16-alpine
+    build:
+      context: ../docker/postgres
+      dockerfile: Dockerfile
     environment:
       POSTGRES_DB: aibo
       POSTGRES_USER: aibo

--- a/dev/src/dto/system.go
+++ b/dev/src/dto/system.go
@@ -1,0 +1,8 @@
+package dto
+
+// SearchConfigResponse 搜尋配置資訊回應
+type SearchConfigResponse struct {
+	FTSConfig      string            `json:"fts_config"`
+	Extensions     map[string]bool   `json:"extensions"`
+	ChineseSupport string            `json:"chinese_support"`
+}

--- a/dev/src/handler/system.go
+++ b/dev/src/handler/system.go
@@ -1,0 +1,38 @@
+package handler
+
+import (
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+	"github.com/gpwork4u/aibo/dto"
+	"github.com/gpwork4u/aibo/service"
+)
+
+// SystemHandler 系統資訊 HTTP handler
+type SystemHandler struct {
+	svc *service.SystemService
+}
+
+// NewSystemHandler 建立新的 SystemHandler
+func NewSystemHandler(svc *service.SystemService) *SystemHandler {
+	return &SystemHandler{svc: svc}
+}
+
+// GetSearchConfig 取得搜尋配置資訊
+// GET /api/v1/system/search-config
+func (h *SystemHandler) GetSearchConfig(c *gin.Context) {
+	result, err := h.svc.GetSearchConfig(c.Request.Context())
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, dto.ErrorResponse{
+			Code:    "INTERNAL_ERROR",
+			Message: "取得搜尋配置資訊失敗",
+		})
+		return
+	}
+
+	c.JSON(http.StatusOK, dto.SearchConfigResponse{
+		FTSConfig:      result.FTSConfig,
+		Extensions:     result.Extensions,
+		ChineseSupport: result.ChineseSupport,
+	})
+}

--- a/dev/src/main.go
+++ b/dev/src/main.go
@@ -114,8 +114,13 @@ func main() {
 	statsSvc := service.NewStatsService(statsRepo)
 	statsHandler := handler.NewStatsHandler(statsSvc)
 
+	// 初始化系統資訊服務
+	systemRepo := repository.NewSystemRepository(pool)
+	systemSvc := service.NewSystemService(systemRepo)
+	systemHandler := handler.NewSystemHandler(systemSvc)
+
 	// 設定路由
-	r := router.Setup(apiKeySvc, apiKeyHandler, categoryHandler, llmProviderHandler, entryHandler, classifyHandler, searchHandler, gitImportHandler, gcalHandler, confidenceHandler, statsHandler)
+	r := router.Setup(apiKeySvc, apiKeyHandler, categoryHandler, llmProviderHandler, entryHandler, classifyHandler, searchHandler, gitImportHandler, gcalHandler, confidenceHandler, statsHandler, systemHandler)
 
 	// 啟動 HTTP server（graceful shutdown）
 	srv := &http.Server{

--- a/dev/src/migration/009_add_chinese_tokenizer.down.sql
+++ b/dev/src/migration/009_add_chinese_tokenizer.down.sql
@@ -1,0 +1,8 @@
+-- 還原 pg_bigm 索引為 pg_trgm 索引
+DROP INDEX IF EXISTS idx_entries_bigm;
+CREATE INDEX idx_entries_trgm ON entries USING GIN (
+  (coalesce(summary,'') || ' ' || coalesce(title,'') || ' ' || coalesce(content,'')) gin_trgm_ops
+);
+
+-- 移除 pg_bigm 擴展
+DROP EXTENSION IF EXISTS pg_bigm;

--- a/dev/src/migration/009_add_chinese_tokenizer.up.sql
+++ b/dev/src/migration/009_add_chinese_tokenizer.up.sql
@@ -1,0 +1,9 @@
+-- 安裝 pg_bigm 擴展（2-gram 索引，優化中文全文搜尋）
+CREATE EXTENSION IF NOT EXISTS pg_bigm;
+
+-- 替換 pg_trgm 索引為 pg_bigm 索引
+-- pg_bigm 的 2-gram 對中文字元自然對齊，效果優於 pg_trgm 的 3-gram
+DROP INDEX IF EXISTS idx_entries_trgm;
+CREATE INDEX idx_entries_bigm ON entries USING GIN (
+  (coalesce(summary,'') || ' ' || coalesce(title,'') || ' ' || coalesce(content,'')) gin_bigm_ops
+);

--- a/dev/src/repository/entry.go
+++ b/dev/src/repository/entry.go
@@ -109,20 +109,22 @@ func (r *EntryRepository) List(ctx context.Context, filter model.EntryFilter) (*
 	if filter.Search != "" {
 		hasSearch = true
 		searchArgIdx = argIdx
-		// 加權 tsvector 全文搜尋 + pg_trgm 模糊搜尋 + tag ILIKE
+		// 加權 tsvector 全文搜尋 + pg_bigm LIKE 模糊搜尋 + tag ILIKE
+		escapedArgIdx := argIdx + 1
 		searchCondition := fmt.Sprintf(
 			`((setweight(to_tsvector('simple', coalesce(e.summary, '')), 'A') ||
 			   setweight(to_tsvector('simple', coalesce(e.title, '')), 'A') ||
 			   setweight(to_tsvector('simple', coalesce(array_to_string(e.tags, ' '), '')), 'A') ||
 			   setweight(to_tsvector('simple', coalesce(e.content, '')), 'B'))
 			  @@ plainto_tsquery('simple', $%d)
-			 OR (coalesce(e.summary,'') || ' ' || coalesce(e.title,'') || ' ' || coalesce(e.content,'')) %% $%d
-			 OR EXISTS (SELECT 1 FROM unnest(e.tags) AS t WHERE t ILIKE '%%' || $%d || '%%'))`,
-			argIdx, argIdx, argIdx,
+			 OR (coalesce(e.summary,'') || ' ' || coalesce(e.title,'') || ' ' || coalesce(e.content,''))
+			    LIKE '%%' || $%d || '%%' ESCAPE '\\'
+			 OR EXISTS (SELECT 1 FROM unnest(e.tags) AS t WHERE t ILIKE '%%' || $%d || '%%' ESCAPE '\\'))`,
+			argIdx, escapedArgIdx, escapedArgIdx,
 		)
 		conditions = append(conditions, searchCondition)
-		args = append(args, filter.Search)
-		argIdx++
+		args = append(args, filter.Search, escapeLikePattern(filter.Search))
+		argIdx += 2
 	}
 
 	// 建構 WHERE 子句

--- a/dev/src/repository/search.go
+++ b/dev/src/repository/search.go
@@ -47,7 +47,7 @@ type SearchParams struct {
 }
 
 // Search 執行加權全文搜尋
-// 使用 tsvector 加權搜尋（title:A, tags:A, content:B）+ trgm 模糊比對
+// 使用 tsvector 加權搜尋（title:A, tags:A, content:B）+ pg_bigm LIKE 模糊比對
 // 多個關鍵字以 OR 邏輯搜尋，ts_rank 取最高分
 func (r *SearchRepository) Search(ctx context.Context, params SearchParams) ([]SearchResult, int, error) {
 	if len(params.Keywords) == 0 {
@@ -72,9 +72,10 @@ func (r *SearchRepository) Search(ctx context.Context, params SearchParams) ([]S
 			   setweight(to_tsvector('simple', coalesce(array_to_string(e.tags, ' '), '')), 'A') ||
 			   setweight(to_tsvector('simple', coalesce(e.content, '')), 'B'))
 			  @@ plainto_tsquery('simple', $%d)
-			 OR (coalesce(e.summary,'') || ' ' || coalesce(e.title,'') || ' ' || coalesce(e.content,'')) %% $%d
+			 OR (coalesce(e.summary,'') || ' ' || coalesce(e.title,'') || ' ' || coalesce(e.content,''))
+			    LIKE '%%' || $%d || '%%' ESCAPE '\\'
 			 OR EXISTS (SELECT 1 FROM unnest(e.tags) AS t WHERE t ILIKE '%%' || $%d || '%%' ESCAPE '\\'))`,
-			kwIdx, kwIdx, escapedKwIdx,
+			kwIdx, escapedKwIdx, escapedKwIdx,
 		))
 		args = append(args, kw, escapeLikePattern(kw))
 		argIdx += 2

--- a/dev/src/repository/system.go
+++ b/dev/src/repository/system.go
@@ -1,0 +1,27 @@
+package repository
+
+import (
+	"context"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+// SystemRepository 系統資訊資料庫操作
+type SystemRepository struct {
+	pool *pgxpool.Pool
+}
+
+// NewSystemRepository 建立新的 SystemRepository
+func NewSystemRepository(pool *pgxpool.Pool) *SystemRepository {
+	return &SystemRepository{pool: pool}
+}
+
+// ExtensionInstalled 檢查 PostgreSQL 擴展是否已安裝
+func (r *SystemRepository) ExtensionInstalled(ctx context.Context, extName string) (bool, error) {
+	var exists bool
+	err := r.pool.QueryRow(ctx,
+		"SELECT EXISTS(SELECT 1 FROM pg_extension WHERE extname = $1)",
+		extName,
+	).Scan(&exists)
+	return exists, err
+}

--- a/dev/src/router/router.go
+++ b/dev/src/router/router.go
@@ -10,7 +10,7 @@ import (
 )
 
 // Setup 設定路由
-func Setup(apiKeySvc *service.ApiKeyService, apiKeyHandler *handler.ApiKeyHandler, categoryHandler *handler.CategoryHandler, llmProviderHandler *handler.LlmProviderHandler, entryHandler *handler.EntryHandler, classifyHandler *handler.ClassifyHandler, searchHandler *handler.SearchHandler, gitImportHandler *handler.GitImportHandler, gcalHandler *handler.GcalHandler, confidenceHandler *handler.ConfidenceHandler, statsHandler *handler.StatsHandler) *gin.Engine {
+func Setup(apiKeySvc *service.ApiKeyService, apiKeyHandler *handler.ApiKeyHandler, categoryHandler *handler.CategoryHandler, llmProviderHandler *handler.LlmProviderHandler, entryHandler *handler.EntryHandler, classifyHandler *handler.ClassifyHandler, searchHandler *handler.SearchHandler, gitImportHandler *handler.GitImportHandler, gcalHandler *handler.GcalHandler, confidenceHandler *handler.ConfidenceHandler, statsHandler *handler.StatsHandler, systemHandler *handler.SystemHandler) *gin.Engine {
 	r := gin.Default()
 
 	// 健康檢查（不需認證）
@@ -93,6 +93,12 @@ func Setup(apiKeySvc *service.ApiKeyService, apiKeyHandler *handler.ApiKeyHandle
 
 		// 統計
 		v1.GET("/stats", statsHandler.GetStats)
+
+		// 系統資訊
+		system := v1.Group("/system")
+		{
+			system.GET("/search-config", systemHandler.GetSearchConfig)
+		}
 	}
 
 	return r

--- a/dev/src/service/system.go
+++ b/dev/src/service/system.go
@@ -1,0 +1,51 @@
+package service
+
+import (
+	"context"
+
+	"github.com/gpwork4u/aibo/repository"
+)
+
+// SearchConfigResult 搜尋配置結果
+type SearchConfigResult struct {
+	FTSConfig      string
+	Extensions     map[string]bool
+	ChineseSupport string
+}
+
+// SystemService 系統資訊業務邏輯
+type SystemService struct {
+	repo *repository.SystemRepository
+}
+
+// NewSystemService 建立新的 SystemService
+func NewSystemService(repo *repository.SystemRepository) *SystemService {
+	return &SystemService{repo: repo}
+}
+
+// GetSearchConfig 取得搜尋配置資訊
+func (s *SystemService) GetSearchConfig(ctx context.Context) (*SearchConfigResult, error) {
+	pgTrgm, err := s.repo.ExtensionInstalled(ctx, "pg_trgm")
+	if err != nil {
+		return nil, err
+	}
+
+	pgBigm, err := s.repo.ExtensionInstalled(ctx, "pg_bigm")
+	if err != nil {
+		return nil, err
+	}
+
+	chineseSupport := "none"
+	if pgBigm {
+		chineseSupport = "pg_bigm (2-gram)"
+	}
+
+	return &SearchConfigResult{
+		FTSConfig: "simple",
+		Extensions: map[string]bool{
+			"pg_trgm": pgTrgm,
+			"pg_bigm": pgBigm,
+		},
+		ChineseSupport: chineseSupport,
+	}, nil
+}

--- a/docker/postgres/Dockerfile
+++ b/docker/postgres/Dockerfile
@@ -1,0 +1,12 @@
+FROM postgres:16-alpine
+
+# 安裝 pg_bigm 擴展（2-gram 索引，優化中文全文搜尋）
+RUN apk add --no-cache build-base postgresql-dev wget \
+    && cd /tmp \
+    && wget -q https://github.com/pgbigm/pg_bigm/archive/refs/tags/v1.2-20240606.tar.gz \
+    && tar xzf v1.2-20240606.tar.gz \
+    && cd pg_bigm-1.2-20240606 \
+    && make USE_PGXS=1 \
+    && make USE_PGXS=1 install \
+    && cd / && rm -rf /tmp/* \
+    && apk del build-base postgresql-dev wget


### PR DESCRIPTION
## Summary
- 整合 pg_bigm 擴展（2-gram 索引），取代 pg_trgm 以提升中文全文搜尋品質
- 自訂 PostgreSQL Docker image 安裝 pg_bigm
- 新增 `GET /api/v1/system/search-config` 診斷端點

## Changes
- **`docker/postgres/Dockerfile`** — 自訂 PostgreSQL 16 Alpine image，從原始碼編譯安裝 pg_bigm v1.2
- **`dev/docker-compose.yml`** — db service 改用 build context 取代 `image: postgres:16-alpine`
- **`dev/src/migration/009_add_chinese_tokenizer.up.sql`** — 安裝 pg_bigm 擴展，建立 `idx_entries_bigm` GIN 索引（取代 `idx_entries_trgm`）
- **`dev/src/migration/009_add_chinese_tokenizer.down.sql`** — 還原為 pg_trgm 索引
- **`dev/src/repository/entry.go`** — List 方法搜尋 SQL 將 `%%` 運算子替換為 `LIKE '%' || $N || '%' ESCAPE '\'`，由 pg_bigm GIN 索引加速
- **`dev/src/repository/search.go`** — Search 方法同步替換 `%%` 為 LIKE，並使用 escaped 參數防止 SQL 注入
- **`dev/src/repository/system.go`** — 新增 SystemRepository，檢查 PostgreSQL 擴展安裝狀態
- **`dev/src/service/system.go`** — 新增 SystemService，查詢搜尋配置
- **`dev/src/handler/system.go`** — 新增 SystemHandler，提供 `GET /api/v1/system/search-config`
- **`dev/src/dto/system.go`** — 新增 SearchConfigResponse DTO
- **`dev/src/router/router.go`** — 註冊 `/system/search-config` 路由
- **`dev/src/main.go`** — 初始化 SystemRepository → SystemService → SystemHandler 並注入 router

## Test Plan
- [ ] `docker compose up` 後驗證 pg_bigm 擴展可用（`SELECT * FROM pg_extension WHERE extname = 'pg_bigm'`）
- [ ] 搜尋「資料庫」能匹配含「PostgreSQL資料庫效能調優」的 entry
- [ ] 搜尋「微服務」能匹配含「使用Docker部署微服務架構」的 entry
- [ ] 英文搜尋（如 `middleware`）仍透過 tsvector 精確匹配正常運作
- [ ] `GET /api/v1/system/search-config` 回傳 `pg_bigm: true`

Closes #42

🤖 Generated with [Claude Code](https://claude.com/claude-code)