### PR TITLE
feat(F-014): Tags 分層 + 多維度搜尋

### DIFF
--- a/dev/__tests__/handler/search_domains_test.go
+++ b/dev/__tests__/handler/search_domains_test.go
@@ -1,0 +1,240 @@
+package handler_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/gpwork4u/aibo/dto"
+)
+
+// TestSmartSearchRequestWithDomains 測試 SmartSearchRequest 包含 domains
+func TestSmartSearchRequestWithDomains(t *testing.T) {
+	jsonStr := `{"query":"middleware","domains":["golang"],"limit":10}`
+
+	var req dto.SmartSearchRequest
+	if err := json.Unmarshal([]byte(jsonStr), &req); err != nil {
+		t.Fatalf("failed to unmarshal: %v", err)
+	}
+
+	if req.Query != "middleware" {
+		t.Errorf("expected query 'middleware', got '%s'", req.Query)
+	}
+	if len(req.Domains) != 1 || req.Domains[0] != "golang" {
+		t.Errorf("expected domains=['golang'], got %v", req.Domains)
+	}
+}
+
+// TestSmartSearchRequestWithContextFilter 測試 SmartSearchRequest 包含 context_filter
+func TestSmartSearchRequestWithContextFilter(t *testing.T) {
+	jsonStr := `{"query":"auth","context_filter":{"languages":["go"],"frameworks":["gin"]}}`
+
+	var req dto.SmartSearchRequest
+	if err := json.Unmarshal([]byte(jsonStr), &req); err != nil {
+		t.Fatalf("failed to unmarshal: %v", err)
+	}
+
+	if len(req.ContextFilter) != 2 {
+		t.Errorf("expected 2 context_filter keys, got %d", len(req.ContextFilter))
+	}
+
+	// 解析 languages 值
+	var langs []string
+	if raw, ok := req.ContextFilter["languages"]; ok {
+		if err := json.Unmarshal(raw, &langs); err != nil {
+			t.Fatalf("failed to unmarshal languages: %v", err)
+		}
+	}
+	if len(langs) != 1 || langs[0] != "go" {
+		t.Errorf("expected languages=['go'], got %v", langs)
+	}
+}
+
+// TestSmartSearchRequestBackwardCompatible 測試 SmartSearchRequest 向下相容（無 domains/context_filter）
+func TestSmartSearchRequestBackwardCompatible(t *testing.T) {
+	jsonStr := `{"query":"middleware","limit":10}`
+
+	var req dto.SmartSearchRequest
+	if err := json.Unmarshal([]byte(jsonStr), &req); err != nil {
+		t.Fatalf("failed to unmarshal: %v", err)
+	}
+
+	if req.Domains != nil {
+		t.Errorf("expected nil domains for backward compat, got %v", req.Domains)
+	}
+	if req.ContextFilter != nil {
+		t.Errorf("expected nil context_filter for backward compat, got %v", req.ContextFilter)
+	}
+}
+
+// TestSearchResultItemIncludesDomains 測試搜尋結果包含 domains/context
+func TestSearchResultItemIncludesDomains(t *testing.T) {
+	ctx := json.RawMessage(`{"languages":["go"]}`)
+	item := dto.SearchResultItem{
+		Domains: []string{"golang"},
+		Context: &ctx,
+	}
+
+	data, err := json.Marshal(item)
+	if err != nil {
+		t.Fatalf("failed to marshal: %v", err)
+	}
+
+	var parsed map[string]interface{}
+	if err := json.Unmarshal(data, &parsed); err != nil {
+		t.Fatalf("failed to unmarshal: %v", err)
+	}
+
+	domains, ok := parsed["domains"].([]interface{})
+	if !ok || len(domains) != 1 || domains[0] != "golang" {
+		t.Errorf("expected domains=[golang], got %v", parsed["domains"])
+	}
+
+	if _, ok := parsed["context"]; !ok {
+		t.Error("expected context field in search result")
+	}
+}
+
+// TestSimpleSearchResultItemIncludesDomains 測試簡單搜尋結果包含 domains/context
+func TestSimpleSearchResultItemIncludesDomains(t *testing.T) {
+	item := dto.SimpleSearchResultItem{
+		Domains: []string{"docker", "kubernetes"},
+	}
+
+	data, err := json.Marshal(item)
+	if err != nil {
+		t.Fatalf("failed to marshal: %v", err)
+	}
+
+	var parsed map[string]interface{}
+	if err := json.Unmarshal(data, &parsed); err != nil {
+		t.Fatalf("failed to unmarshal: %v", err)
+	}
+
+	domains, ok := parsed["domains"].([]interface{})
+	if !ok || len(domains) != 2 {
+		t.Errorf("expected 2 domains, got %v", parsed["domains"])
+	}
+}
+
+// TestCreateEntryRequestWithDomains 測試建立 Entry 請求包含 domains/context
+func TestCreateEntryRequestWithDomains(t *testing.T) {
+	jsonStr := `{
+		"content": "Using Gin middleware for JWT auth",
+		"domains": ["golang"],
+		"context": {"languages": ["go"], "frameworks": ["gin"]}
+	}`
+
+	var req dto.CreateEntryRequest
+	if err := json.Unmarshal([]byte(jsonStr), &req); err != nil {
+		t.Fatalf("failed to unmarshal: %v", err)
+	}
+
+	if len(req.Domains) != 1 || req.Domains[0] != "golang" {
+		t.Errorf("expected domains=['golang'], got %v", req.Domains)
+	}
+	if req.Context == nil {
+		t.Fatal("expected context to be non-nil")
+	}
+
+	var ctx map[string]interface{}
+	if err := json.Unmarshal(*req.Context, &ctx); err != nil {
+		t.Fatalf("failed to unmarshal context: %v", err)
+	}
+	langs, ok := ctx["languages"].([]interface{})
+	if !ok || len(langs) != 1 || langs[0] != "go" {
+		t.Errorf("expected languages=['go'], got %v", ctx["languages"])
+	}
+}
+
+// TestEntryResponseIncludesDomains 測試 EntryResponse 包含 domains/context
+func TestEntryResponseIncludesDomains(t *testing.T) {
+	ctx := json.RawMessage(`{"pattern":"middleware"}`)
+	resp := dto.EntryResponse{
+		Domains: []string{"golang"},
+		Context: &ctx,
+		Tags:    []string{"gin", "auth"},
+	}
+
+	data, err := json.Marshal(resp)
+	if err != nil {
+		t.Fatalf("failed to marshal: %v", err)
+	}
+
+	var parsed map[string]interface{}
+	if err := json.Unmarshal(data, &parsed); err != nil {
+		t.Fatalf("failed to unmarshal: %v", err)
+	}
+
+	// 驗證 domains 存在
+	if _, ok := parsed["domains"]; !ok {
+		t.Error("expected domains field in response")
+	}
+
+	// 驗證 context 存在
+	if _, ok := parsed["context"]; !ok {
+		t.Error("expected context field in response")
+	}
+
+	// 驗證 tags 仍存在（向下相容）
+	if _, ok := parsed["tags"]; !ok {
+		t.Error("expected tags field in response (backward compat)")
+	}
+}
+
+// TestClassifyResultWithDomains 測試 ClassifyResult 包含 domains/context
+func TestClassifyResultWithDomains(t *testing.T) {
+	jsonStr := `{
+		"category": "Backend Development",
+		"tags": ["middleware", "auth"],
+		"domains": ["golang"],
+		"context": {"languages": ["go"], "frameworks": ["gin"], "pattern": "middleware"},
+		"title": "Gin JWT Middleware",
+		"summary": "使用 Gin middleware 實作 JWT 認證",
+		"detail": "詳細說明",
+		"action": "供參考"
+	}`
+
+	var result dto.ClassifyResult
+	if err := json.Unmarshal([]byte(jsonStr), &result); err != nil {
+		t.Fatalf("failed to unmarshal: %v", err)
+	}
+
+	if len(result.Domains) != 1 || result.Domains[0] != "golang" {
+		t.Errorf("expected domains=['golang'], got %v", result.Domains)
+	}
+	if result.Context == nil {
+		t.Fatal("expected context to be non-nil")
+	}
+
+	var ctx map[string]interface{}
+	if err := json.Unmarshal(*result.Context, &ctx); err != nil {
+		t.Fatalf("failed to unmarshal context: %v", err)
+	}
+	if ctx["pattern"] != "middleware" {
+		t.Errorf("expected pattern='middleware', got '%v'", ctx["pattern"])
+	}
+}
+
+// TestClassifyResultBackwardCompatible 測試舊格式 ClassifyResult（無 domains/context）
+func TestClassifyResultBackwardCompatible(t *testing.T) {
+	jsonStr := `{
+		"category": "Backend Development",
+		"tags": ["middleware"],
+		"title": "Test",
+		"summary": "Test",
+		"detail": "Test",
+		"action": "供參考"
+	}`
+
+	var result dto.ClassifyResult
+	if err := json.Unmarshal([]byte(jsonStr), &result); err != nil {
+		t.Fatalf("failed to unmarshal: %v", err)
+	}
+
+	if result.Domains != nil {
+		t.Errorf("expected nil domains for old format, got %v", result.Domains)
+	}
+	if result.Context != nil {
+		t.Errorf("expected nil context for old format, got %v", result.Context)
+	}
+}

