### PR TITLE
feat: F-019 品質檢測（VIBE 簡化版）

### DIFF
--- a/dev/__tests__/service/quality_test.go
+++ b/dev/__tests__/service/quality_test.go
@@ -1,0 +1,259 @@
+package service_test
+
+import (
+	"testing"
+
+	"github.com/gpwork4u/aibo/service"
+)
+
+func TestDetectEmail(t *testing.T) {
+	qc := service.NewQualityChecker()
+	flags, warnings := qc.Check("請聯繫 user@example.com 取得更多資訊")
+
+	if len(flags) == 0 {
+		t.Fatal("應偵測到 email pattern")
+	}
+	found := false
+	for _, f := range flags {
+		if f.Pattern == "email" && f.Type == "pii_detected" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("flags 中應包含 email pattern")
+	}
+	if len(warnings) == 0 {
+		t.Error("warnings 不應為空")
+	}
+}
+
+func TestDetectTaiwanID(t *testing.T) {
+	qc := service.NewQualityChecker()
+	flags, _ := qc.Check("身分證字號 A123456789")
+
+	found := false
+	for _, f := range flags {
+		if f.Pattern == "taiwan_id" && f.Type == "pii_detected" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("應偵測到台灣身分證 pattern")
+	}
+}
+
+func TestDetectTaiwanPhone(t *testing.T) {
+	qc := service.NewQualityChecker()
+	flags, _ := qc.Check("手機號碼 0912345678")
+
+	found := false
+	for _, f := range flags {
+		if f.Pattern == "taiwan_phone" && f.Type == "pii_detected" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("應偵測到台灣手機 pattern")
+	}
+}
+
+func TestDetectCreditCard(t *testing.T) {
+	qc := service.NewQualityChecker()
+
+	tests := []struct {
+		name    string
+		content string
+	}{
+		{"with dashes", "信用卡號 1234-5678-9012-3456"},
+		{"with spaces", "信用卡號 1234 5678 9012 3456"},
+		{"no separator", "信用卡號 1234567890123456"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			flags, _ := qc.Check(tt.content)
+			found := false
+			for _, f := range flags {
+				if f.Pattern == "credit_card" {
+					found = true
+					break
+				}
+			}
+			if !found {
+				t.Errorf("應偵測到信用卡 pattern: %s", tt.content)
+			}
+		})
+	}
+}
+
+func TestDetectIPAddress(t *testing.T) {
+	qc := service.NewQualityChecker()
+	flags, _ := qc.Check("伺服器 IP 為 192.168.1.1")
+
+	found := false
+	for _, f := range flags {
+		if f.Pattern == "ip_address" && f.Severity == "info" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("應偵測到 IP address pattern")
+	}
+}
+
+func TestDetectAWSKey(t *testing.T) {
+	qc := service.NewQualityChecker()
+	flags, _ := qc.Check("AWS key: AKIAIOSFODNN7EXAMPLE")
+
+	found := false
+	for _, f := range flags {
+		if f.Pattern == "aws_key" && f.Type == "secret_detected" && f.Severity == "critical" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("應偵測到 AWS key pattern，且 severity 應為 critical")
+	}
+}
+
+func TestDetectPrivateKey(t *testing.T) {
+	qc := service.NewQualityChecker()
+	flags, _ := qc.Check("-----BEGIN RSA PRIVATE KEY-----\nMIIEpA...")
+
+	found := false
+	for _, f := range flags {
+		if f.Pattern == "private_key" && f.Type == "secret_detected" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("應偵測到 private key pattern")
+	}
+}
+
+func TestDetectJWT(t *testing.T) {
+	qc := service.NewQualityChecker()
+	flags, _ := qc.Check("Bearer eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.abc123def456")
+
+	found := false
+	for _, f := range flags {
+		if f.Pattern == "jwt" && f.Type == "secret_detected" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("應偵測到 JWT pattern")
+	}
+}
+
+func TestDetectGenericAPIKey(t *testing.T) {
+	qc := service.NewQualityChecker()
+	flags, _ := qc.Check("API key: sk-abcdefghijklmnopqrstuvwx")
+
+	found := false
+	for _, f := range flags {
+		if f.Pattern == "generic_api_key" && f.Type == "secret_detected" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("應偵測到 generic API key pattern")
+	}
+}
+
+func TestNoDetection_CleanContent(t *testing.T) {
+	qc := service.NewQualityChecker()
+	flags, warnings := qc.Check("這是一篇關於 Go 語言的技術文章，內容包括 goroutine 和 channel 的使用方式。")
+
+	if len(flags) != 0 {
+		t.Errorf("乾淨內容不應有 flags，但偵測到 %d 個", len(flags))
+	}
+	if len(warnings) != 0 {
+		t.Errorf("乾淨內容不應有 warnings，但偵測到 %d 個", len(warnings))
+	}
+}
+
+func TestMultipleDetections(t *testing.T) {
+	qc := service.NewQualityChecker()
+	content := "聯繫 admin@example.com，伺服器 192.168.1.100，AWS key: AKIAIOSFODNN7EXAMPLE"
+	flags, warnings := qc.Check(content)
+
+	if len(flags) < 3 {
+		t.Errorf("應至少偵測到 3 種 pattern，實際偵測到 %d 種", len(flags))
+	}
+	if len(warnings) < 3 {
+		t.Errorf("應至少有 3 個 warnings，實際 %d 個", len(warnings))
+	}
+
+	// 檢查是否包含所有預期 pattern
+	patterns := make(map[string]bool)
+	for _, f := range flags {
+		patterns[f.Pattern] = true
+	}
+	expected := []string{"email", "ip_address", "aws_key"}
+	for _, p := range expected {
+		if !patterns[p] {
+			t.Errorf("應偵測到 %s pattern", p)
+		}
+	}
+}
+
+func TestSummaryTooShort(t *testing.T) {
+	qc := service.NewQualityChecker()
+	flags, warnings := qc.CheckSummaryLength("短")
+
+	if len(flags) == 0 {
+		t.Fatal("summary 太短應產生 flag")
+	}
+	if flags[0].Pattern != "summary_too_short" {
+		t.Errorf("pattern 應為 summary_too_short，實際為 %s", flags[0].Pattern)
+	}
+	if len(warnings) == 0 {
+		t.Error("應有 warning")
+	}
+}
+
+func TestSummaryTooLong(t *testing.T) {
+	qc := service.NewQualityChecker()
+	longSummary := ""
+	for i := 0; i < 210; i++ {
+		longSummary += "字"
+	}
+	flags, _ := qc.CheckSummaryLength(longSummary)
+
+	if len(flags) == 0 {
+		t.Fatal("summary 太長應產生 flag")
+	}
+	if flags[0].Pattern != "summary_too_long" {
+		t.Errorf("pattern 應為 summary_too_long，實際為 %s", flags[0].Pattern)
+	}
+}
+
+func TestSummaryNormalLength(t *testing.T) {
+	qc := service.NewQualityChecker()
+	flags, warnings := qc.CheckSummaryLength("這是一段正常長度的摘要，大約二十幾個字左右。")
+
+	if len(flags) != 0 {
+		t.Errorf("正常 summary 不應有 flags，但偵測到 %d 個", len(flags))
+	}
+	if len(warnings) != 0 {
+		t.Errorf("正常 summary 不應有 warnings，但偵測到 %d 個", len(warnings))
+	}
+}
+
+func TestSummaryEmpty(t *testing.T) {
+	qc := service.NewQualityChecker()
+	flags, _ := qc.CheckSummaryLength("")
+
+	if len(flags) != 0 {
+		t.Errorf("空 summary 不應產生 flag（空字串代表未產生 summary）")
+	}
+}

