### PR TITLE
feat(F-017): LLM Client 連線池

### DIFF
--- a/dev/__tests__/service/llm_pool_test.go
+++ b/dev/__tests__/service/llm_pool_test.go
@@ -1,0 +1,124 @@
+package service_test
+
+import (
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/gpwork4u/aibo/model"
+	"github.com/gpwork4u/aibo/service"
+)
+
+func TestGetOrCreateClient_CacheHit(t *testing.T) {
+	svc := service.NewLlmService(nil, nil)
+
+	providerID := uuid.New()
+	provider := &model.LlmProvider{
+		ID:          providerID,
+		Name:        "test-provider",
+		EndpointURL: "https://api.example.com",
+		ModelName:   "gpt-4",
+	}
+
+	// 第一次呼叫應建立新 client
+	addr1 := svc.WarmClient(provider, "test-key")
+	if addr1 == "" {
+		t.Fatal("WarmClient 應回傳非空的位址字串")
+	}
+	if svc.ClientCacheLen() != 1 {
+		t.Errorf("快取大小應為 1，實際為 %d", svc.ClientCacheLen())
+	}
+
+	// 第二次呼叫應回傳相同的 client（cache hit）
+	addr2 := svc.WarmClient(provider, "test-key")
+	if addr1 != addr2 {
+		t.Errorf("相同 provider + 相同設定應回傳同一個 cached client，但得到 %s vs %s", addr1, addr2)
+	}
+	if svc.ClientCacheLen() != 1 {
+		t.Errorf("cache hit 後快取大小仍應為 1，實際為 %d", svc.ClientCacheLen())
+	}
+}
+
+func TestGetOrCreateClient_CacheMiss(t *testing.T) {
+	svc := service.NewLlmService(nil, nil)
+
+	p1 := &model.LlmProvider{
+		ID:          uuid.New(),
+		Name:        "provider-1",
+		EndpointURL: "https://api1.example.com",
+		ModelName:   "gpt-4",
+	}
+	p2 := &model.LlmProvider{
+		ID:          uuid.New(),
+		Name:        "provider-2",
+		EndpointURL: "https://api2.example.com",
+		ModelName:   "gpt-4",
+	}
+
+	addr1 := svc.WarmClient(p1, "key-1")
+	addr2 := svc.WarmClient(p2, "key-2")
+
+	if addr1 == addr2 {
+		t.Error("不同 provider 應回傳不同的 cached client")
+	}
+	if svc.ClientCacheLen() != 2 {
+		t.Errorf("快取大小應為 2，實際為 %d", svc.ClientCacheLen())
+	}
+}
+
+func TestInvalidateClient_RemovesFromCache(t *testing.T) {
+	svc := service.NewLlmService(nil, nil)
+
+	providerID := uuid.New()
+	provider := &model.LlmProvider{
+		ID:          providerID,
+		Name:        "test-provider",
+		EndpointURL: "https://api.example.com",
+		ModelName:   "gpt-4",
+	}
+
+	addr1 := svc.WarmClient(provider, "test-key")
+	if !svc.HasCachedClient(providerID) {
+		t.Fatal("WarmClient 後應有快取")
+	}
+
+	// 清除快取
+	svc.InvalidateClient(providerID)
+	if svc.HasCachedClient(providerID) {
+		t.Error("InvalidateClient 後不應有快取")
+	}
+	if svc.ClientCacheLen() != 0 {
+		t.Errorf("InvalidateClient 後快取大小應為 0，實際為 %d", svc.ClientCacheLen())
+	}
+
+	// 再次取得，應建立新的 client
+	addr2 := svc.WarmClient(provider, "test-key")
+	if addr1 == addr2 {
+		t.Error("InvalidateClient 後應建立新的 client 實例")
+	}
+}
+
+func TestConfigChange_RecreatesClient(t *testing.T) {
+	svc := service.NewLlmService(nil, nil)
+
+	providerID := uuid.New()
+	provider := &model.LlmProvider{
+		ID:          providerID,
+		Name:        "test-provider",
+		EndpointURL: "https://api.example.com",
+		ModelName:   "gpt-4",
+	}
+
+	// 使用 key-1 建立
+	addr1 := svc.WarmClient(provider, "key-1")
+
+	// 使用不同的 api key（模擬設定變更），configHash 不同應重建
+	addr2 := svc.WarmClient(provider, "key-2")
+
+	if addr1 == addr2 {
+		t.Error("config 變更（不同 apiKey）後應建立新的 client")
+	}
+	// 快取大小仍為 1（舊的被替換）
+	if svc.ClientCacheLen() != 1 {
+		t.Errorf("config 變更後快取大小應為 1，實際為 %d", svc.ClientCacheLen())
+	}
+}