--- a/dev/__tests__/repository/entry_domains_test.go
+++ b/dev/__tests__/repository/entry_domains_test.go
@@ -1,0 +1,132 @@
+package repository_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/gpwork4u/aibo/model"
+)
+
+// TestEntryModelDomainsField 測試 Entry model 新增 domains 欄位
+func TestEntryModelDomainsField(t *testing.T) {
+	entry := model.Entry{
+		Domains: []string{"golang", "docker"},
+	}
+
+	if len(entry.Domains) != 2 {
+		t.Errorf("expected 2 domains, got %d", len(entry.Domains))
+	}
+	if entry.Domains[0] != "golang" {
+		t.Errorf("expected first domain 'golang', got '%s'", entry.Domains[0])
+	}
+	if entry.Domains[1] != "docker" {
+		t.Errorf("expected second domain 'docker', got '%s'", entry.Domains[1])
+	}
+}
+
+// TestEntryModelContextField 測試 Entry model 新增 context 欄位
+func TestEntryModelContextField(t *testing.T) {
+	ctx := json.RawMessage(`{"languages":["go"],"frameworks":["gin"],"pattern":"middleware"}`)
+	entry := model.Entry{
+		Context: &ctx,
+	}
+
+	if entry.Context == nil {
+		t.Fatal("expected context to be non-nil")
+	}
+
+	var parsed map[string]interface{}
+	if err := json.Unmarshal(*entry.Context, &parsed); err != nil {
+		t.Fatalf("failed to unmarshal context: %v", err)
+	}
+
+	langs, ok := parsed["languages"].([]interface{})
+	if !ok || len(langs) != 1 || langs[0] != "go" {
+		t.Errorf("expected languages=[go], got %v", parsed["languages"])
+	}
+}
+
+// TestEntryModelDomainsDefaultEmpty 測試 Entry model domains 預設為空
+func TestEntryModelDomainsDefaultEmpty(t *testing.T) {
+	entry := model.Entry{}
+
+	if entry.Domains != nil {
+		t.Errorf("expected nil domains for zero value, got %v", entry.Domains)
+	}
+	if entry.Context != nil {
+		t.Error("expected nil context for zero value")
+	}
+}
+
+// TestEntryFilterDomains 測試 EntryFilter 支援 domains 過濾
+func TestEntryFilterDomains(t *testing.T) {
+	filter := model.EntryFilter{
+		Domains: []string{"golang", "docker"},
+	}
+
+	if len(filter.Domains) != 2 {
+		t.Errorf("expected 2 domains in filter, got %d", len(filter.Domains))
+	}
+}
+
+// TestEntryFilterContextFilter 測試 EntryFilter 支援 context 子欄位過濾
+func TestEntryFilterContextFilter(t *testing.T) {
+	filter := model.EntryFilter{
+		ContextFilter: map[string][]string{
+			"languages":  {"go"},
+			"frameworks": {"gin"},
+		},
+	}
+
+	if len(filter.ContextFilter) != 2 {
+		t.Errorf("expected 2 context filter keys, got %d", len(filter.ContextFilter))
+	}
+	if filter.ContextFilter["languages"][0] != "go" {
+		t.Errorf("expected languages filter 'go', got '%s'", filter.ContextFilter["languages"][0])
+	}
+}
+
+// TestEntryListItemDomains 測試 EntryListItem 也包含 domains/context
+func TestEntryListItemDomains(t *testing.T) {
+	ctx := json.RawMessage(`{"languages":["python"]}`)
+	item := model.EntryListItem{
+		Domains: []string{"python"},
+		Context: &ctx,
+	}
+
+	if len(item.Domains) != 1 || item.Domains[0] != "python" {
+		t.Errorf("expected domains=['python'], got %v", item.Domains)
+	}
+	if item.Context == nil {
+		t.Error("expected context to be non-nil")
+	}
+}
+
+// TestEntryJSONSerialization 測試 Entry JSON 序列化包含 domains/context
+func TestEntryJSONSerialization(t *testing.T) {
+	ctx := json.RawMessage(`{"languages":["go"]}`)
+	entry := model.Entry{
+		Domains: []string{"golang"},
+		Context: &ctx,
+	}
+
+	data, err := json.Marshal(entry)
+	if err != nil {
+		t.Fatalf("failed to marshal: %v", err)
+	}
+
+	var parsed map[string]interface{}
+	if err := json.Unmarshal(data, &parsed); err != nil {
+		t.Fatalf("failed to unmarshal: %v", err)
+	}
+
+	domains, ok := parsed["domains"].([]interface{})
+	if !ok || len(domains) != 1 || domains[0] != "golang" {
+		t.Errorf("expected domains=[golang] in JSON, got %v", parsed["domains"])
+	}
+
+	context, ok := parsed["context"]
+	if !ok || context == nil {
+		t.Error("expected context in JSON output")
+	}
+}