--- a/dev/src/dto/entry.go
+++ b/dev/src/dto/entry.go
@@ -63,10 +63,20 @@ type EntryResponse struct {
 	Confidence      float64          `json:"confidence"`
 	Confirmations   int              `json:"confirmations"`
 	FlagsCount      int              `json:"flags_count"`
-	SupersededBy    *uuid.UUID       `json:"superseded_by"`
-	LifecycleStatus string           `json:"lifecycle_status"`
-	CreatedAt       time.Time        `json:"created_at"`
-	UpdatedAt       time.Time        `json:"updated_at"`
+	SupersededBy    *uuid.UUID               `json:"superseded_by"`
+	QualityFlags    []QualityFlagResponse    `json:"quality_flags"`
+	QualityWarnings []QualityWarningResponse `json:"quality_warnings,omitempty"`
+	LifecycleStatus string                   `json:"lifecycle_status"`
+	CreatedAt       time.Time                `json:"created_at"`
+	UpdatedAt       time.Time                `json:"updated_at"`
+}
+
+// QualityFlagResponse 品質標記回應
+type QualityFlagResponse struct {
+	Type       string    `json:"type"`
+	Pattern    string    `json:"pattern"`
+	Severity   string    `json:"severity"`
+	DetectedAt time.Time `json:"detected_at"`
 }
 
 // EntryListItemResponse 列表中的知識條目（含 summary，不含 detail/action/source）