--- a/dev/src/main.go
+++ b/dev/src/main.go
@@ -80,8 +80,9 @@ func main() {
 	entryRepo := repository.NewEntryRepository(pool)
 	entrySvc := service.NewEntryService(entryRepo)
 
-	// 初始化 LLM 分類服務
+	// 初始化 LLM 分類服務（含 client 連線池）
 	llmSvc := service.NewLlmService(llmProviderSvc, aesCrypto)
+	llmProviderSvc.SetLlmService(llmSvc) // 反向參考：provider 更新/刪除時清除 client 快取
 	classifierSvc := service.NewClassifierService(llmSvc, entryRepo, categoryRepo)
 	classifierWorker := service.NewClassifierWorker(classifierSvc)
 	classifierWorker.Start()

--- a/dev/src/service/apikey.go
+++ b/dev/src/service/apikey.go
@@ -12,7 +12,6 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/gpwork4u/aibo/model"
-	"github.com/gpwork4u/aibo/repository"
 )
 
 const (
@@ -23,11 +22,11 @@ const (
 
 // ApiKeyService API Key 業務邏輯
 type ApiKeyService struct {
-	repo *repository.ApiKeyRepository
+	repo ApiKeyRepository
 }
 
 // NewApiKeyService 建立新的 ApiKeyService
-func NewApiKeyService(repo *repository.ApiKeyRepository) *ApiKeyService {
+func NewApiKeyService(repo ApiKeyRepository) *ApiKeyService {
 	return &ApiKeyService{repo: repo}
 }
 

--- a/dev/src/service/category.go
+++ b/dev/src/service/category.go
@@ -6,16 +6,15 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/gpwork4u/aibo/model"
-	"github.com/gpwork4u/aibo/repository"
 )
 
 // CategoryService 分類業務邏輯
 type CategoryService struct {
-	repo *repository.CategoryRepository
+	repo CategoryRepository
 }
 
 // NewCategoryService 建立新的 CategoryService
-func NewCategoryService(repo *repository.CategoryRepository) *CategoryService {
+func NewCategoryService(repo CategoryRepository) *CategoryService {
 	return &CategoryService{repo: repo}
 }
 

--- a/dev/src/service/classifier.go
+++ b/dev/src/service/classifier.go
@@ -9,25 +9,24 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/gpwork4u/aibo/model"
-	"github.com/gpwork4u/aibo/repository"
 )
 
 // ClassifierService 自動分類業務邏輯
 type ClassifierService struct {
-	llmSvc      *LlmService
-	entryRepo   *repository.EntryRepository
-	categoryRepo *repository.CategoryRepository
+	llmSvc       *LlmService
+	entryRepo    EntryRepository
+	categoryRepo CategoryRepository
 }
 
 // NewClassifierService 建立新的 ClassifierService
 func NewClassifierService(
 	llmSvc *LlmService,
-	entryRepo *repository.EntryRepository,
-	categoryRepo *repository.CategoryRepository,
+	entryRepo EntryRepository,
+	categoryRepo CategoryRepository,
 ) *ClassifierService {
 	return &ClassifierService{
-		llmSvc:      llmSvc,
-		entryRepo:   entryRepo,
+		llmSvc:       llmSvc,
+		entryRepo:    entryRepo,
 		categoryRepo: categoryRepo,
 	}
 }

--- a/dev/src/service/entry.go
+++ b/dev/src/service/entry.go
@@ -7,16 +7,15 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/gpwork4u/aibo/model"
-	"github.com/gpwork4u/aibo/repository"
 )
 
 // EntryService 知識條目業務邏輯
 type EntryService struct {
-	repo *repository.EntryRepository
+	repo EntryRepository
 }
 
 // NewEntryService 建立新的 EntryService
-func NewEntryService(repo *repository.EntryRepository) *EntryService {
+func NewEntryService(repo EntryRepository) *EntryService {
 	return &EntryService{repo: repo}
 }
 

--- a/dev/src/service/gcal.go
+++ b/dev/src/service/gcal.go
@@ -12,7 +12,6 @@ import (
 	"github.com/google/uuid"
 	"github.com/gpwork4u/aibo/crypto"
 	"github.com/gpwork4u/aibo/model"
-	"github.com/gpwork4u/aibo/repository"
 	"golang.org/x/oauth2"
 	"golang.org/x/oauth2/google"
 	"google.golang.org/api/calendar/v3"
@@ -30,16 +29,16 @@ type GcalConfig struct {
 
 // GcalService Google Calendar 整合服務
 type GcalService struct {
-	gcalRepo  *repository.GcalIntegrationRepository
-	entryRepo *repository.EntryRepository
+	gcalRepo  GcalIntegrationRepository
+	entryRepo EntryRepository
 	aesCrypto *crypto.AESCrypto
 	config    *GcalConfig
 }
 
 // NewGcalService 建立新的 GcalService
 func NewGcalService(
-	gcalRepo *repository.GcalIntegrationRepository,
-	entryRepo *repository.EntryRepository,
+	gcalRepo GcalIntegrationRepository,
+	entryRepo EntryRepository,
 	aesCrypto *crypto.AESCrypto,
 	config *GcalConfig,
 ) *GcalService {

--- a/dev/src/service/git_import.go
+++ b/dev/src/service/git_import.go
@@ -16,7 +16,6 @@ import (
 	"github.com/google/uuid"
 	"github.com/gpwork4u/aibo/dto"
 	"github.com/gpwork4u/aibo/model"
-	"github.com/gpwork4u/aibo/repository"
 )
 
 const (
@@ -32,12 +31,12 @@ var (
 
 // GitImportService Git 匯入業務邏輯
 type GitImportService struct {
-	entryRepo        *repository.EntryRepository
+	entryRepo        EntryRepository
 	allowedRepoPaths []string
 }
 
 // NewGitImportService 建立新的 GitImportService
-func NewGitImportService(entryRepo *repository.EntryRepository) *GitImportService {
+func NewGitImportService(entryRepo EntryRepository) *GitImportService {
 	return &GitImportService{entryRepo: entryRepo}
 }
 

--- a/dev/src/service/interfaces.go
+++ b/dev/src/service/interfaces.go
@@ -1,0 +1,115 @@
+package service
+
+import (
+	"context"
+
+	"github.com/google/uuid"
+	"github.com/gpwork4u/aibo/model"
+	"github.com/gpwork4u/aibo/repository"
+	"github.com/jackc/pgx/v5"
+)
+
+// EntryRepository defines the interface for entry data access.
+// Used by: EntryService, ClassifierService, GitImportService, GcalService, LifecycleService
+type EntryRepository interface {
+	Create(ctx context.Context, entry *model.Entry) error
+	FindByID(ctx context.Context, id uuid.UUID) (*model.Entry, error)
+	List(ctx context.Context, filter model.EntryFilter) (*model.EntryListResult, error)
+	Update(ctx context.Context, entry *model.Entry) error
+	Delete(ctx context.Context, id uuid.UUID) error
+	ConfirmEntry(ctx context.Context, id uuid.UUID) (*model.Entry, error)
+	FlagEntry(ctx context.Context, id uuid.UUID, reason string, note *string) (*model.Entry, *model.EntryFlag, error)
+	GetFlags(ctx context.Context, entryID uuid.UUID) ([]model.EntryFlag, error)
+	ExistsBySourceRef(ctx context.Context, sourceType, sourceRef string) (bool, error)
+	CategoryExists(ctx context.Context, id uuid.UUID) (bool, error)
+	// Lifecycle methods (defined in repository/lifecycle.go on EntryRepository)
+	SupersedeEntry(ctx context.Context, oldID, newID uuid.UUID) (*model.Entry, error)
+	ClearSupersede(ctx context.Context, id uuid.UUID) (*model.Entry, error)
+	GetSupersedeChain(ctx context.Context, id uuid.UUID) ([]repository.HistoryItem, error)
+	CheckCircularSupersede(ctx context.Context, oldID, newID uuid.UUID) (bool, error)
+}
+
+// CategoryRepository defines the interface for category data access.
+// Used by: CategoryService, ClassifierService
+type CategoryRepository interface {
+	Create(ctx context.Context, cat *model.Category) error
+	FindByID(ctx context.Context, id uuid.UUID) (*model.Category, error)
+	List(ctx context.Context) ([]model.Category, error)
+	Update(ctx context.Context, cat *model.Category) error
+	Delete(ctx context.Context, id uuid.UUID) error
+	ExistsByID(ctx context.Context, id uuid.UUID) (bool, error)
+}
+
+// SearchRepository defines the interface for search data access.
+// Used by: SearchService
+type SearchRepository interface {
+	Search(ctx context.Context, params repository.SearchParams) ([]repository.SearchResult, int, error)
+}
+
+// LlmProviderRepository defines the interface for LLM provider data access.
+// Used by: LlmProviderService
+type LlmProviderRepository interface {
+	Create(ctx context.Context, provider *model.LlmProvider) error
+	CreateTx(ctx context.Context, tx pgx.Tx, provider *model.LlmProvider) error
+	FindByID(ctx context.Context, id uuid.UUID) (*model.LlmProvider, error)
+	List(ctx context.Context) ([]model.LlmProvider, error)
+	Update(ctx context.Context, provider *model.LlmProvider) error
+	UpdateTx(ctx context.Context, tx pgx.Tx, provider *model.LlmProvider) error
+	Delete(ctx context.Context, id uuid.UUID) error
+	BeginTx(ctx context.Context) (pgx.Tx, error)
+	ClearDefault(ctx context.Context, tx pgx.Tx) error
+	SetDefault(ctx context.Context, tx pgx.Tx, id uuid.UUID) error
+	FindDefaultActive(ctx context.Context) (*model.LlmProvider, error)
+	FindAnyActive(ctx context.Context) (*model.LlmProvider, error)
+}
+
+// GcalIntegrationRepository defines the interface for Google Calendar integration data access.
+// Used by: GcalService
+type GcalIntegrationRepository interface {
+	Get(ctx context.Context) (*model.GcalIntegration, error)
+	Upsert(ctx context.Context, integration *model.GcalIntegration) error
+	UpdateTokens(ctx context.Context, id interface{}, accessToken, refreshToken string, expiry interface{}) error
+	SaveOAuthState(ctx context.Context, state string) error
+	ValidateOAuthState(ctx context.Context, state string) (bool, error)
+	CleanExpiredOAuthStates(ctx context.Context) error
+}
+
+// ApiKeyRepository defines the interface for API key data access.
+// Used by: ApiKeyService
+type ApiKeyRepository interface {
+	Count(ctx context.Context) (int, error)
+	CountActiveValid(ctx context.Context) (int, error)
+	Create(ctx context.Context, apiKey *model.ApiKey) error
+	FindByKeyHash(ctx context.Context, keyHash string) (*model.ApiKey, error)
+	FindByID(ctx context.Context, id uuid.UUID) (*model.ApiKey, error)
+	List(ctx context.Context) ([]model.ApiKey, error)
+	Delete(ctx context.Context, id uuid.UUID) error
+	UpdateLastUsedAt(ctx context.Context, id uuid.UUID) error
+}
+
+// StatsRepository defines the interface for statistics data access.
+// Used by: StatsService
+type StatsRepository interface {
+	GetTotalEntries(ctx context.Context) (int, error)
+	GetTotalCategories(ctx context.Context) (int, error)
+	GetEntriesByCategory(ctx context.Context) ([]repository.CategoryCount, error)
+	GetAvgConfidence(ctx context.Context) (float64, error)
+	GetRecentEntries(ctx context.Context) ([]repository.RecentEntry, error)
+}
+
+// SystemRepository defines the interface for system information data access.
+// Used by: SystemService
+type SystemRepository interface {
+	ExtensionInstalled(ctx context.Context, extName string) (bool, error)
+}
+
+// Compile-time interface satisfaction checks.
+// These ensure that the concrete repository structs implement the interfaces.
+var _ EntryRepository = (*repository.EntryRepository)(nil)
+var _ CategoryRepository = (*repository.CategoryRepository)(nil)
+var _ SearchRepository = (*repository.SearchRepository)(nil)
+var _ LlmProviderRepository = (*repository.LlmProviderRepository)(nil)
+var _ GcalIntegrationRepository = (*repository.GcalIntegrationRepository)(nil)
+var _ ApiKeyRepository = (*repository.ApiKeyRepository)(nil)
+var _ StatsRepository = (*repository.StatsRepository)(nil)
+var _ SystemRepository = (*repository.SystemRepository)(nil)

--- a/dev/src/service/lifecycle.go
+++ b/dev/src/service/lifecycle.go
@@ -11,11 +11,11 @@ import (
 
 // LifecycleService 知識生命週期業務邏輯
 type LifecycleService struct {
-	repo *repository.EntryRepository
+	repo EntryRepository
 }
 
 // NewLifecycleService 建立新的 LifecycleService
-func NewLifecycleService(repo *repository.EntryRepository) *LifecycleService {
+func NewLifecycleService(repo EntryRepository) *LifecycleService {
 	return &LifecycleService{repo: repo}
 }
 

--- a/dev/src/service/llm.go
+++ b/dev/src/service/llm.go
@@ -2,12 +2,17 @@ package service
 
 import (
 	"context"
+	"crypto/sha256"
 	"encoding/json"
 	"fmt"
 	"log/slog"
+	"net"
+	"net/http"
 	"strings"
+	"sync"
 	"time"
 
+	"github.com/google/uuid"
 	openai "github.com/sashabaranov/go-openai"
 	"golang.org/x/time/rate"
 
@@ -16,11 +21,30 @@ import (
 	"github.com/gpwork4u/aibo/model"
 )
 
+// cachedClient 快取的 openai client 與 per-provider rate limiter
+type cachedClient struct {
+	client     *openai.Client
+	limiter    *rate.Limiter
+	configHash string // sha256(endpointURL + apiKey)，用於偵測設定變更
+}
+
+// sharedTransport 所有 client 共用的 HTTP Transport，啟用連線池
+var sharedTransport = &http.Transport{
+	MaxIdleConns:        100,
+	MaxIdleConnsPerHost: 10,
+	IdleConnTimeout:     90 * time.Second,
+	DialContext: (&net.Dialer{
+		Timeout:   30 * time.Second,
+		KeepAlive: 30 * time.Second,
+	}).DialContext,
+}
+
 // LlmService 統一的 LLM 呼叫介面
 type LlmService struct {
 	providerSvc *LlmProviderService
 	crypto      *crypto.AESCrypto
-	limiter     *rate.Limiter
+	mu          sync.RWMutex
+	clients     map[uuid.UUID]*cachedClient
 }
 
 // NewLlmService 建立新的 LlmService
@@ -28,8 +52,86 @@ func NewLlmService(providerSvc *LlmProviderService, aesCrypto *crypto.AESCrypto)
 	return &LlmService{
 		providerSvc: providerSvc,
 		crypto:      aesCrypto,
-		limiter:     rate.NewLimiter(rate.Every(time.Second), 5), // 每秒最多 5 個請求
+		clients:     make(map[uuid.UUID]*cachedClient),
 	}
+}
+
+// InvalidateClient 清除指定 provider 的快取 client
+// 當 provider 設定變更或刪除時呼叫
+func (s *LlmService) InvalidateClient(providerID uuid.UUID) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	delete(s.clients, providerID)
+	slog.Info("已清除 LLM client 快取", "provider_id", providerID)
+}
+
+// getOrCreateClient 取得或建立 openai client（含 per-provider rate limiter）
+func (s *LlmService) getOrCreateClient(provider *model.LlmProvider, apiKey string) *cachedClient {
+	hash := computeConfigHash(provider.EndpointURL, apiKey)
+
+	// 先用 RLock 查快取
+	s.mu.RLock()
+	if cached, ok := s.clients[provider.ID]; ok && cached.configHash == hash {
+		s.mu.RUnlock()
+		return cached
+	}
+	s.mu.RUnlock()
+
+	// cache miss 或 config 已變更，用 Lock 建立新的
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	// double-check（避免多個 goroutine 同時 miss）
+	if cached, ok := s.clients[provider.ID]; ok && cached.configHash == hash {
+		return cached
+	}
+
+	config := openai.DefaultConfig(apiKey)
+	config.BaseURL = strings.TrimRight(provider.EndpointURL, "/")
+	if !strings.HasSuffix(config.BaseURL, "/v1") {
+		config.BaseURL = config.BaseURL + "/v1"
+	}
+	config.HTTPClient = &http.Client{
+		Transport: sharedTransport,
+	}
+
+	cached := &cachedClient{
+		client:     openai.NewClientWithConfig(config),
+		limiter:    rate.NewLimiter(rate.Every(time.Second), 5), // 每個 provider 每秒最多 5 個請求
+		configHash: hash,
+	}
+	s.clients[provider.ID] = cached
+
+	slog.Info("建立新的 LLM client", "provider_id", provider.ID, "provider_name", provider.Name)
+	return cached
+}
+
+// computeConfigHash 計算 provider 設定的 hash，用於偵測變更
+func computeConfigHash(endpointURL, apiKey string) string {
+	h := sha256.Sum256([]byte(endpointURL + "|" + apiKey))
+	return fmt.Sprintf("%x", h)
+}
+
+// ClientCacheLen 回傳目前快取的 client 數量（供測試使用）
+func (s *LlmService) ClientCacheLen() int {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return len(s.clients)
+}
+
+// HasCachedClient 檢查指定 provider 是否有快取的 client（供測試使用）
+func (s *LlmService) HasCachedClient(providerID uuid.UUID) bool {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	_, ok := s.clients[providerID]
+	return ok
+}
+
+// WarmClient 預熱指定 provider 的 client 快取（供測試和外部呼叫）
+// 回傳 client 實例的指標位址字串，相同字串代表同一個 cached client
+func (s *LlmService) WarmClient(provider *model.LlmProvider, apiKey string) string {
+	c := s.getOrCreateClient(provider, apiKey)
+	return fmt.Sprintf("%p", c)
 }
 
 // classifySystemPrompt 分類用的 system prompt
@@ -79,7 +181,7 @@ func (s *LlmService) Classify(ctx context.Context, content string, existingCateg
 		return nil, fmt.Errorf("取得 LLM provider 失敗: %w", err)
 	}
 
-	// 解密 api_key
+	// 解密 api_key 並取得快取 client
 	apiKey := ""
 	if provider.ApiKey != nil && *provider.ApiKey != "" {
 		decrypted, err := s.crypto.Decrypt(*provider.ApiKey)
@@ -89,13 +191,7 @@ func (s *LlmService) Classify(ctx context.Context, content string, existingCateg
 		apiKey = decrypted
 	}
 
-	// 建立 go-openai client
-	config := openai.DefaultConfig(apiKey)
-	config.BaseURL = strings.TrimRight(provider.EndpointURL, "/")
-	if !strings.HasSuffix(config.BaseURL, "/v1") {
-		config.BaseURL = config.BaseURL + "/v1"
-	}
-	client := openai.NewClientWithConfig(config)
+	cached := s.getOrCreateClient(provider, apiKey)
 
 	// 組裝 user prompt
 	userPrompt := content
@@ -116,8 +212,8 @@ func (s *LlmService) Classify(ctx context.Context, content string, existingCateg
 	callCtx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
 
-	// 等待 rate limiter
-	if err := s.limiter.Wait(callCtx); err != nil {
+	// 等待 per-provider rate limiter
+	if err := cached.limiter.Wait(callCtx); err != nil {
 		return nil, fmt.Errorf("rate limit 等待取消: %w", err)
 	}
 
@@ -126,7 +222,7 @@ func (s *LlmService) Classify(ctx context.Context, content string, existingCateg
 		"model", provider.ModelName,
 	)
 
-	resp, err := client.CreateChatCompletion(callCtx, openai.ChatCompletionRequest{
+	resp, err := cached.client.CreateChatCompletion(callCtx, openai.ChatCompletionRequest{
 		Model: provider.ModelName,
 		Messages: []openai.ChatCompletionMessage{
 			{Role: openai.ChatMessageRoleSystem, Content: classifySystemPrompt},
@@ -174,7 +270,7 @@ func (s *LlmService) ExpandSynonyms(ctx context.Context, query string) ([]string
 		return nil, fmt.Errorf("無可用的 LLM Provider: %w", err)
 	}
 
-	// 解密 api_key
+	// 解密 api_key 並取得快取 client
 	apiKey := ""
 	if provider.ApiKey != nil && *provider.ApiKey != "" {
 		decrypted, err := s.crypto.Decrypt(*provider.ApiKey)
@@ -184,20 +280,14 @@ func (s *LlmService) ExpandSynonyms(ctx context.Context, query string) ([]string
 		apiKey = decrypted
 	}
 
-	// 建立 go-openai client
-	clientConfig := openai.DefaultConfig(apiKey)
-	clientConfig.BaseURL = strings.TrimRight(provider.EndpointURL, "/")
-	if !strings.HasSuffix(clientConfig.BaseURL, "/v1") {
-		clientConfig.BaseURL = clientConfig.BaseURL + "/v1"
-	}
-	client := openai.NewClientWithConfig(clientConfig)
+	cached := s.getOrCreateClient(provider, apiKey)
 
 	// 設定 10 秒 timeout
 	callCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
 	defer cancel()
 
-	// 等待 rate limiter
-	if err := s.limiter.Wait(callCtx); err != nil {
+	// 等待 per-provider rate limiter
+	if err := cached.limiter.Wait(callCtx); err != nil {
 		return nil, fmt.Errorf("rate limit 等待取消: %w", err)
 	}
 
@@ -209,7 +299,7 @@ func (s *LlmService) ExpandSynonyms(ctx context.Context, query string) ([]string
 		"query", query,
 	)
 
-	resp, err := client.CreateChatCompletion(callCtx, openai.ChatCompletionRequest{
+	resp, err := cached.client.CreateChatCompletion(callCtx, openai.ChatCompletionRequest{
 		Model: provider.ModelName,
 		Messages: []openai.ChatCompletionMessage{
 			{Role: openai.ChatMessageRoleSystem, Content: synonymSystemPrompt},

--- a/dev/src/service/llm_provider.go
+++ b/dev/src/service/llm_provider.go
@@ -22,6 +22,7 @@ import (
 type LlmProviderService struct {
 	repo   *repository.LlmProviderRepository
 	crypto *crypto.AESCrypto
+	llmSvc *LlmService // 反向參考，用於在 Update/Delete 時清除 client 快取
 }
 
 // NewLlmProviderService 建立新的 LlmProviderService
@@ -30,6 +31,11 @@ func NewLlmProviderService(repo *repository.LlmProviderRepository, aesCrypto *cr
 		repo:   repo,
 		crypto: aesCrypto,
 	}
+}
+
+// SetLlmService 設定 LlmService 反向參考（避免循環依賴）
+func (s *LlmProviderService) SetLlmService(llmSvc *LlmService) {
+	s.llmSvc = llmSvc
 }
 
 // CreateInput 建立 LLM Provider 的輸入
@@ -196,12 +202,21 @@ func (s *LlmProviderService) Update(ctx context.Context, id uuid.UUID, input Upd
 		}
 	}
 
+	// 清除該 provider 的 client 快取（設定可能已變更）
+	if s.llmSvc != nil {
+		s.llmSvc.InvalidateClient(id)
+	}
+
 	// 重新取得更新後的資料
 	return s.repo.FindByID(ctx, id)
 }
 
 // Delete 刪除 LLM Provider（硬刪除）
 func (s *LlmProviderService) Delete(ctx context.Context, id uuid.UUID) error {
+	// 清除該 provider 的 client 快取
+	if s.llmSvc != nil {
+		s.llmSvc.InvalidateClient(id)
+	}
 	return s.repo.Delete(ctx, id)
 }
 

--- a/dev/src/service/search.go
+++ b/dev/src/service/search.go
@@ -14,11 +14,11 @@ import (
 // SearchService 搜尋業務邏輯
 type SearchService struct {
 	llmSvc     *LlmService
-	searchRepo *repository.SearchRepository
+	searchRepo SearchRepository
 }
 
 // NewSearchService 建立新的 SearchService
-func NewSearchService(llmSvc *LlmService, searchRepo *repository.SearchRepository) *SearchService {
+func NewSearchService(llmSvc *LlmService, searchRepo SearchRepository) *SearchService {
 	return &SearchService{
 		llmSvc:     llmSvc,
 		searchRepo: searchRepo,

--- a/dev/src/service/stats.go
+++ b/dev/src/service/stats.go
@@ -2,8 +2,6 @@ package service
 
 import (
 	"context"
-
-	"github.com/gpwork4u/aibo/repository"
 )
 
 // StatsResult 統計結果
@@ -30,11 +28,11 @@ type RecentEntryResult struct {
 
 // StatsService 統計業務邏輯
 type StatsService struct {
-	repo *repository.StatsRepository
+	repo StatsRepository
 }
 
 // NewStatsService 建立新的 StatsService
-func NewStatsService(repo *repository.StatsRepository) *StatsService {
+func NewStatsService(repo StatsRepository) *StatsService {
 	return &StatsService{repo: repo}
 }
 

--- a/dev/src/service/system.go
+++ b/dev/src/service/system.go
@@ -2,8 +2,6 @@ package service
 
 import (
 	"context"
-
-	"github.com/gpwork4u/aibo/repository"
 )
 
 // SearchConfigResult 搜尋配置結果
@@ -15,11 +13,11 @@ type SearchConfigResult struct {
 
 // SystemService 系統資訊業務邏輯
 type SystemService struct {
-	repo *repository.SystemRepository
+	repo SystemRepository
 }
 
 // NewSystemService 建立新的 SystemService
-func NewSystemService(repo *repository.SystemRepository) *SystemService {
+func NewSystemService(repo SystemRepository) *SystemService {
 	return &SystemService{repo: repo}
 }
 


### PR DESCRIPTION
## Summary
- 依 provider ID 快取 `openai.Client` 實例，避免每次 Classify/ExpandSynonyms 重建 client
- 使用 `sync.RWMutex` + `map[uuid.UUID]*cachedClient` 實現 goroutine-safe 快取，採用 double-check locking
- 共用 `http.Transport`（MaxIdleConns=100, IdleConnTimeout=90s）實現 HTTP 連線池
- Provider Update/Delete 時自動呼叫 `InvalidateClient()` 清除快取
- `configHash` (sha256) 偵測 endpoint_url + apiKey 變更並自動重建 client
- 全域 rate limiter 改為 per-provider rate limiter，不同 provider 不互相阻塞

## 修改檔案
- `dev/src/service/llm.go` — 新增 cachedClient、getOrCreateClient()、InvalidateClient()、共用 Transport
- `dev/src/service/llm_provider.go` — Update/Delete 時呼叫 InvalidateClient()
- `dev/src/main.go` — 串接 SetLlmService() 反向參考
- `dev/__tests__/service/llm_pool_test.go` — 4 個 unit test

## Test plan
- [ ] TestGetOrCreateClient_CacheHit — 相同 provider + 設定回傳同一個 client
- [ ] TestGetOrCreateClient_CacheMiss — 不同 provider 回傳不同 client
- [ ] TestInvalidateClient_RemovesFromCache — 清除後重建新 client
- [ ] TestConfigChange_RecreatesClient — apiKey 變更後自動重建

Closes #50

🤖 Generated with [Claude Code](https://claude.com/claude-code)