--- a/dev/src/dto/entry.go
+++ b/dev/src/dto/entry.go
@@ -1,6 +1,7 @@
 package dto
 
 import (
+	"encoding/json"
 	"time"
 
 	"github.com/google/uuid"
@@ -8,16 +9,18 @@ import (
 
 // CreateEntryRequest 建立知識條目的請求
 type CreateEntryRequest struct {
-	Title      *string    `json:"title"`
-	Content    *string    `json:"content"`
-	Summary    *string    `json:"summary"`
-	Detail     *string    `json:"detail"`
-	Action     *string    `json:"action"`
-	CategoryID *uuid.UUID `json:"category_id"`
-	Source     *string    `json:"source"`
-	SourceType *string    `json:"source_type"`
-	SourceRef  *string    `json:"source_ref"`
-	Tags       []string   `json:"tags"`
+	Title      *string          `json:"title"`
+	Content    *string          `json:"content"`
+	Summary    *string          `json:"summary"`
+	Detail     *string          `json:"detail"`
+	Action     *string          `json:"action"`
+	CategoryID *uuid.UUID       `json:"category_id"`
+	Source     *string          `json:"source"`
+	SourceType *string          `json:"source_type"`
+	SourceRef  *string          `json:"source_ref"`
+	Tags       []string         `json:"tags"`
+	Domains    []string         `json:"domains"`
+	Context    *json.RawMessage `json:"context"`
 }
 
 // UpdateEntryRequest 部分更新知識條目的請求（PATCH）
@@ -43,36 +46,40 @@ type UpdateEntryRequest struct {
 
 // EntryResponse 單筆知識條目回應（完整 content + summary/detail/action）
 type EntryResponse struct {
-	ID              uuid.UUID  `json:"id"`
-	Title           *string    `json:"title"`
-	Content         *string    `json:"content"`
-	Summary         *string    `json:"summary"`
-	Detail          *string    `json:"detail"`
-	Action          *string    `json:"action"`
-	CategoryID      *uuid.UUID `json:"category_id"`
-	Source          *string    `json:"source"`
-	SourceType      *string    `json:"source_type"`
-	SourceRef       *string    `json:"source_ref"`
-	Tags            []string   `json:"tags"`
-	IsArchived      bool       `json:"is_archived"`
-	Confidence      float64    `json:"confidence"`
-	Confirmations   int        `json:"confirmations"`
-	FlagsCount      int        `json:"flags_count"`
-	SupersededBy    *uuid.UUID `json:"superseded_by"`
-	LifecycleStatus string     `json:"lifecycle_status"`
-	CreatedAt       time.Time  `json:"created_at"`
-	UpdatedAt       time.Time  `json:"updated_at"`
+	ID              uuid.UUID        `json:"id"`
+	Title           *string          `json:"title"`
+	Content         *string          `json:"content"`
+	Summary         *string          `json:"summary"`
+	Detail          *string          `json:"detail"`
+	Action          *string          `json:"action"`
+	CategoryID      *uuid.UUID       `json:"category_id"`
+	Source          *string          `json:"source"`
+	SourceType      *string          `json:"source_type"`
+	SourceRef       *string          `json:"source_ref"`
+	Tags            []string         `json:"tags"`
+	Domains         []string         `json:"domains"`
+	Context         *json.RawMessage `json:"context"`
+	IsArchived      bool             `json:"is_archived"`
+	Confidence      float64          `json:"confidence"`
+	Confirmations   int              `json:"confirmations"`
+	FlagsCount      int              `json:"flags_count"`
+	SupersededBy    *uuid.UUID       `json:"superseded_by"`
+	LifecycleStatus string           `json:"lifecycle_status"`
+	CreatedAt       time.Time        `json:"created_at"`
+	UpdatedAt       time.Time        `json:"updated_at"`
 }
 
 // EntryListItemResponse 列表中的知識條目（含 summary，不含 detail/action/source）
 type EntryListItemResponse struct {
-	ID              uuid.UUID  `json:"id"`
-	Title           *string    `json:"title"`
-	Summary         *string    `json:"summary"`
-	ContentPreview  *string    `json:"content_preview"`
-	CategoryID      *uuid.UUID `json:"category_id"`
-	Tags            []string   `json:"tags"`
-	IsArchived      bool       `json:"is_archived"`
+	ID              uuid.UUID        `json:"id"`
+	Title           *string          `json:"title"`
+	Summary         *string          `json:"summary"`
+	ContentPreview  *string          `json:"content_preview"`
+	CategoryID      *uuid.UUID       `json:"category_id"`
+	Tags            []string         `json:"tags"`
+	Domains         []string         `json:"domains"`
+	Context         *json.RawMessage `json:"context"`
+	IsArchived      bool             `json:"is_archived"`
 	Confidence      float64    `json:"confidence"`
 	Confirmations   int        `json:"confirmations"`
 	FlagsCount      int        `json:"flags_count"`

--- a/dev/src/dto/llm.go
+++ b/dev/src/dto/llm.go
@@ -1,15 +1,21 @@
 package dto
 
-import "github.com/google/uuid"
+import (
+	"encoding/json"
+
+	"github.com/google/uuid"
+)
 
 // ClassifyResult LLM 分類回傳結果
 type ClassifyResult struct {
-	Category string   `json:"category"`
-	Tags     []string `json:"tags"`
-	Title    string   `json:"title"`
-	Summary  string   `json:"summary"` // 一句話摘要
-	Detail   string   `json:"detail"`  // 詳細說明
-	Action   string   `json:"action"`  // 可執行的建議/行動
+	Category string           `json:"category"`
+	Tags     []string         `json:"tags"`
+	Domains  []string         `json:"domains"`
+	Context  *json.RawMessage `json:"context"`
+	Title    string           `json:"title"`
+	Summary  string           `json:"summary"` // 一句話摘要
+	Detail   string           `json:"detail"`  // 詳細說明
+	Action   string           `json:"action"`  // 可執行的建議/行動
 }
 
 // ClassifyResponse 手動觸發分類的回應

--- a/dev/src/dto/search.go
+++ b/dev/src/dto/search.go
@@ -1,25 +1,33 @@
 package dto
 
-import "github.com/google/uuid"
+import (
+	"encoding/json"
+
+	"github.com/google/uuid"
+)
 
 // SmartSearchRequest 智慧搜尋請求
 type SmartSearchRequest struct {
-	Query      string  `json:"query" binding:"required"`
-	CategoryID *string `json:"category_id"`
-	Limit      *int    `json:"limit"`
+	Query         string                     `json:"query" binding:"required"`
+	CategoryID    *string                    `json:"category_id"`
+	Domains       []string                   `json:"domains"`
+	ContextFilter map[string]json.RawMessage `json:"context_filter"`
+	Limit         *int                       `json:"limit"`
 }
 
 // SearchResultItem 搜尋結果項目
 type SearchResultItem struct {
-	EntryID         uuid.UUID  `json:"entry_id"`
-	Title           *string    `json:"title"`
-	Summary         *string    `json:"summary"`
-	ContentPreview  string     `json:"content_preview"`
-	Tags            []string   `json:"tags"`
-	LifecycleStatus string     `json:"lifecycle_status"`
-	SupersededBy    *uuid.UUID `json:"superseded_by"`
-	Relevance       float64    `json:"relevance"`
-	MatchedKeywords []string   `json:"matched_keywords,omitempty"`
+	EntryID         uuid.UUID        `json:"entry_id"`
+	Title           *string          `json:"title"`
+	Summary         *string          `json:"summary"`
+	ContentPreview  string           `json:"content_preview"`
+	Tags            []string         `json:"tags"`
+	Domains         []string         `json:"domains"`
+	Context         *json.RawMessage `json:"context"`
+	LifecycleStatus string           `json:"lifecycle_status"`
+	SupersededBy    *uuid.UUID       `json:"superseded_by"`
+	Relevance       float64          `json:"relevance"`
+	MatchedKeywords []string         `json:"matched_keywords,omitempty"`
 }
 
 // SmartSearchResponse 智慧搜尋回應
@@ -32,14 +40,16 @@ type SmartSearchResponse struct {
 
 // SimpleSearchResultItem 簡單搜尋結果項目
 type SimpleSearchResultItem struct {
-	EntryID         uuid.UUID  `json:"entry_id"`
-	Title           *string    `json:"title"`
-	Summary         *string    `json:"summary"`
-	ContentPreview  string     `json:"content_preview"`
-	Tags            []string   `json:"tags"`
-	LifecycleStatus string     `json:"lifecycle_status"`
-	SupersededBy    *uuid.UUID `json:"superseded_by"`
-	Relevance       float64    `json:"relevance"`
+	EntryID         uuid.UUID        `json:"entry_id"`
+	Title           *string          `json:"title"`
+	Summary         *string          `json:"summary"`
+	ContentPreview  string           `json:"content_preview"`
+	Tags            []string         `json:"tags"`
+	Domains         []string         `json:"domains"`
+	Context         *json.RawMessage `json:"context"`
+	LifecycleStatus string           `json:"lifecycle_status"`
+	SupersededBy    *uuid.UUID       `json:"superseded_by"`
+	Relevance       float64          `json:"relevance"`
 }
 
 // SimpleSearchResponse 簡單搜尋回應

--- a/dev/src/handler/entry.go
+++ b/dev/src/handler/entry.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"net/http"
 	"strconv"
+	"strings"
 
 	"github.com/gin-gonic/gin"
 	"github.com/google/uuid"
@@ -40,7 +41,7 @@ func (h *EntryHandler) Create(c *gin.Context) {
 		c.Request.Context(),
 		req.Title, req.Content, req.CategoryID,
 		req.Source, req.SourceType, req.SourceRef,
-		req.Tags,
+		req.Tags, req.Domains, req.Context,
 	)
 	if err != nil {
 		handleEntryError(c, err)
@@ -97,6 +98,23 @@ func (h *EntryHandler) List(c *gin.Context) {
 	// 解析 tag（可多個，AND 邏輯）
 	filter.Tags = c.QueryArray("tag")
 
+	// 解析 domain（可多個，AND 邏輯）
+	filter.Domains = c.QueryArray("domain")
+
+	// 解析 context.* 過濾參數
+	contextFilter := make(map[string][]string)
+	for key, values := range c.Request.URL.Query() {
+		if strings.HasPrefix(key, "context.") {
+			subKey := strings.TrimPrefix(key, "context.")
+			if subKey != "" {
+				contextFilter[subKey] = values
+			}
+		}
+	}
+	if len(contextFilter) > 0 {
+		filter.ContextFilter = contextFilter
+	}
+
 	// 解析 is_archived
 	if archivedStr := c.Query("is_archived"); archivedStr != "" {
 		archived, err := strconv.ParseBool(archivedStr)
@@ -141,6 +159,10 @@ func (h *EntryHandler) List(c *gin.Context) {
 		if tags == nil {
 			tags = []string{}
 		}
+		domains := item.Domains
+		if domains == nil {
+			domains = []string{}
+		}
 		items = append(items, dto.EntryListItemResponse{
 			ID:              item.ID,
 			Title:           item.Title,
@@ -148,6 +170,8 @@ func (h *EntryHandler) List(c *gin.Context) {
 			ContentPreview:  item.ContentPreview,
 			CategoryID:      item.CategoryID,
 			Tags:            tags,
+			Domains:         domains,
+			Context:         item.Context,
 			IsArchived:      item.IsArchived,
 			Confidence:      item.Confidence,
 			Confirmations:   item.Confirmations,
@@ -365,6 +389,40 @@ func (h *EntryHandler) Update(c *gin.Context) {
 		}
 	}
 
+	if v, ok := rawMap["domains"]; ok {
+		if string(v) == "null" {
+			updates["domains"] = nil
+		} else {
+			var domains []string
+			if err := json.Unmarshal(v, &domains); err != nil {
+				c.JSON(http.StatusBadRequest, dto.ErrorResponse{
+					Code:    model.ErrCodeInvalidInput,
+					Message: "domains 格式錯誤，須為字串陣列",
+				})
+				return
+			}
+			updates["domains"] = domains
+		}
+	}
+
+	if v, ok := rawMap["context"]; ok {
+		if string(v) == "null" {
+			updates["context"] = nil
+		} else {
+			// 驗證是合法 JSON object
+			var obj map[string]interface{}
+			if err := json.Unmarshal(v, &obj); err != nil {
+				c.JSON(http.StatusBadRequest, dto.ErrorResponse{
+					Code:    model.ErrCodeInvalidInput,
+					Message: "context 格式錯誤，須為 JSON 物件",
+				})
+				return
+			}
+			raw := json.RawMessage(v)
+			updates["context"] = &raw
+		}
+	}
+
 	if v, ok := rawMap["is_archived"]; ok {
 		var b bool
 		if err := json.Unmarshal(v, &b); err != nil {
@@ -408,6 +466,10 @@ func toEntryResponse(entry *model.Entry) dto.EntryResponse {
 	if tags == nil {
 		tags = []string{}
 	}
+	domains := entry.Domains
+	if domains == nil {
+		domains = []string{}
+	}
 	return dto.EntryResponse{
 		ID:              entry.ID,
 		Title:           entry.Title,
@@ -420,6 +482,8 @@ func toEntryResponse(entry *model.Entry) dto.EntryResponse {
 		SourceType:      entry.SourceType,
 		SourceRef:       entry.SourceRef,
 		Tags:            tags,
+		Domains:         domains,
+		Context:         entry.Context,
 		IsArchived:      entry.IsArchived,
 		Confidence:      entry.Confidence,
 		Confirmations:   entry.Confirmations,

--- a/dev/src/handler/search.go
+++ b/dev/src/handler/search.go
@@ -1,6 +1,7 @@
 package handler
 
 import (
+	"encoding/json"
 	"net/http"
 	"strconv"
 	"strings"
@@ -72,10 +73,32 @@ func (h *SearchHandler) SmartSearch(c *gin.Context) {
 		categoryID = &parsed
 	}
 
+	// 解析 context_filter 為 map[string][]string
+	contextFilter := make(map[string][]string)
+	for key, raw := range req.ContextFilter {
+		// 嘗試解析為 []string
+		var arr []string
+		if err := json.Unmarshal(raw, &arr); err != nil {
+			// 嘗試解析為 string
+			var s string
+			if err := json.Unmarshal(raw, &s); err != nil {
+				c.JSON(http.StatusBadRequest, dto.ErrorResponse{
+					Code:    model.ErrCodeInvalidInput,
+					Message: "context_filter 值格式錯誤，須為字串或字串陣列",
+				})
+				return
+			}
+			arr = []string{s}
+		}
+		contextFilter[key] = arr
+	}
+
 	result, err := h.searchSvc.SmartSearch(c.Request.Context(), service.SmartSearchInput{
-		Query:      req.Query,
-		CategoryID: categoryID,
-		Limit:      limit,
+		Query:         req.Query,
+		CategoryID:    categoryID,
+		Domains:       req.Domains,
+		ContextFilter: contextFilter,
+		Limit:         limit,
 	})
 	if err != nil {
 		handleSearchError(c, err)
@@ -89,12 +112,18 @@ func (h *SearchHandler) SmartSearch(c *gin.Context) {
 		if tags == nil {
 			tags = []string{}
 		}
+		domains := r.Domains
+		if domains == nil {
+			domains = []string{}
+		}
 		items = append(items, dto.SearchResultItem{
 			EntryID:         r.EntryID,
 			Title:           r.Title,
 			Summary:         r.Summary,
 			ContentPreview:  r.ContentPreview,
 			Tags:            tags,
+			Domains:         domains,
+			Context:         r.Context,
 			LifecycleStatus: r.LifecycleStatus,
 			SupersededBy:    r.SupersededBy,
 			Relevance:       r.Relevance,
@@ -144,6 +173,20 @@ func (h *SearchHandler) SimpleSearch(c *gin.Context) {
 	// 解析 tags
 	tags := c.QueryArray("tag")
 
+	// 解析 domains
+	domains := c.QueryArray("domain")
+
+	// 解析 context.* 過濾參數
+	simpleContextFilter := make(map[string][]string)
+	for key, values := range c.Request.URL.Query() {
+		if strings.HasPrefix(key, "context.") {
+			subKey := strings.TrimPrefix(key, "context.")
+			if subKey != "" {
+				simpleContextFilter[subKey] = values
+			}
+		}
+	}
+
 	// 解析 limit
 	limit := 10
 	if limitStr := c.Query("limit"); limitStr != "" {
@@ -173,11 +216,13 @@ func (h *SearchHandler) SimpleSearch(c *gin.Context) {
 	}
 
 	result, err := h.searchSvc.SimpleSearch(c.Request.Context(), service.SimpleSearchInput{
-		Query:      q,
-		CategoryID: categoryID,
-		Tags:       tags,
-		Limit:      limit,
-		Offset:     offset,
+		Query:         q,
+		CategoryID:    categoryID,
+		Tags:          tags,
+		Domains:       domains,
+		ContextFilter: simpleContextFilter,
+		Limit:         limit,
+		Offset:        offset,
 	})
 	if err != nil {
 		handleSearchError(c, err)
@@ -191,12 +236,18 @@ func (h *SearchHandler) SimpleSearch(c *gin.Context) {
 		if tags == nil {
 			tags = []string{}
 		}
+		domains := r.Domains
+		if domains == nil {
+			domains = []string{}
+		}
 		items = append(items, dto.SimpleSearchResultItem{
 			EntryID:         r.EntryID,
 			Title:           r.Title,
 			Summary:         r.Summary,
 			ContentPreview:  r.ContentPreview,
 			Tags:            tags,
+			Domains:         domains,
+			Context:         r.Context,
 			LifecycleStatus: r.LifecycleStatus,
 			SupersededBy:    r.SupersededBy,
 			Relevance:       r.Relevance,

--- a/dev/src/mcp/client.go
+++ b/dev/src/mcp/client.go
@@ -29,9 +29,11 @@ func NewClient(baseURL, apiKey string) *Client {
 
 // SearchRequest 搜尋請求
 type SearchRequest struct {
-	Query      string `json:"query"`
-	CategoryID string `json:"category_id,omitempty"`
-	Limit      int    `json:"limit,omitempty"`
+	Query      string   `json:"query"`
+	CategoryID string   `json:"category_id,omitempty"`
+	Domain     string   `json:"-"` // domain 透過 query param 傳遞，不在 JSON body
+	Limit      int      `json:"limit,omitempty"`
+	Domains    []string `json:"domains,omitempty"`
 }
 
 // SearchResponse 搜尋回應
@@ -136,6 +138,10 @@ type CategoryItem struct {
 
 // Search 搜尋知識庫
 func (c *Client) Search(req SearchRequest) (*SearchResponse, error) {
+	// 如果有 domain 參數，轉為 domains 陣列
+	if req.Domain != "" && len(req.Domains) == 0 {
+		req.Domains = []string{req.Domain}
+	}
 	body, err := json.Marshal(req)
 	if err != nil {
 		return nil, fmt.Errorf("序列化請求失敗: %w", err)

--- a/dev/src/mcp/tools.go
+++ b/dev/src/mcp/tools.go
@@ -28,6 +28,9 @@ func QueryTool() mcp.Tool {
 		mcp.WithString("category",
 			mcp.Description("限定分類名稱（可選）"),
 		),
+		mcp.WithString("domain",
+			mcp.Description("限定技術領域（可選，如 golang, postgresql, docker）"),
+		),
 		mcp.WithNumber("limit",
 			mcp.Description("回傳數量上限（預設 5，最大 20）"),
 		),
@@ -42,6 +45,7 @@ func (h *ToolHandlers) HandleQuery(ctx context.Context, req mcp.CallToolRequest)
 	}
 
 	category := mcp.ParseString(req, "category", "")
+	domain := mcp.ParseString(req, "domain", "")
 	limit := int(mcp.ParseInt64(req, "limit", 5))
 
 	if limit < 1 {
@@ -54,6 +58,7 @@ func (h *ToolHandlers) HandleQuery(ctx context.Context, req mcp.CallToolRequest)
 	searchReq := SearchRequest{
 		Query:      query,
 		CategoryID: category,
+		Domain:     domain,
 		Limit:      limit,
 	}
 

--- a/dev/src/migration/008_add_tags_hierarchy.down.sql
+++ b/dev/src/migration/008_add_tags_hierarchy.down.sql
@@ -1,0 +1,16 @@
+-- 還原 FTS 索引（移除 domains）
+DROP INDEX IF EXISTS idx_entries_fts;
+CREATE INDEX idx_entries_fts ON entries USING GIN (
+  (setweight(to_tsvector('simple', coalesce(summary, '')), 'A') ||
+   setweight(to_tsvector('simple', coalesce(title, '')), 'A') ||
+   setweight(to_tsvector('simple', coalesce(array_to_string(tags, ' '), '')), 'A') ||
+   setweight(to_tsvector('simple', coalesce(content, '')), 'B'))
+);
+
+-- 移除索引
+DROP INDEX IF EXISTS idx_entries_context;
+DROP INDEX IF EXISTS idx_entries_domains;
+
+-- 移除欄位
+ALTER TABLE entries DROP COLUMN IF EXISTS context;
+ALTER TABLE entries DROP COLUMN IF EXISTS domains;

--- a/dev/src/migration/008_add_tags_hierarchy.up.sql
+++ b/dev/src/migration/008_add_tags_hierarchy.up.sql
@@ -1,0 +1,19 @@
+-- 新增 domains TEXT[] 和 context JSONB 欄位
+ALTER TABLE entries ADD COLUMN domains TEXT[] DEFAULT '{}';
+ALTER TABLE entries ADD COLUMN context JSONB NULL;
+
+-- domains GIN 索引
+CREATE INDEX idx_entries_domains ON entries USING GIN (domains);
+
+-- context GIN 索引（jsonb_path_ops，支援 @> 查詢）
+CREATE INDEX idx_entries_context ON entries USING GIN (context jsonb_path_ops);
+
+-- 更新 FTS 索引：加入 domains 到權重 A
+DROP INDEX IF EXISTS idx_entries_fts;
+CREATE INDEX idx_entries_fts ON entries USING GIN (
+  (setweight(to_tsvector('simple', coalesce(summary, '')), 'A') ||
+   setweight(to_tsvector('simple', coalesce(title, '')), 'A') ||
+   setweight(to_tsvector('simple', coalesce(array_to_string(tags, ' '), '')), 'A') ||
+   setweight(to_tsvector('simple', coalesce(array_to_string(domains, ' '), '')), 'A') ||
+   setweight(to_tsvector('simple', coalesce(content, '')), 'B'))
+);

--- a/dev/src/model/entry.go
+++ b/dev/src/model/entry.go
@@ -1,6 +1,7 @@
 package model
 
 import (
+	"encoding/json"
 	"time"
 
 	"github.com/google/uuid"
@@ -18,8 +19,10 @@ type Entry struct {
 	Source        *string    `json:"source"`
 	SourceType    *string    `json:"source_type"`
 	SourceRef     *string    `json:"source_ref"`
-	Tags          []string   `json:"tags"`
-	IsArchived    bool       `json:"is_archived"`
+	Tags          []string         `json:"tags"`
+	Domains       []string         `json:"domains"`
+	Context       *json.RawMessage `json:"context"`
+	IsArchived    bool             `json:"is_archived"`
 	Confidence    float64    `json:"confidence"`
 	Confirmations int        `json:"confirmations"`
 	FlagsCount    int        `json:"flags_count"`
@@ -44,13 +47,15 @@ func (e *Entry) LifecycleStatus() string {
 
 // EntryListItem 列表查詢用的條目（content 改為 preview，不含 source 欄位）
 type EntryListItem struct {
-	ID             uuid.UUID  `json:"id"`
-	Title          *string    `json:"title"`
-	Summary        *string    `json:"summary"`
-	ContentPreview *string    `json:"content_preview"`
-	CategoryID     *uuid.UUID `json:"category_id"`
-	Tags           []string   `json:"tags"`
-	IsArchived     bool       `json:"is_archived"`
+	ID             uuid.UUID        `json:"id"`
+	Title          *string          `json:"title"`
+	Summary        *string          `json:"summary"`
+	ContentPreview *string          `json:"content_preview"`
+	CategoryID     *uuid.UUID       `json:"category_id"`
+	Tags           []string         `json:"tags"`
+	Domains        []string         `json:"domains"`
+	Context        *json.RawMessage `json:"context"`
+	IsArchived     bool             `json:"is_archived"`
 	Confidence     float64    `json:"confidence"`
 	Confirmations  int        `json:"confirmations"`
 	FlagsCount     int        `json:"flags_count"`
@@ -76,6 +81,8 @@ type EntryFilter struct {
 	PerPage         int
 	CategoryID      *string // "null" 表示未分類，UUID 字串表示特定分類
 	Tags            []string
+	Domains         []string            // domain 過濾（AND 邏輯）
+	ContextFilter   map[string][]string // context 子欄位過濾（如 languages=["go"]）
 	IsArchived      *bool
 	Search          string
 	Sort            string

--- a/dev/src/repository/entry.go
+++ b/dev/src/repository/entry.go
@@ -2,6 +2,7 @@ package repository
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"strings"
@@ -25,11 +26,11 @@ func NewEntryRepository(pool *pgxpool.Pool) *EntryRepository {
 // Create 建立新知識條目
 func (r *EntryRepository) Create(ctx context.Context, entry *model.Entry) error {
 	_, err := r.pool.Exec(ctx,
-		`INSERT INTO entries (id, title, content, summary, detail, action, category_id, source, source_type, source_ref, tags, is_archived, created_at, updated_at)
-		 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14)`,
+		`INSERT INTO entries (id, title, content, summary, detail, action, category_id, source, source_type, source_ref, tags, domains, context, is_archived, created_at, updated_at)
+		 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16)`,
 		entry.ID, entry.Title, entry.Content, entry.Summary, entry.Detail, entry.Action,
 		entry.CategoryID, entry.Source, entry.SourceType, entry.SourceRef,
-		entry.Tags, entry.IsArchived, entry.CreatedAt, entry.UpdatedAt,
+		entry.Tags, entry.Domains, entry.Context, entry.IsArchived, entry.CreatedAt, entry.UpdatedAt,
 	)
 	if err != nil {
 		if strings.Contains(err.Error(), "idx_entries_source") {
@@ -47,14 +48,14 @@ func (r *EntryRepository) Create(ctx context.Context, entry *model.Entry) error 
 func (r *EntryRepository) FindByID(ctx context.Context, id uuid.UUID) (*model.Entry, error) {
 	entry := &model.Entry{}
 	err := r.pool.QueryRow(ctx,
-		`SELECT id, title, content, summary, detail, action, category_id, source, source_type, source_ref, tags, is_archived,
+		`SELECT id, title, content, summary, detail, action, category_id, source, source_type, source_ref, tags, domains, context, is_archived,
 		        confidence, confirmations, flags_count, superseded_by, created_at, updated_at
 		 FROM entries WHERE id = $1`,
 		id,
 	).Scan(
 		&entry.ID, &entry.Title, &entry.Content, &entry.Summary, &entry.Detail, &entry.Action,
 		&entry.CategoryID, &entry.Source, &entry.SourceType, &entry.SourceRef,
-		&entry.Tags, &entry.IsArchived,
+		&entry.Tags, &entry.Domains, &entry.Context, &entry.IsArchived,
 		&entry.Confidence, &entry.Confirmations, &entry.FlagsCount, &entry.SupersededBy,
 		&entry.CreatedAt, &entry.UpdatedAt,
 	)
@@ -103,6 +104,22 @@ func (r *EntryRepository) List(ctx context.Context, filter model.EntryFilter) (*
 		argIdx++
 	}
 
+	// domain 過濾（AND 邏輯）
+	if len(filter.Domains) > 0 {
+		conditions = append(conditions, fmt.Sprintf("e.domains @> $%d::text[]", argIdx))
+		args = append(args, filter.Domains)
+		argIdx++
+	}
+
+	// context 子欄位過濾
+	for key, values := range filter.ContextFilter {
+		jsonObj := map[string][]string{key: values}
+		jsonBytes, _ := json.Marshal(jsonObj)
+		conditions = append(conditions, fmt.Sprintf("e.context @> $%d::jsonb", argIdx))
+		args = append(args, string(jsonBytes))
+		argIdx++
+	}
+
 	// lifecycle_status 過濾（計算欄位，用 SQL 條件實現）
 	if filter.LifecycleStatus != "" {
 		switch filter.LifecycleStatus {
@@ -127,6 +144,7 @@ func (r *EntryRepository) List(ctx context.Context, filter model.EntryFilter) (*
 			`((setweight(to_tsvector('simple', coalesce(e.summary, '')), 'A') ||
 			   setweight(to_tsvector('simple', coalesce(e.title, '')), 'A') ||
 			   setweight(to_tsvector('simple', coalesce(array_to_string(e.tags, ' '), '')), 'A') ||
+			   setweight(to_tsvector('simple', coalesce(array_to_string(e.domains, ' '), '')), 'A') ||
 			   setweight(to_tsvector('simple', coalesce(e.content, '')), 'B'))
 			  @@ plainto_tsquery('simple', $%d)
 			 OR (coalesce(e.summary,'') || ' ' || coalesce(e.title,'') || ' ' || coalesce(e.content,''))
@@ -153,6 +171,7 @@ func (r *EntryRepository) List(ctx context.Context, filter model.EntryFilter) (*
 			   setweight(to_tsvector('simple', coalesce(e.summary, '')), 'A') ||
 			   setweight(to_tsvector('simple', coalesce(e.title, '')), 'A') ||
 			   setweight(to_tsvector('simple', coalesce(array_to_string(e.tags, ' '), '')), 'A') ||
+			   setweight(to_tsvector('simple', coalesce(array_to_string(e.domains, ' '), '')), 'A') ||
 			   setweight(to_tsvector('simple', coalesce(e.content, '')), 'B'),
 			   plainto_tsquery('simple', $%d)
 			 ) * e.confidence) DESC, e.created_at DESC`, searchArgIdx)
@@ -191,7 +210,7 @@ func (r *EntryRepository) List(ctx context.Context, filter model.EntryFilter) (*
 	// 查詢資料（content_preview 用 LEFT(content, 200)，列表不含 source/source_type/source_ref）
 	dataQuery := fmt.Sprintf(
 		`SELECT e.id, e.title, e.summary, LEFT(e.content, 200) AS content_preview, e.category_id,
-		        e.tags, e.is_archived, e.confidence, e.confirmations, e.flags_count, e.superseded_by,
+		        e.tags, e.domains, e.context, e.is_archived, e.confidence, e.confirmations, e.flags_count, e.superseded_by,
 		        e.created_at, e.updated_at
 		 FROM entries e
 		 %s
@@ -212,7 +231,7 @@ func (r *EntryRepository) List(ctx context.Context, filter model.EntryFilter) (*
 		var item model.EntryListItem
 		if err := rows.Scan(
 			&item.ID, &item.Title, &item.Summary, &item.ContentPreview, &item.CategoryID,
-			&item.Tags, &item.IsArchived, &item.Confidence, &item.Confirmations, &item.FlagsCount, &item.SupersededBy,
+			&item.Tags, &item.Domains, &item.Context, &item.IsArchived, &item.Confidence, &item.Confirmations, &item.FlagsCount, &item.SupersededBy,
 			&item.CreatedAt, &item.UpdatedAt,
 		); err != nil {
 			return nil, err
@@ -240,11 +259,11 @@ func (r *EntryRepository) Update(ctx context.Context, entry *model.Entry) error 
 		`UPDATE entries
 		 SET title = $1, content = $2, summary = $3, detail = $4, action = $5,
 		     category_id = $6, source = $7, source_type = $8,
-		     source_ref = $9, tags = $10, is_archived = $11, updated_at = NOW()
-		 WHERE id = $12`,
+		     source_ref = $9, tags = $10, domains = $11, context = $12, is_archived = $13, updated_at = NOW()
+		 WHERE id = $14`,
 		entry.Title, entry.Content, entry.Summary, entry.Detail, entry.Action,
 		entry.CategoryID, entry.Source, entry.SourceType, entry.SourceRef,
-		entry.Tags, entry.IsArchived, entry.ID,
+		entry.Tags, entry.Domains, entry.Context, entry.IsArchived, entry.ID,
 	)
 	if err != nil {
 		if strings.Contains(err.Error(), "idx_entries_source") {
@@ -282,13 +301,13 @@ func (r *EntryRepository) ConfirmEntry(ctx context.Context, id uuid.UUID) (*mode
 		     confidence = LEAST(0.5 + (confirmations + 1) * 0.05 - flags_count * 0.1, 1.0),
 		     updated_at = NOW()
 		 WHERE id = $1
-		 RETURNING id, title, content, summary, detail, action, category_id, source, source_type, source_ref, tags, is_archived,
+		 RETURNING id, title, content, summary, detail, action, category_id, source, source_type, source_ref, tags, domains, context, is_archived,
 		           confidence, confirmations, flags_count, superseded_by, created_at, updated_at`,
 		id,
 	).Scan(
 		&entry.ID, &entry.Title, &entry.Content, &entry.Summary, &entry.Detail, &entry.Action,
 		&entry.CategoryID, &entry.Source, &entry.SourceType, &entry.SourceRef,
-		&entry.Tags, &entry.IsArchived,
+		&entry.Tags, &entry.Domains, &entry.Context, &entry.IsArchived,
 		&entry.Confidence, &entry.Confirmations, &entry.FlagsCount, &entry.SupersededBy,
 		&entry.CreatedAt, &entry.UpdatedAt,
 	)
@@ -332,13 +351,13 @@ func (r *EntryRepository) FlagEntry(ctx context.Context, id uuid.UUID, reason st
 		     confidence = GREATEST(0.5 + confirmations * 0.05 - (flags_count + 1) * 0.1, 0.0),
 		     updated_at = NOW()
 		 WHERE id = $1
-		 RETURNING id, title, content, summary, detail, action, category_id, source, source_type, source_ref, tags, is_archived,
+		 RETURNING id, title, content, summary, detail, action, category_id, source, source_type, source_ref, tags, domains, context, is_archived,
 		           confidence, confirmations, flags_count, superseded_by, created_at, updated_at`,
 		id,
 	).Scan(
 		&entry.ID, &entry.Title, &entry.Content, &entry.Summary, &entry.Detail, &entry.Action,
 		&entry.CategoryID, &entry.Source, &entry.SourceType, &entry.SourceRef,
-		&entry.Tags, &entry.IsArchived,
+		&entry.Tags, &entry.Domains, &entry.Context, &entry.IsArchived,
 		&entry.Confidence, &entry.Confirmations, &entry.FlagsCount, &entry.SupersededBy,
 		&entry.CreatedAt, &entry.UpdatedAt,
 	)

--- a/dev/src/repository/search.go
+++ b/dev/src/repository/search.go
@@ -2,6 +2,7 @@ package repository
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"strings"
 
@@ -24,6 +25,8 @@ type SearchResult struct {
 	Summary        *string
 	ContentPreview *string
 	Tags           []string
+	Domains        []string
+	Context        *json.RawMessage
 	Confidence     float64
 	SupersededBy   *uuid.UUID
 	Relevance      float64
@@ -41,11 +44,13 @@ func NewSearchRepository(pool *pgxpool.Pool) *SearchRepository {
 
 // SearchParams 搜尋參數
 type SearchParams struct {
-	Keywords   []string   // 搜尋關鍵字（原始 query + 同義詞）
-	CategoryID *uuid.UUID // 可選的分類過濾
-	Tags       []string   // 可選的 tag 過濾（AND 邏輯）
-	Limit      int        // 回傳數量上限
-	Offset     int        // 分頁偏移
+	Keywords      []string            // 搜尋關鍵字（原始 query + 同義詞）
+	CategoryID    *uuid.UUID          // 可選的分類過濾
+	Tags          []string            // 可選的 tag 過濾（AND 邏輯）
+	Domains       []string            // 可選的 domain 過濾（AND 邏輯）
+	ContextFilter map[string][]string // 可選的 context 子欄位過濾
+	Limit         int                 // 回傳數量上限
+	Offset        int                 // 分頁偏移
 }
 
 // Search 執行加權全文搜尋
@@ -72,6 +77,7 @@ func (r *SearchRepository) Search(ctx context.Context, params SearchParams) ([]S
 			`((setweight(to_tsvector('simple', coalesce(e.summary, '')), 'A') ||
 			   setweight(to_tsvector('simple', coalesce(e.title, '')), 'A') ||
 			   setweight(to_tsvector('simple', coalesce(array_to_string(e.tags, ' '), '')), 'A') ||
+			   setweight(to_tsvector('simple', coalesce(array_to_string(e.domains, ' '), '')), 'A') ||
 			   setweight(to_tsvector('simple', coalesce(e.content, '')), 'B'))
 			  @@ plainto_tsquery('simple', $%d)
 			 OR (coalesce(e.summary,'') || ' ' || coalesce(e.title,'') || ' ' || coalesce(e.content,''))
@@ -98,6 +104,22 @@ func (r *SearchRepository) Search(ctx context.Context, params SearchParams) ([]S
 		argIdx++
 	}
 
+	// domain 過濾（AND 邏輯）
+	if len(params.Domains) > 0 {
+		conditions = append(conditions, fmt.Sprintf("e.domains @> $%d::text[]", argIdx))
+		args = append(args, params.Domains)
+		argIdx++
+	}
+
+	// context 子欄位過濾
+	for key, values := range params.ContextFilter {
+		jsonObj := map[string][]string{key: values}
+		jsonBytes, _ := json.Marshal(jsonObj)
+		conditions = append(conditions, fmt.Sprintf("e.context @> $%d::jsonb", argIdx))
+		args = append(args, string(jsonBytes))
+		argIdx++
+	}
+
 	whereClause := "WHERE " + strings.Join(conditions, " AND ")
 
 	// 建構 ts_rank：取所有關鍵字中最高的 rank
@@ -108,6 +130,7 @@ func (r *SearchRepository) Search(ctx context.Context, params SearchParams) ([]S
 			   setweight(to_tsvector('simple', coalesce(e.summary, '')), 'A') ||
 			   setweight(to_tsvector('simple', coalesce(e.title, '')), 'A') ||
 			   setweight(to_tsvector('simple', coalesce(array_to_string(e.tags, ' '), '')), 'A') ||
+			   setweight(to_tsvector('simple', coalesce(array_to_string(e.domains, ' '), '')), 'A') ||
 			   setweight(to_tsvector('simple', coalesce(e.content, '')), 'B'),
 			   plainto_tsquery('simple', $%d)
 			 )`, kwIdx,
@@ -130,7 +153,7 @@ func (r *SearchRepository) Search(ctx context.Context, params SearchParams) ([]S
 	// 查詢資料（relevance = ts_rank * confidence）
 	dataQuery := fmt.Sprintf(
 		`SELECT e.id, e.title, e.summary, LEFT(e.content, 200) AS content_preview,
-		        e.tags, e.confidence, e.superseded_by, (%s * e.confidence) AS relevance
+		        e.tags, e.domains, e.context, e.confidence, e.superseded_by, (%s * e.confidence) AS relevance
 		 FROM entries e
 		 %s
 		 ORDER BY relevance DESC, e.created_at DESC
@@ -150,7 +173,7 @@ func (r *SearchRepository) Search(ctx context.Context, params SearchParams) ([]S
 		var item SearchResult
 		if err := rows.Scan(
 			&item.EntryID, &item.Title, &item.Summary, &item.ContentPreview,
-			&item.Tags, &item.Confidence, &item.SupersededBy, &item.Relevance,
+			&item.Tags, &item.Domains, &item.Context, &item.Confidence, &item.SupersededBy, &item.Relevance,
 		); err != nil {
 			return nil, 0, err
 		}

--- a/dev/src/service/classifier.go
+++ b/dev/src/service/classifier.go
@@ -76,6 +76,7 @@ func (s *ClassifierService) ClassifyEntry(ctx context.Context, entryID uuid.UUID
 		"entry_id", entryID,
 		"category", result.Category,
 		"tags", result.Tags,
+		"domains", result.Domains,
 		"title", result.Title,
 	)
 
@@ -91,6 +92,16 @@ func (s *ClassifierService) ClassifyEntry(ctx context.Context, entryID uuid.UUID
 	// tags 合併（union）
 	if len(result.Tags) > 0 {
 		entry.Tags = mergeTags(entry.Tags, result.Tags)
+	}
+
+	// domains 合併（union）
+	if len(result.Domains) > 0 {
+		entry.Domains = mergeTags(entry.Domains, result.Domains)
+	}
+
+	// context：LLM 產生時覆蓋（只在有值時覆蓋）
+	if result.Context != nil {
+		entry.Context = result.Context
 	}
 
 	// title 僅在原本為空時覆蓋
@@ -117,6 +128,7 @@ func (s *ClassifierService) ClassifyEntry(ctx context.Context, entryID uuid.UUID
 		"entry_id", entryID,
 		"category_id", categoryID,
 		"tags", entry.Tags,
+		"domains", entry.Domains,
 	)
 
 	return nil

--- a/dev/src/service/entry.go
+++ b/dev/src/service/entry.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"context"
+	"encoding/json"
 	"time"
 
 	"github.com/google/uuid"
@@ -21,7 +22,7 @@ func NewEntryService(repo *repository.EntryRepository) *EntryService {
 
 // Create 建立新知識條目
 func (s *EntryService) Create(ctx context.Context, title, content *string, categoryID *uuid.UUID,
-	source, sourceType, sourceRef *string, tags []string) (*model.Entry, error) {
+	source, sourceType, sourceRef *string, tags []string, domains []string, entryContext *json.RawMessage) (*model.Entry, error) {
 
 	// 驗證 title 和 content 至少一個非空
 	if (title == nil || *title == "") && (content == nil || *content == "") {
@@ -71,6 +72,9 @@ func (s *EntryService) Create(ctx context.Context, title, content *string, categ
 	if tags == nil {
 		tags = []string{}
 	}
+	if domains == nil {
+		domains = []string{}
+	}
 
 	now := time.Now().UTC()
 	entry := &model.Entry{
@@ -82,6 +86,8 @@ func (s *EntryService) Create(ctx context.Context, title, content *string, categ
 		SourceType:    sourceType,
 		SourceRef:     sourceRef,
 		Tags:          tags,
+		Domains:       domains,
+		Context:       entryContext,
 		IsArchived:    false,
 		Confidence:    0.5,
 		Confirmations: 0,
@@ -250,6 +256,22 @@ func (s *EntryService) Update(ctx context.Context, id uuid.UUID, updates map[str
 			existing.Tags = []string{}
 		} else {
 			existing.Tags = v.([]string)
+		}
+	}
+
+	if v, ok := updates["domains"]; ok {
+		if v == nil {
+			existing.Domains = []string{}
+		} else {
+			existing.Domains = v.([]string)
+		}
+	}
+
+	if v, ok := updates["context"]; ok {
+		if v == nil {
+			existing.Context = nil
+		} else {
+			existing.Context = v.(*json.RawMessage)
 		}
 	}
 

--- a/dev/src/service/llm.go
+++ b/dev/src/service/llm.go
@@ -39,6 +39,14 @@ const classifySystemPrompt = `你是一個知識分類助手。根據使用者�
 {
   "category": "分類名稱",
   "tags": ["tag1", "tag2"],
+  "domains": ["domain1", "domain2"],
+  "context": {
+    "languages": ["go", "python"],
+    "frameworks": ["gin"],
+    "pattern": "middleware",
+    "environment": "docker",
+    "use_case": "authentication"
+  },
   "title": "建議標題",
   "summary": "一句話摘要（30字以內）",
   "detail": "詳細說明（保留原始內容的關鍵資訊，100-300字）",
@@ -48,10 +56,18 @@ const classifySystemPrompt = `你是一個知識分類助手。根據使用者�
 規則：
 1. category：選擇最適合的分類名稱，簡潔明確
 2. tags：提取 2-5 個關鍵字作為標籤，使用小寫英文或中文
-3. title：根據內容產生一個簡潔的標題（不超過 50 字）
-4. summary：用一句話概括這則知識的核心觀點
-5. detail：萃取內容中的關鍵資訊、步驟或論點
-6. action：如果內容包含可操作的建議，提取為行動指引；如果是純知識性內容，寫「供參考」
+3. domains：提取 1-3 個技術領域標籤（如 golang, postgresql, docker, frontend, backend），使用小寫英文
+4. context：多維度情境標籤，只包含相關的 key：
+   - languages：程式語言（如 go, python, javascript）
+   - frameworks：框架（如 gin, fastapi, react）
+   - pattern：設計模式或架構模式（如 middleware, singleton, api-integration）
+   - environment：執行環境（如 docker, kubernetes, local）
+   - use_case：應用場景（如 authentication, logging, monitoring）
+   如果某個 key 不適用，省略該 key 即可
+5. title：根據內容產生一個簡潔的標題（不超過 50 字）
+6. summary：用一句話概括這則知識的核心觀點
+7. detail：萃取內容中的關鍵資訊、步驟或論點
+8. action：如果內容包含可操作的建議，提取為行動指引；如果是純知識性內容，寫「供參考」
 
 只回傳 JSON，不要包含任何其他文字、說明或 markdown 格式。`
 

--- a/dev/src/service/search.go
+++ b/dev/src/service/search.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"context"
+	"encoding/json"
 	"log/slog"
 	"strings"
 
@@ -26,9 +27,11 @@ func NewSearchService(llmSvc *LlmService, searchRepo *repository.SearchRepositor
 
 // SmartSearchInput 智慧搜尋輸入
 type SmartSearchInput struct {
-	Query      string
-	CategoryID *uuid.UUID
-	Limit      int
+	Query         string
+	CategoryID    *uuid.UUID
+	Domains       []string
+	ContextFilter map[string][]string
+	Limit         int
 }
 
 // SmartSearchOutput 智慧搜尋輸出
@@ -46,6 +49,8 @@ type SearchResultOutput struct {
 	Summary         *string
 	ContentPreview  string
 	Tags            []string
+	Domains         []string
+	Context         *json.RawMessage
 	LifecycleStatus string
 	SupersededBy    *uuid.UUID
 	Relevance       float64
@@ -54,11 +59,13 @@ type SearchResultOutput struct {
 
 // SimpleSearchInput 簡單搜尋輸入
 type SimpleSearchInput struct {
-	Query      string
-	CategoryID *uuid.UUID
-	Tags       []string
-	Limit      int
-	Offset     int
+	Query         string
+	CategoryID    *uuid.UUID
+	Tags          []string
+	Domains       []string
+	ContextFilter map[string][]string
+	Limit         int
+	Offset        int
 }
 
 // SimpleSearchOutput 簡單搜尋輸出
@@ -75,6 +82,8 @@ type SimpleSearchResultOutput struct {
 	Summary         *string
 	ContentPreview  string
 	Tags            []string
+	Domains         []string
+	Context         *json.RawMessage
 	LifecycleStatus string
 	SupersededBy    *uuid.UUID
 	Relevance       float64
@@ -121,10 +130,12 @@ func (s *SearchService) SmartSearch(ctx context.Context, input SmartSearchInput)
 
 	// 執行搜尋
 	results, total, err := s.searchRepo.Search(ctx, repository.SearchParams{
-		Keywords:   keywords,
-		CategoryID: input.CategoryID,
-		Limit:      input.Limit,
-		Offset:     0,
+		Keywords:      keywords,
+		CategoryID:    input.CategoryID,
+		Domains:       input.Domains,
+		ContextFilter: input.ContextFilter,
+		Limit:         input.Limit,
+		Offset:        0,
 	})
 	if err != nil {
 		return nil, err
@@ -151,6 +162,10 @@ func (s *SearchService) SmartSearch(ctx context.Context, input SmartSearchInput)
 		if tags == nil {
 			tags = []string{}
 		}
+		domains := r.Domains
+		if domains == nil {
+			domains = []string{}
+		}
 
 		item := SearchResultOutput{
 			EntryID:         r.EntryID,
@@ -158,6 +173,8 @@ func (s *SearchService) SmartSearch(ctx context.Context, input SmartSearchInput)
 			Summary:         r.Summary,
 			ContentPreview:  preview,
 			Tags:            tags,
+			Domains:         domains,
+			Context:         r.Context,
 			LifecycleStatus: computeLifecycleStatus(r.SupersededBy, r.Confidence),
 			SupersededBy:    r.SupersededBy,
 			Relevance:       r.Relevance,
@@ -188,11 +205,13 @@ func (s *SearchService) SimpleSearch(ctx context.Context, input SimpleSearchInpu
 	}
 
 	results, total, err := s.searchRepo.Search(ctx, repository.SearchParams{
-		Keywords:   []string{input.Query},
-		CategoryID: input.CategoryID,
-		Tags:       input.Tags,
-		Limit:      input.Limit,
-		Offset:     input.Offset,
+		Keywords:      []string{input.Query},
+		CategoryID:    input.CategoryID,
+		Tags:          input.Tags,
+		Domains:       input.Domains,
+		ContextFilter: input.ContextFilter,
+		Limit:         input.Limit,
+		Offset:        input.Offset,
 	})
 	if err != nil {
 		return nil, err
@@ -214,12 +233,18 @@ func (s *SearchService) SimpleSearch(ctx context.Context, input SimpleSearchInpu
 			tags = []string{}
 		}
 
+		domains := r.Domains
+		if domains == nil {
+			domains = []string{}
+		}
 		output.Results = append(output.Results, SimpleSearchResultOutput{
 			EntryID:         r.EntryID,
 			Title:           r.Title,
 			Summary:         r.Summary,
 			ContentPreview:  preview,
 			Tags:            tags,
+			Domains:         domains,
+			Context:         r.Context,
 			LifecycleStatus: computeLifecycleStatus(r.SupersededBy, r.Confidence),
 			SupersededBy:    r.SupersededBy,
 			Relevance:       r.Relevance,


### PR DESCRIPTION
## Summary
- 新增 `domains TEXT[]` + `context JSONB` 欄位，實現結構化 tag 分層架構
- 所有搜尋 API（智慧搜尋、簡單搜尋、列表）支援 domain/context 多維度過濾
- LLM 分類器更新，自動產生 domains + context，向下相容保留原有 tags

## Changes

### DB Migration (`008_add_tags_hierarchy`)
- `ALTER TABLE entries ADD COLUMN domains TEXT[] DEFAULT '{}'`
- `ALTER TABLE entries ADD COLUMN context JSONB NULL`
- GIN 索引：`idx_entries_domains`、`idx_entries_context`（jsonb_path_ops）
- FTS 索引更新：domains 加入權重 A

### Model + DTO
- `model/entry.go`：Entry、EntryListItem、EntryFilter 新增 Domains/Context/ContextFilter
- `dto/entry.go`：CreateEntryRequest、EntryResponse、EntryListItemResponse 新增 domains/context
- `dto/search.go`：SmartSearchRequest 新增 domains/context_filter，搜尋結果新增 domains/context
- `dto/llm.go`：ClassifyResult 新增 domains/context

### Repository
- `repository/entry.go`：Create/Update/FindByID/List SQL 加入 domains/context
- `repository/search.go`：Search 新增 domain GIN 過濾 + context @> jsonb 過濾

### Handler
- `handler/entry.go`：Create/Update/List 處理 domains/context 參數（含 `context.*` query params）
- `handler/search.go`：SmartSearch/SimpleSearch 處理 domain/context 過濾

### Service
- `service/entry.go`：Create 簽章新增 domains/context，Update 支援 domains/context
- `service/search.go`：SmartSearchInput/SimpleSearchInput 新增 Domains/ContextFilter
- `service/llm.go`：classifySystemPrompt 更新，產生 domains + context
- `service/classifier.go`：分類結果更新 entry 的 domains + context

### MCP
- `mcp/tools.go`：aibo_query tool 新增 domain 參數
- `mcp/client.go`：SearchRequest 新增 Domain/Domains

### Unit Tests
- `dev/__tests__/repository/entry_domains_test.go`：Model domains/context 欄位測試
- `dev/__tests__/handler/search_domains_test.go`：搜尋 DTO domains/context 序列化測試

## Test Plan
- [ ] 執行 migration 008 確認 DB schema 正確
- [ ] POST /api/v1/entries 帶 domains + context，確認 201 回傳
- [ ] GET /api/v1/entries?domain=golang 確認 domain 過濾
- [ ] GET /api/v1/search/simple?q=auth&domain=golang&context.languages=go 確認多維度過濾
- [ ] POST /api/v1/search 帶 domains + context_filter 確認過濾
- [ ] POST /api/v1/entries/:id/classify 確認 LLM 產生 domains + context
- [ ] 舊 entry 查詢確認 domains=[] + context=null（向下相容）

Closes #44

🤖 Generated with [Claude Code](https://claude.com/claude-code)