@@ -83,10 +93,11 @@ type EntryListItemResponse struct {
 	Confidence      float64    `json:"confidence"`
 	Confirmations   int        `json:"confirmations"`
 	FlagsCount      int        `json:"flags_count"`
-	SupersededBy    *uuid.UUID `json:"superseded_by"`
-	LifecycleStatus string     `json:"lifecycle_status"`
-	CreatedAt       time.Time  `json:"created_at"`
-	UpdatedAt       time.Time  `json:"updated_at"`
+	SupersededBy    *uuid.UUID            `json:"superseded_by"`
+	QualityFlags    []QualityFlagResponse `json:"quality_flags"`
+	LifecycleStatus string                `json:"lifecycle_status"`
+	CreatedAt       time.Time             `json:"created_at"`
+	UpdatedAt       time.Time             `json:"updated_at"`
 }
 
 // PaginationResponse 分頁資訊回應

--- a/dev/src/dto/llm.go
+++ b/dev/src/dto/llm.go
@@ -18,6 +18,13 @@ type ClassifyResult struct {
 	Action   string           `json:"action"`  // 可執行的建議/行動
 }
 
+// QualityWarningResponse 品質警告回應
+type QualityWarningResponse struct {
+	Type     string `json:"type"`
+	Details  string `json:"details"`
+	Severity string `json:"severity"`
+}
+
 // ClassifyResponse 手動觸發分類的回應
 type ClassifyResponse struct {
 	Message string    `json:"message"`

--- a/dev/src/handler/entry.go
+++ b/dev/src/handler/entry.go
@@ -163,6 +163,15 @@ func (h *EntryHandler) List(c *gin.Context) {
 		if domains == nil {
 			domains = []string{}
 		}
+		itemQualityFlags := make([]dto.QualityFlagResponse, 0)
+		for _, qf := range item.QualityFlags {
+			itemQualityFlags = append(itemQualityFlags, dto.QualityFlagResponse{
+				Type:       qf.Type,
+				Pattern:    qf.Pattern,
+				Severity:   qf.Severity,
+				DetectedAt: qf.DetectedAt,
+			})
+		}
 		items = append(items, dto.EntryListItemResponse{
 			ID:              item.ID,
 			Title:           item.Title,
@@ -177,6 +186,7 @@ func (h *EntryHandler) List(c *gin.Context) {
 			Confirmations:   item.Confirmations,
 			FlagsCount:      item.FlagsCount,
 			SupersededBy:    item.SupersededBy,
+			QualityFlags:    itemQualityFlags,
 			LifecycleStatus: item.LifecycleStatus(),
 			CreatedAt:       item.CreatedAt,
 			UpdatedAt:       item.UpdatedAt,
@@ -470,6 +480,23 @@ func toEntryResponse(entry *model.Entry) dto.EntryResponse {
 	if domains == nil {
 		domains = []string{}
 	}
+	// 轉換 quality_flags
+	qualityFlags := make([]dto.QualityFlagResponse, 0)
+	qualityWarnings := make([]dto.QualityWarningResponse, 0)
+	for _, qf := range entry.QualityFlags {
+		qualityFlags = append(qualityFlags, dto.QualityFlagResponse{
+			Type:       qf.Type,
+			Pattern:    qf.Pattern,
+			Severity:   qf.Severity,
+			DetectedAt: qf.DetectedAt,
+		})
+		qualityWarnings = append(qualityWarnings, dto.QualityWarningResponse{
+			Type:     qf.Type,
+			Details:  qf.Pattern + " pattern detected",
+			Severity: qf.Severity,
+		})
+	}
+
 	return dto.EntryResponse{
 		ID:              entry.ID,
 		Title:           entry.Title,
@@ -489,6 +516,8 @@ func toEntryResponse(entry *model.Entry) dto.EntryResponse {
 		Confirmations:   entry.Confirmations,
 		FlagsCount:      entry.FlagsCount,
 		SupersededBy:    entry.SupersededBy,
+		QualityFlags:    qualityFlags,
+		QualityWarnings: qualityWarnings,
 		LifecycleStatus: entry.LifecycleStatus(),
 		CreatedAt:       entry.CreatedAt,
 		UpdatedAt:       entry.UpdatedAt,

--- a/dev/src/migration/010_add_quality_flags.down.sql
+++ b/dev/src/migration/010_add_quality_flags.down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE entries DROP COLUMN IF EXISTS quality_flags;

--- a/dev/src/migration/010_add_quality_flags.up.sql
+++ b/dev/src/migration/010_add_quality_flags.up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE entries ADD COLUMN quality_flags JSONB DEFAULT '[]';

--- a/dev/src/model/entry.go
+++ b/dev/src/model/entry.go
@@ -25,10 +25,11 @@ type Entry struct {
 	IsArchived    bool             `json:"is_archived"`
 	Confidence    float64    `json:"confidence"`
 	Confirmations int        `json:"confirmations"`
-	FlagsCount    int        `json:"flags_count"`
-	SupersededBy  *uuid.UUID `json:"superseded_by"`
-	CreatedAt     time.Time  `json:"created_at"`
-	UpdatedAt     time.Time  `json:"updated_at"`
+	FlagsCount    int            `json:"flags_count"`
+	SupersededBy  *uuid.UUID     `json:"superseded_by"`
+	QualityFlags  []QualityFlag  `json:"quality_flags"`
+	CreatedAt     time.Time      `json:"created_at"`
+	UpdatedAt     time.Time      `json:"updated_at"`
 }
 
 // LifecycleStatus 計算知識條目的生命週期狀態
@@ -58,10 +59,11 @@ type EntryListItem struct {
 	IsArchived     bool             `json:"is_archived"`
 	Confidence     float64    `json:"confidence"`
 	Confirmations  int        `json:"confirmations"`
-	FlagsCount     int        `json:"flags_count"`
-	SupersededBy   *uuid.UUID `json:"superseded_by"`
-	CreatedAt      time.Time  `json:"created_at"`
-	UpdatedAt      time.Time  `json:"updated_at"`
+	FlagsCount     int            `json:"flags_count"`
+	SupersededBy   *uuid.UUID     `json:"superseded_by"`
+	QualityFlags   []QualityFlag  `json:"quality_flags"`
+	CreatedAt      time.Time      `json:"created_at"`
+	UpdatedAt      time.Time      `json:"updated_at"`
 }
 
 // LifecycleStatus 計算列表條目的生命週期狀態

--- a/dev/src/model/quality.go
+++ b/dev/src/model/quality.go
@@ -1,0 +1,18 @@
+package model
+
+import "time"
+
+// QualityFlag 品質檢測標記
+type QualityFlag struct {
+	Type       string    `json:"type"`        // "pii_detected" | "secret_detected"
+	Pattern    string    `json:"pattern"`      // "email", "credit_card", "aws_key", etc.
+	Severity   string    `json:"severity"`     // "info" | "warning" | "critical"
+	DetectedAt time.Time `json:"detected_at"`
+}
+
+// QualityWarning 品質警告（用於 API 回應）
+type QualityWarning struct {
+	Type     string `json:"type"`
+	Details  string `json:"details"`
+	Severity string `json:"severity"`
+}

--- a/dev/src/repository/entry.go
+++ b/dev/src/repository/entry.go
@@ -25,12 +25,17 @@ func NewEntryRepository(pool *pgxpool.Pool) *EntryRepository {
 
 // Create 建立新知識條目
 func (r *EntryRepository) Create(ctx context.Context, entry *model.Entry) error {
-	_, err := r.pool.Exec(ctx,
-		`INSERT INTO entries (id, title, content, summary, detail, action, category_id, source, source_type, source_ref, tags, domains, context, is_archived, created_at, updated_at)
-		 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16)`,
+	qualityFlagsJSON, err := json.Marshal(entry.QualityFlags)
+	if err != nil || entry.QualityFlags == nil {
+		qualityFlagsJSON = []byte("[]")
+	}
+
+	_, err = r.pool.Exec(ctx,
+		`INSERT INTO entries (id, title, content, summary, detail, action, category_id, source, source_type, source_ref, tags, domains, context, is_archived, quality_flags, created_at, updated_at)
+		 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17)`,
 		entry.ID, entry.Title, entry.Content, entry.Summary, entry.Detail, entry.Action,
 		entry.CategoryID, entry.Source, entry.SourceType, entry.SourceRef,
-		entry.Tags, entry.Domains, entry.Context, entry.IsArchived, entry.CreatedAt, entry.UpdatedAt,
+		entry.Tags, entry.Domains, entry.Context, entry.IsArchived, qualityFlagsJSON, entry.CreatedAt, entry.UpdatedAt,
 	)
 	if err != nil {
 		if strings.Contains(err.Error(), "idx_entries_source") {
@@ -47,9 +52,10 @@ func (r *EntryRepository) Create(ctx context.Context, entry *model.Entry) error 
 // FindByID 透過 ID 查找知識條目（完整 content）
 func (r *EntryRepository) FindByID(ctx context.Context, id uuid.UUID) (*model.Entry, error) {
 	entry := &model.Entry{}
+	var qualityFlagsJSON []byte
 	err := r.pool.QueryRow(ctx,
 		`SELECT id, title, content, summary, detail, action, category_id, source, source_type, source_ref, tags, domains, context, is_archived,
-		        confidence, confirmations, flags_count, superseded_by, created_at, updated_at
+		        confidence, confirmations, flags_count, superseded_by, quality_flags, created_at, updated_at
 		 FROM entries WHERE id = $1`,
 		id,
 	).Scan(
@@ -57,13 +63,16 @@ func (r *EntryRepository) FindByID(ctx context.Context, id uuid.UUID) (*model.En
 		&entry.CategoryID, &entry.Source, &entry.SourceType, &entry.SourceRef,
 		&entry.Tags, &entry.Domains, &entry.Context, &entry.IsArchived,
 		&entry.Confidence, &entry.Confirmations, &entry.FlagsCount, &entry.SupersededBy,
-		&entry.CreatedAt, &entry.UpdatedAt,
+		&qualityFlagsJSON, &entry.CreatedAt, &entry.UpdatedAt,
 	)
 	if errors.Is(err, pgx.ErrNoRows) {
 		return nil, nil
 	}
 	if err != nil {
 		return nil, err
+	}
+	if qualityFlagsJSON != nil {
+		_ = json.Unmarshal(qualityFlagsJSON, &entry.QualityFlags)
 	}
 	return entry, nil
 }
@@ -211,7 +220,7 @@ func (r *EntryRepository) List(ctx context.Context, filter model.EntryFilter) (*
 	dataQuery := fmt.Sprintf(
 		`SELECT e.id, e.title, e.summary, LEFT(e.content, 200) AS content_preview, e.category_id,
 		        e.tags, e.domains, e.context, e.is_archived, e.confidence, e.confirmations, e.flags_count, e.superseded_by,
-		        e.created_at, e.updated_at
+		        e.quality_flags, e.created_at, e.updated_at
 		 FROM entries e
 		 %s
 		 ORDER BY %s
@@ -229,12 +238,16 @@ func (r *EntryRepository) List(ctx context.Context, filter model.EntryFilter) (*
 	items := make([]model.EntryListItem, 0)
 	for rows.Next() {
 		var item model.EntryListItem
+		var qfJSON []byte
 		if err := rows.Scan(
 			&item.ID, &item.Title, &item.Summary, &item.ContentPreview, &item.CategoryID,
 			&item.Tags, &item.Domains, &item.Context, &item.IsArchived, &item.Confidence, &item.Confirmations, &item.FlagsCount, &item.SupersededBy,
-			&item.CreatedAt, &item.UpdatedAt,
+			&qfJSON, &item.CreatedAt, &item.UpdatedAt,
 		); err != nil {
 			return nil, err
+		}
+		if qfJSON != nil {
+			_ = json.Unmarshal(qfJSON, &item.QualityFlags)
 		}
 		items = append(items, item)
 	}
@@ -255,15 +268,20 @@ func (r *EntryRepository) List(ctx context.Context, filter model.EntryFilter) (*
 
 // Update 部分更新知識條目
 func (r *EntryRepository) Update(ctx context.Context, entry *model.Entry) error {
+	updateQFJSON, jsonErr := json.Marshal(entry.QualityFlags)
+	if jsonErr != nil || entry.QualityFlags == nil {
+		updateQFJSON = []byte("[]")
+	}
+
 	tag, err := r.pool.Exec(ctx,
 		`UPDATE entries
 		 SET title = $1, content = $2, summary = $3, detail = $4, action = $5,
 		     category_id = $6, source = $7, source_type = $8,
-		     source_ref = $9, tags = $10, domains = $11, context = $12, is_archived = $13, updated_at = NOW()
-		 WHERE id = $14`,
+		     source_ref = $9, tags = $10, domains = $11, context = $12, is_archived = $13, quality_flags = $14, updated_at = NOW()
+		 WHERE id = $15`,
 		entry.Title, entry.Content, entry.Summary, entry.Detail, entry.Action,
 		entry.CategoryID, entry.Source, entry.SourceType, entry.SourceRef,
-		entry.Tags, entry.Domains, entry.Context, entry.IsArchived, entry.ID,
+		entry.Tags, entry.Domains, entry.Context, entry.IsArchived, updateQFJSON, entry.ID,
 	)
 	if err != nil {
 		if strings.Contains(err.Error(), "idx_entries_source") {
@@ -295,6 +313,7 @@ func (r *EntryRepository) Delete(ctx context.Context, id uuid.UUID) error {
 // ConfirmEntry 確認知識條目有用，增加 confirmations 並重算 confidence
 func (r *EntryRepository) ConfirmEntry(ctx context.Context, id uuid.UUID) (*model.Entry, error) {
 	entry := &model.Entry{}
+	var confirmQFJSON []byte
 	err := r.pool.QueryRow(ctx,
 		`UPDATE entries
 		 SET confirmations = confirmations + 1,
@@ -302,20 +321,23 @@ func (r *EntryRepository) ConfirmEntry(ctx context.Context, id uuid.UUID) (*mode
 		     updated_at = NOW()
 		 WHERE id = $1
 		 RETURNING id, title, content, summary, detail, action, category_id, source, source_type, source_ref, tags, domains, context, is_archived,
-		           confidence, confirmations, flags_count, superseded_by, created_at, updated_at`,
+		           confidence, confirmations, flags_count, superseded_by, quality_flags, created_at, updated_at`,
 		id,
 	).Scan(
 		&entry.ID, &entry.Title, &entry.Content, &entry.Summary, &entry.Detail, &entry.Action,
 		&entry.CategoryID, &entry.Source, &entry.SourceType, &entry.SourceRef,
 		&entry.Tags, &entry.Domains, &entry.Context, &entry.IsArchived,
 		&entry.Confidence, &entry.Confirmations, &entry.FlagsCount, &entry.SupersededBy,
-		&entry.CreatedAt, &entry.UpdatedAt,
+		&confirmQFJSON, &entry.CreatedAt, &entry.UpdatedAt,
 	)
 	if errors.Is(err, pgx.ErrNoRows) {
 		return nil, model.NewAppError(404, model.ErrCodeNotFound, "知識條目不存在")
 	}
 	if err != nil {
 		return nil, err
+	}
+	if confirmQFJSON != nil {
+		_ = json.Unmarshal(confirmQFJSON, &entry.QualityFlags)
 	}
 	return entry, nil
 }
@@ -345,6 +367,7 @@ func (r *EntryRepository) FlagEntry(ctx context.Context, id uuid.UUID, reason st
 
 	// 更新 entry 的 flags_count 和 confidence
 	entry := &model.Entry{}
+	var flagQFJSON []byte
 	err = tx.QueryRow(ctx,
 		`UPDATE entries
 		 SET flags_count = flags_count + 1,
@@ -352,17 +375,20 @@ func (r *EntryRepository) FlagEntry(ctx context.Context, id uuid.UUID, reason st
 		     updated_at = NOW()
 		 WHERE id = $1
 		 RETURNING id, title, content, summary, detail, action, category_id, source, source_type, source_ref, tags, domains, context, is_archived,
-		           confidence, confirmations, flags_count, superseded_by, created_at, updated_at`,
+		           confidence, confirmations, flags_count, superseded_by, quality_flags, created_at, updated_at`,
 		id,
 	).Scan(
 		&entry.ID, &entry.Title, &entry.Content, &entry.Summary, &entry.Detail, &entry.Action,
 		&entry.CategoryID, &entry.Source, &entry.SourceType, &entry.SourceRef,
 		&entry.Tags, &entry.Domains, &entry.Context, &entry.IsArchived,
 		&entry.Confidence, &entry.Confirmations, &entry.FlagsCount, &entry.SupersededBy,
-		&entry.CreatedAt, &entry.UpdatedAt,
+		&flagQFJSON, &entry.CreatedAt, &entry.UpdatedAt,
 	)
 	if err != nil {
 		return nil, nil, err
+	}
+	if flagQFJSON != nil {
+		_ = json.Unmarshal(flagQFJSON, &entry.QualityFlags)
 	}
 
 	if err := tx.Commit(ctx); err != nil {

--- a/dev/src/service/classifier.go
+++ b/dev/src/service/classifier.go
@@ -13,9 +13,10 @@ import (
 
 // ClassifierService 自動分類業務邏輯
 type ClassifierService struct {
-	llmSvc       *LlmService
-	entryRepo    EntryRepository
-	categoryRepo CategoryRepository
+	llmSvc         *LlmService
+	entryRepo      EntryRepository
+	categoryRepo   CategoryRepository
+	qualityChecker *QualityChecker
 }
 
 // NewClassifierService 建立新的 ClassifierService
@@ -25,9 +26,10 @@ func NewClassifierService(
 	categoryRepo CategoryRepository,
 ) *ClassifierService {
 	return &ClassifierService{
-		llmSvc:       llmSvc,
-		entryRepo:    entryRepo,
-		categoryRepo: categoryRepo,
+		llmSvc:         llmSvc,
+		entryRepo:      entryRepo,
+		categoryRepo:   categoryRepo,
+		qualityChecker: NewQualityChecker(),
 	}
 }
 
@@ -117,6 +119,36 @@ func (s *ClassifierService) ClassifyEntry(ctx context.Context, entryID uuid.UUID
 	}
 	if result.Action != "" {
 		entry.Action = &result.Action
+	}
+
+	// 品質檢測：對原始 content 和 LLM 產出的 summary/detail/action 執行 PII/Secret 偵測
+	allContent := content
+	if result.Summary != "" {
+		allContent += "\n" + result.Summary
+	}
+	if result.Detail != "" {
+		allContent += "\n" + result.Detail
+	}
+	if result.Action != "" {
+		allContent += "\n" + result.Action
+	}
+
+	flags, _ := s.qualityChecker.Check(allContent)
+
+	// 檢測 summary 長度
+	if result.Summary != "" {
+		summaryFlags, _ := s.qualityChecker.CheckSummaryLength(result.Summary)
+		flags = append(flags, summaryFlags...)
+	}
+
+	if len(flags) > 0 {
+		entry.QualityFlags = flags
+		slog.Info("品質檢測發現問題",
+			"entry_id", entryID,
+			"flags_count", len(flags),
+		)
+	} else {
+		entry.QualityFlags = nil
 	}
 
 	if err := s.entryRepo.Update(ctx, entry); err != nil {

--- a/dev/src/service/quality.go
+++ b/dev/src/service/quality.go
@@ -1,0 +1,159 @@
+package service
+
+import (
+	"regexp"
+	"time"
+	"unicode/utf8"
+
+	"github.com/gpwork4u/aibo/model"
+)
+
+// PatternRule 定義單一偵測規則
+type PatternRule struct {
+	Type     string         // "pii_detected" | "secret_detected"
+	Pattern  string         // pattern 名稱: "email", "credit_card", etc.
+	Regex    *regexp.Regexp
+	Severity string         // "info" | "warning" | "critical"
+	Details  string         // 人類可讀的說明
+}
+
+// QualityChecker 品質檢測服務
+type QualityChecker struct {
+	rules []PatternRule
+}
+
+// NewQualityChecker 建立品質檢測服務，初始化所有偵測規則
+func NewQualityChecker() *QualityChecker {
+	rules := []PatternRule{
+		{
+			Type:     "pii_detected",
+			Pattern:  "email",
+			Regex:    regexp.MustCompile(`[a-zA-Z0-9._%+\-]+@[a-zA-Z0-9.\-]+\.[a-zA-Z]{2,}`),
+			Severity: "warning",
+			Details:  "email address pattern found",
+		},
+		{
+			Type:     "pii_detected",
+			Pattern:  "taiwan_id",
+			Regex:    regexp.MustCompile(`[A-Z][12]\d{8}`),
+			Severity: "warning",
+			Details:  "Taiwan national ID pattern found",
+		},
+		{
+			Type:     "pii_detected",
+			Pattern:  "taiwan_phone",
+			Regex:    regexp.MustCompile(`09\d{8}`),
+			Severity: "warning",
+			Details:  "Taiwan mobile phone pattern found",
+		},
+		{
+			Type:     "pii_detected",
+			Pattern:  "credit_card",
+			Regex:    regexp.MustCompile(`\b\d{4}[-\s]?\d{4}[-\s]?\d{4}[-\s]?\d{4}\b`),
+			Severity: "warning",
+			Details:  "credit card number pattern found",
+		},
+		{
+			Type:     "pii_detected",
+			Pattern:  "ip_address",
+			Regex:    regexp.MustCompile(`\b\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}\b`),
+			Severity: "info",
+			Details:  "IP address pattern found",
+		},
+		{
+			Type:     "secret_detected",
+			Pattern:  "aws_key",
+			Regex:    regexp.MustCompile(`AKIA[0-9A-Z]{16}`),
+			Severity: "critical",
+			Details:  "AWS access key pattern found",
+		},
+		{
+			Type:     "secret_detected",
+			Pattern:  "private_key",
+			Regex:    regexp.MustCompile(`-----BEGIN (RSA |EC |DSA )?PRIVATE KEY-----`),
+			Severity: "critical",
+			Details:  "private key pattern found",
+		},
+		{
+			Type:     "secret_detected",
+			Pattern:  "jwt",
+			Regex:    regexp.MustCompile(`eyJ[A-Za-z0-9_-]+\.eyJ[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+`),
+			Severity: "critical",
+			Details:  "JWT token pattern found",
+		},
+		{
+			Type:     "secret_detected",
+			Pattern:  "generic_api_key",
+			Regex:    regexp.MustCompile(`(sk-|pk_|api_key|token)[a-zA-Z0-9]{20,}`),
+			Severity: "critical",
+			Details:  "API key / token pattern found",
+		},
+	}
+
+	return &QualityChecker{rules: rules}
+}
+
+// Check 對內容執行品質檢測，回傳所有偵測到的 flags 和 warnings
+func (qc *QualityChecker) Check(content string) ([]model.QualityFlag, []model.QualityWarning) {
+	now := time.Now().UTC()
+	var flags []model.QualityFlag
+	var warnings []model.QualityWarning
+
+	// PII / Secret pattern 偵測
+	for _, rule := range qc.rules {
+		if rule.Regex.MatchString(content) {
+			flags = append(flags, model.QualityFlag{
+				Type:       rule.Type,
+				Pattern:    rule.Pattern,
+				Severity:   rule.Severity,
+				DetectedAt: now,
+			})
+			warnings = append(warnings, model.QualityWarning{
+				Type:     rule.Type,
+				Details:  rule.Details,
+				Severity: rule.Severity,
+			})
+		}
+	}
+
+	return flags, warnings
+}
+
+// CheckSummaryLength 檢測 summary 長度是否合理
+func (qc *QualityChecker) CheckSummaryLength(summary string) ([]model.QualityFlag, []model.QualityWarning) {
+	now := time.Now().UTC()
+	var flags []model.QualityFlag
+	var warnings []model.QualityWarning
+
+	runeCount := utf8.RuneCountInString(summary)
+
+	if summary != "" && runeCount < 10 {
+		flags = append(flags, model.QualityFlag{
+			Type:       "quality_issue",
+			Pattern:    "summary_too_short",
+			Severity:   "info",
+			DetectedAt: now,
+		})
+		warnings = append(warnings, model.QualityWarning{
+			Type:     "quality_issue",
+			Details:  "summary is too short (< 10 characters)",
+			Severity: "info",
+		})
+	}
+
+	if runeCount > 200 {
+		flags = append(flags, model.QualityFlag{
+			Type:       "quality_issue",
+			Pattern:    "summary_too_long",
+			Severity:   "info",
+			DetectedAt: now,
+		})
+		warnings = append(warnings, model.QualityWarning{
+			Type:     "quality_issue",
+			Details:  "summary is too long (> 200 characters)",
+			Severity: "info",
+		})
+	}
+
+	return flags, warnings
+}


### PR DESCRIPTION
## Summary
- 在 LLM 分類流程中加入品質檢測層（QualityChecker），使用 regex 偵測 PII 和敏感資訊
- 支援 8 種偵測模式：email、台灣身分證、台灣手機、信用卡、IP 位址、AWS Key、Private Key、JWT、Generic API Key
- 額外檢測 summary 長度（太短 < 10 字或太長 > 200 字）
- 偵測結果存入 entries.quality_flags（JSONB），不阻擋分類流程
- API 回應中新增 quality_flags 和 quality_warnings 欄位

## 變更檔案
### 新增
- `dev/src/service/quality.go` — QualityChecker 服務，regex pattern 匹配邏輯
- `dev/src/model/quality.go` — QualityFlag / QualityWarning struct 定義
- `dev/src/migration/010_add_quality_flags.up.sql` — ALTER TABLE entries ADD COLUMN quality_flags
- `dev/src/migration/010_add_quality_flags.down.sql`
- `dev/__tests__/service/quality_test.go` — 完整 unit tests

### 修改
- `dev/src/service/classifier.go` — ClassifyEntry 中整合品質檢測
- `dev/src/dto/llm.go` — 新增 QualityWarningResponse
- `dev/src/dto/entry.go` — EntryResponse / EntryListItemResponse 新增 quality_flags / quality_warnings
- `dev/src/model/entry.go` — Entry / EntryListItem 新增 QualityFlags 欄位
- `dev/src/repository/entry.go` — CRUD SQL 加入 quality_flags JSONB 欄位
- `dev/src/handler/entry.go` — 回應轉換包含 quality_flags / quality_warnings

## Test plan
- [ ] 單元測試：所有 PII pattern 偵測（email, 台灣身分證, 信用卡, AWS Key, JWT 等）
- [ ] 單元測試：乾淨內容不產生 flag
- [ ] 單元測試：多重偵測
- [ ] 單元測試：summary 長度檢測
- [ ] 整合測試：建立含 PII 的 entry → 分類後 quality_flags 不為空
- [ ] 整合測試：建立乾淨 entry → 分類後 quality_flags 為空陣列

Closes #52

🤖 Generated with [Claude Code](https://claude.com/claude-code)