### PR TITLE
feat(F-020): 小項修復 — OAuth 持久化、環境變數驗證、repo_path 白名單

### DIFF
--- a/dev/__tests__/config/config_test.go
+++ b/dev/__tests__/config/config_test.go
@@ -1,0 +1,119 @@
+package config_test
+
+import (
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/gpwork4u/aibo/config"
+)
+
+// validEncryptionKey 是有效的 64 hex chars（32 bytes）
+const validEncryptionKey = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+
+// helper: 設定必要環境變數
+func setRequiredEnvVars(t *testing.T) {
+	t.Helper()
+	t.Setenv("DATABASE_URL", "postgres://test:test@localhost:5432/test")
+	t.Setenv("AIBO_ENCRYPTION_KEY", validEncryptionKey)
+}
+
+func TestLoad_MissingDatabaseURL(t *testing.T) {
+	t.Setenv("AIBO_ENCRYPTION_KEY", validEncryptionKey)
+	os.Unsetenv("DATABASE_URL")
+
+	_, err := config.Load()
+	if err == nil {
+		t.Fatal("預期應回傳錯誤，但沒有")
+	}
+	if !strings.Contains(err.Error(), "DATABASE_URL") {
+		t.Errorf("錯誤訊息應包含 DATABASE_URL，實際: %s", err.Error())
+	}
+}
+
+func TestLoad_MissingEncryptionKey(t *testing.T) {
+	t.Setenv("DATABASE_URL", "postgres://test:test@localhost:5432/test")
+	os.Unsetenv("AIBO_ENCRYPTION_KEY")
+
+	_, err := config.Load()
+	if err == nil {
+		t.Fatal("預期應回傳錯誤，但沒有")
+	}
+	if !strings.Contains(err.Error(), "AIBO_ENCRYPTION_KEY") {
+		t.Errorf("錯誤訊息應包含 AIBO_ENCRYPTION_KEY，實際: %s", err.Error())
+	}
+}
+
+func TestLoad_MultipleMissingVars(t *testing.T) {
+	os.Unsetenv("DATABASE_URL")
+	os.Unsetenv("AIBO_ENCRYPTION_KEY")
+
+	_, err := config.Load()
+	if err == nil {
+		t.Fatal("預期應回傳錯誤，但沒有")
+	}
+	errMsg := err.Error()
+	if !strings.Contains(errMsg, "DATABASE_URL") || !strings.Contains(errMsg, "AIBO_ENCRYPTION_KEY") {
+		t.Errorf("錯誤訊息應同時包含 DATABASE_URL 和 AIBO_ENCRYPTION_KEY，實際: %s", errMsg)
+	}
+}
+
+func TestLoad_InvalidEncryptionKeyFormat(t *testing.T) {
+	t.Setenv("DATABASE_URL", "postgres://test:test@localhost:5432/test")
+	t.Setenv("AIBO_ENCRYPTION_KEY", "not-a-valid-hex-key")
+
+	_, err := config.Load()
+	if err == nil {
+		t.Fatal("預期應回傳錯誤，但沒有")
+	}
+	if !strings.Contains(err.Error(), "AIBO_ENCRYPTION_KEY 格式無效") {
+		t.Errorf("錯誤訊息應包含格式無效提示，實際: %s", err.Error())
+	}
+}
+
+func TestLoad_ValidConfig(t *testing.T) {
+	setRequiredEnvVars(t)
+
+	cfg, err := config.Load()
+	if err != nil {
+		t.Fatalf("Load() 不應回傳錯誤: %v", err)
+	}
+	if cfg.DatabaseURL == "" {
+		t.Error("DatabaseURL 不應為空")
+	}
+	if cfg.ServerPort != "8080" {
+		t.Errorf("ServerPort 預設應為 8080，實際: %s", cfg.ServerPort)
+	}
+}
+
+func TestLoad_AllowedRepoPaths(t *testing.T) {
+	setRequiredEnvVars(t)
+	t.Setenv("ALLOWED_REPO_PATHS", "/home/user/repos,/data/git")
+
+	cfg, err := config.Load()
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+	if len(cfg.AllowedRepoPaths) != 2 {
+		t.Fatalf("AllowedRepoPaths 長度應為 2，實際: %d", len(cfg.AllowedRepoPaths))
+	}
+	if cfg.AllowedRepoPaths[0] != "/home/user/repos" {
+		t.Errorf("AllowedRepoPaths[0] = %s, want /home/user/repos", cfg.AllowedRepoPaths[0])
+	}
+	if cfg.AllowedRepoPaths[1] != "/data/git" {
+		t.Errorf("AllowedRepoPaths[1] = %s, want /data/git", cfg.AllowedRepoPaths[1])
+	}
+}
+
+func TestLoad_AllowedRepoPathsEmpty(t *testing.T) {
+	setRequiredEnvVars(t)
+	os.Unsetenv("ALLOWED_REPO_PATHS")
+
+	cfg, err := config.Load()
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+	if cfg.AllowedRepoPaths != nil {
+		t.Errorf("AllowedRepoPaths 未設定時應為 nil，實際: %v", cfg.AllowedRepoPaths)
+	}
+}

--- a/dev/__tests__/service/git_import_test.go
+++ b/dev/__tests__/service/git_import_test.go
@@ -1,0 +1,133 @@
+package service_test
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/gpwork4u/aibo/dto"
+	"github.com/gpwork4u/aibo/model"
+	"github.com/gpwork4u/aibo/service"
+)
+
+func newGitImportSvcWithPaths(paths []string) *service.GitImportService {
+	// 傳入 nil entryRepo — 白名單驗證在 DB 操作前就會被攔截
+	svc := service.NewGitImportService(nil)
+	if len(paths) > 0 {
+		svc.SetAllowedRepoPaths(paths)
+	}
+	return svc
+}
+
+func TestGitImportService_RepoPathWhitelist_Blocked(t *testing.T) {
+	svc := newGitImportSvcWithPaths([]string{"/home/user/repos", "/data/git"})
+
+	req := dto.GitImportRequest{
+		RepoPath: "/etc/passwd",
+	}
+
+	_, err := svc.ImportCommits(context.Background(), req)
+	if err == nil {
+		t.Fatal("預期應回傳錯誤，但沒有")
+	}
+
+	appErr, ok := err.(*model.AppError)
+	if !ok {
+		t.Fatalf("預期 AppError，實際: %T", err)
+	}
+	if appErr.Status != 403 {
+		t.Errorf("預期 status 403，實際: %d", appErr.Status)
+	}
+	if !strings.Contains(appErr.Message, "不在允許的路徑範圍內") {
+		t.Errorf("錯誤訊息應包含路徑範圍提示，實際: %s", appErr.Message)
+	}
+}
+
+func TestGitImportService_RepoPathWhitelist_Allowed(t *testing.T) {
+	svc := newGitImportSvcWithPaths([]string{"/home/user/repos"})
+
+	req := dto.GitImportRequest{
+		RepoPath: "/home/user/repos/my-project",
+	}
+
+	// 路徑在白名單內，但不是真的 git repo，所以會得到 "不是有效的 Git repository" 錯誤
+	_, err := svc.ImportCommits(context.Background(), req)
+	if err == nil {
+		t.Fatal("預期應回傳錯誤（非 git repo），但沒有")
+	}
+
+	appErr, ok := err.(*model.AppError)
+	if !ok {
+		t.Fatalf("預期 AppError，實際: %T", err)
+	}
+	// 不應是 403（白名單錯誤），而是 400（非 git repo）
+	if appErr.Status == 403 {
+		t.Error("路徑在白名單內，不應回傳 403")
+	}
+}
+
+func TestGitImportService_RepoPathWhitelist_DirectoryTraversal(t *testing.T) {
+	svc := newGitImportSvcWithPaths([]string{"/home/user/repos"})
+
+	req := dto.GitImportRequest{
+		RepoPath: "/home/user/repos/../../../etc/passwd",
+	}
+
+	_, err := svc.ImportCommits(context.Background(), req)
+	if err == nil {
+		t.Fatal("預期應回傳錯誤，但沒有")
+	}
+
+	appErr, ok := err.(*model.AppError)
+	if !ok {
+		t.Fatalf("預期 AppError，實際: %T", err)
+	}
+	if appErr.Status != 403 {
+		t.Errorf("目錄遍歷攻擊應回傳 403，實際: %d", appErr.Status)
+	}
+}
+
+func TestGitImportService_RepoPathWhitelist_EmptyAllowsAll(t *testing.T) {
+	// 空白名單 = 允許所有路徑（不呼叫 SetAllowedRepoPaths）
+	svc := service.NewGitImportService(nil)
+
+	req := dto.GitImportRequest{
+		RepoPath: "/any/path/here",
+	}
+
+	_, err := svc.ImportCommits(context.Background(), req)
+	if err == nil {
+		t.Fatal("預期應回傳錯誤（非 git repo），但沒有")
+	}
+
+	appErr, ok := err.(*model.AppError)
+	if !ok {
+		t.Fatalf("預期 AppError，實際: %T", err)
+	}
+	// 不應是 403（允許所有路徑），而是 400（非 git repo）
+	if appErr.Status == 403 {
+		t.Error("空白名單應允許所有路徑，不應回傳 403")
+	}
+}
+
+func TestGitImportService_RepoPathWhitelist_ExactMatch(t *testing.T) {
+	svc := newGitImportSvcWithPaths([]string{"/home/user/repos/my-project"})
+
+	req := dto.GitImportRequest{
+		RepoPath: "/home/user/repos/my-project",
+	}
+
+	_, err := svc.ImportCommits(context.Background(), req)
+	if err == nil {
+		t.Fatal("預期應回傳錯誤（非 git repo），但沒有")
+	}
+
+	appErr, ok := err.(*model.AppError)
+	if !ok {
+		t.Fatalf("預期 AppError，實際: %T", err)
+	}
+	// 完全匹配應被允許
+	if appErr.Status == 403 {
+		t.Error("完全匹配的路徑應被允許，不應回傳 403")
+	}
+}

--- a/dev/src/config/config.go
+++ b/dev/src/config/config.go
@@ -1,19 +1,23 @@
 package config
 
 import (
+	"encoding/hex"
 	"fmt"
+	"log/slog"
 	"os"
+	"strings"
 
 	"github.com/joho/godotenv"
 )
 
 // Config 應用程式設定
 type Config struct {
-	DatabaseURL       string
-	ServerPort        string
-	GoogleClientID    string
+	DatabaseURL        string
+	ServerPort         string
+	GoogleClientID     string
 	GoogleClientSecret string
-	GoogleRedirectURL string
+	GoogleRedirectURL  string
+	AllowedRepoPaths   []string // ALLOWED_REPO_PATHS 白名單（空 = 允許所有）
 }
 
 // Load 從環境變數載入設定
@@ -21,9 +25,33 @@ func Load() (*Config, error) {
 	// 嘗試載入 .env 檔案（不存在也不報錯）
 	_ = godotenv.Load()
 
+	// 驗證必要環境變數
+	var missing []string
+
 	dbURL := os.Getenv("DATABASE_URL")
 	if dbURL == "" {
-		return nil, fmt.Errorf("DATABASE_URL 環境變數未設定")
+		missing = append(missing, "DATABASE_URL")
+	}
+
+	encKey := os.Getenv("AIBO_ENCRYPTION_KEY")
+	if encKey == "" {
+		missing = append(missing, "AIBO_ENCRYPTION_KEY")
+	}
+
+	if len(missing) > 0 {
+		return nil, fmt.Errorf("以下必要環境變數未設定: %s", strings.Join(missing, ", "))
+	}
+
+	// 驗證 AIBO_ENCRYPTION_KEY 格式（64 hex chars = 32 bytes）
+	if err := validateEncryptionKey(encKey); err != nil {
+		return nil, err
+	}
+
+	// 選填環境變數：缺失時 log warning
+	googleClientID := os.Getenv("GOOGLE_CLIENT_ID")
+	googleClientSecret := os.Getenv("GOOGLE_CLIENT_SECRET")
+	if googleClientID == "" || googleClientSecret == "" {
+		slog.Warn("Google OAuth 環境變數未設定（GOOGLE_CLIENT_ID, GOOGLE_CLIENT_SECRET），Google Calendar 功能將無法使用")
 	}
 
 	port := os.Getenv("SERVER_PORT")
@@ -36,11 +64,42 @@ func Load() (*Config, error) {
 		googleRedirectURL = "http://localhost:8080/api/v1/integrations/gcal/callback"
 	}
 
+	// 解析 ALLOWED_REPO_PATHS
+	allowedRepoPaths := parseAllowedRepoPaths(os.Getenv("ALLOWED_REPO_PATHS"))
+
 	return &Config{
-		DatabaseURL:       dbURL,
-		ServerPort:        port,
-		GoogleClientID:    os.Getenv("GOOGLE_CLIENT_ID"),
-		GoogleClientSecret: os.Getenv("GOOGLE_CLIENT_SECRET"),
-		GoogleRedirectURL: googleRedirectURL,
+		DatabaseURL:        dbURL,
+		ServerPort:         port,
+		GoogleClientID:     googleClientID,
+		GoogleClientSecret: googleClientSecret,
+		GoogleRedirectURL:  googleRedirectURL,
+		AllowedRepoPaths:   allowedRepoPaths,
 	}, nil
+}
+
+// validateEncryptionKey 驗證 AIBO_ENCRYPTION_KEY 格式
+func validateEncryptionKey(key string) error {
+	// 64 hex chars = 32 bytes
+	if len(key) == 64 {
+		if _, err := hex.DecodeString(key); err == nil {
+			return nil
+		}
+	}
+	return fmt.Errorf("AIBO_ENCRYPTION_KEY 格式無效，需為 64 字元的 hex 字串（32 bytes）")
+}
+
+// parseAllowedRepoPaths 解析逗號分隔的路徑白名單
+func parseAllowedRepoPaths(raw string) []string {
+	if strings.TrimSpace(raw) == "" {
+		return nil
+	}
+	parts := strings.Split(raw, ",")
+	var paths []string
+	for _, p := range parts {
+		p = strings.TrimSpace(p)
+		if p != "" {
+			paths = append(paths, p)
+		}
+	}
+	return paths
 }

--- a/dev/src/main.go
+++ b/dev/src/main.go
@@ -92,6 +92,7 @@ func main() {
 
 	// 初始化 Git 匯入服務
 	gitImportSvc := service.NewGitImportService(entryRepo)
+	gitImportSvc.SetAllowedRepoPaths(cfg.AllowedRepoPaths)
 	gitImportHandler := handler.NewGitImportHandler(gitImportSvc)
 
 	// 初始化 Google Calendar 整合服務

--- a/dev/src/migration/010_create_oauth_states.down.sql
+++ b/dev/src/migration/010_create_oauth_states.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS oauth_states;

--- a/dev/src/migration/010_create_oauth_states.up.sql
+++ b/dev/src/migration/010_create_oauth_states.up.sql
@@ -1,0 +1,6 @@
+CREATE TABLE oauth_states (
+    state VARCHAR(64) PRIMARY KEY,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX idx_oauth_states_created_at ON oauth_states (created_at);

--- a/dev/src/repository/gcal_integration.go
+++ b/dev/src/repository/gcal_integration.go
@@ -3,6 +3,7 @@ package repository
 import (
 	"context"
 	"errors"
+	"time"
 
 	"github.com/gpwork4u/aibo/model"
 	"github.com/jackc/pgx/v5"
@@ -77,6 +78,46 @@ func (r *GcalIntegrationRepository) UpdateTokens(ctx context.Context, id interfa
 		 SET access_token = $1, refresh_token = $2, token_expiry = $3, updated_at = NOW()
 		 WHERE id = $4`,
 		accessToken, refreshToken, expiry, id,
+	)
+	return err
+}
+
+// SaveOAuthState 儲存 OAuth state 到 DB
+func (r *GcalIntegrationRepository) SaveOAuthState(ctx context.Context, state string) error {
+	_, err := r.pool.Exec(ctx,
+		`INSERT INTO oauth_states (state, created_at) VALUES ($1, NOW())`,
+		state,
+	)
+	return err
+}
+
+// ValidateOAuthState 驗證 OAuth state 是否存在且未過期（10 分鐘內），驗證後刪除
+func (r *GcalIntegrationRepository) ValidateOAuthState(ctx context.Context, state string) (bool, error) {
+	var createdAt time.Time
+	err := r.pool.QueryRow(ctx,
+		`DELETE FROM oauth_states WHERE state = $1 RETURNING created_at`,
+		state,
+	).Scan(&createdAt)
+
+	if errors.Is(err, pgx.ErrNoRows) {
+		return false, nil
+	}
+	if err != nil {
+		return false, err
+	}
+
+	// 檢查是否在 10 分鐘內
+	if time.Since(createdAt) > 10*time.Minute {
+		return false, nil
+	}
+
+	return true, nil
+}
+
+// CleanExpiredOAuthStates 清理超過 10 分鐘的過期 state
+func (r *GcalIntegrationRepository) CleanExpiredOAuthStates(ctx context.Context) error {
+	_, err := r.pool.Exec(ctx,
+		`DELETE FROM oauth_states WHERE created_at < NOW() - INTERVAL '10 minutes'`,
 	)
 	return err
 }

--- a/dev/src/service/gcal.go
+++ b/dev/src/service/gcal.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
-	"sync"
 	"time"
 
 	"github.com/google/uuid"
@@ -35,10 +34,6 @@ type GcalService struct {
 	entryRepo *repository.EntryRepository
 	aesCrypto *crypto.AESCrypto
 	config    *GcalConfig
-
-	// OAuth state 管理（記憶體中暫存）
-	stateMu sync.RWMutex
-	states  map[string]time.Time // state → 建立時間
 }
 
 // NewGcalService 建立新的 GcalService
@@ -53,7 +48,6 @@ func NewGcalService(
 		entryRepo: entryRepo,
 		aesCrypto: aesCrypto,
 		config:    config,
-		states:    make(map[string]time.Time),
 	}
 }
 
@@ -69,6 +63,7 @@ func (s *GcalService) oauthConfig() *oauth2.Config {
 }
 
 // StartOAuth 開始 OAuth 授權流程，回傳 auth_url
+// OAuth state 持久化到 DB，server 重啟後仍可驗證
 func (s *GcalService) StartOAuth() (string, error) {
 	if s.config.ClientID == "" || s.config.ClientSecret == "" {
 		return "", model.NewAppError(http.StatusInternalServerError, "INTERNAL_ERROR", "Google OAuth client 未設定")
@@ -79,13 +74,18 @@ func (s *GcalService) StartOAuth() (string, error) {
 		return "", fmt.Errorf("產生 state 失敗: %w", err)
 	}
 
-	// 儲存 state（10 分鐘後過期）
-	s.stateMu.Lock()
-	s.states[state] = time.Now()
-	s.stateMu.Unlock()
+	// 儲存 state 到 DB（持久化，重啟後不遺失）
+	ctx := context.Background()
+	if err := s.gcalRepo.SaveOAuthState(ctx, state); err != nil {
+		return "", fmt.Errorf("儲存 OAuth state 失敗: %w", err)
+	}
 
-	// 清理過期 states
-	go s.cleanExpiredStates()
+	// 背景清理過期 states
+	go func() {
+		if cleanErr := s.gcalRepo.CleanExpiredOAuthStates(context.Background()); cleanErr != nil {
+			slog.Error("清理過期 OAuth states 失敗", "error", cleanErr)
+		}
+	}()
 
 	authURL := s.oauthConfig().AuthCodeURL(state, oauth2.AccessTypeOffline, oauth2.ApprovalForce)
 	return authURL, nil
@@ -93,21 +93,13 @@ func (s *GcalService) StartOAuth() (string, error) {
 
 // HandleCallback 處理 OAuth callback
 func (s *GcalService) HandleCallback(ctx context.Context, code, state string) (string, error) {
-	// 驗證 state
-	s.stateMu.Lock()
-	createdAt, exists := s.states[state]
-	if exists {
-		delete(s.states, state)
+	// 驗證 state（從 DB 查詢並刪除，同時檢查是否過期）
+	valid, err := s.gcalRepo.ValidateOAuthState(ctx, state)
+	if err != nil {
+		return "", fmt.Errorf("驗證 OAuth state 失敗: %w", err)
 	}
-	s.stateMu.Unlock()
-
-	if !exists {
-		return "", model.NewAppError(http.StatusBadRequest, model.ErrCodeInvalidInput, "無效的 state 參數")
-	}
-
-	// 檢查 state 是否過期（10 分鐘）
-	if time.Since(createdAt) > 10*time.Minute {
-		return "", model.NewAppError(http.StatusBadRequest, model.ErrCodeInvalidInput, "state 已過期，請重新授權")
+	if !valid {
+		return "", model.NewAppError(http.StatusBadRequest, model.ErrCodeInvalidInput, "無效或已過期的 state 參數")
 	}
 
 	// 交換 code 取得 token
@@ -355,15 +347,3 @@ func generateRandomState() (string, error) {
 	return hex.EncodeToString(b), nil
 }
 
-// cleanExpiredStates 清理過期的 state（超過 10 分鐘）
-func (s *GcalService) cleanExpiredStates() {
-	s.stateMu.Lock()
-	defer s.stateMu.Unlock()
-
-	now := time.Now()
-	for state, createdAt := range s.states {
-		if now.Sub(createdAt) > 10*time.Minute {
-			delete(s.states, state)
-		}
-	}
-}

--- a/dev/src/service/git_import.go
+++ b/dev/src/service/git_import.go
@@ -32,12 +32,21 @@ var (
 
 // GitImportService Git 匯入業務邏輯
 type GitImportService struct {
-	entryRepo *repository.EntryRepository
+	entryRepo        *repository.EntryRepository
+	allowedRepoPaths []string
 }
 
 // NewGitImportService 建立新的 GitImportService
 func NewGitImportService(entryRepo *repository.EntryRepository) *GitImportService {
 	return &GitImportService{entryRepo: entryRepo}
+}
+
+// SetAllowedRepoPaths 設定允許的 repo 路徑白名單
+func (s *GitImportService) SetAllowedRepoPaths(paths []string) {
+	s.allowedRepoPaths = paths
+	if len(paths) == 0 {
+		slog.Warn("ALLOWED_REPO_PATHS 未設定，允許匯入任何路徑")
+	}
 }
 
 // commitInfo 暫存 commit 資訊
@@ -55,6 +64,11 @@ func (s *GitImportService) ImportCommits(ctx context.Context, req dto.GitImportR
 	// 驗證 repo_path
 	if strings.TrimSpace(req.RepoPath) == "" {
 		return nil, model.NewAppError(400, model.ErrCodeInvalidInput, "repo_path 不可為空")
+	}
+
+	// 驗證 repo_path 是否在白名單內
+	if err := s.validateRepoPath(req.RepoPath); err != nil {
+		return nil, err
 	}
 
 	// 開啟 repo
@@ -284,4 +298,25 @@ func extractSubject(message string) string {
 		subject = string(runes[:77]) + "..."
 	}
 	return subject
+}
+
+// validateRepoPath 驗證 repo_path 是否在白名單允許的路徑範圍內
+func (s *GitImportService) validateRepoPath(repoPath string) error {
+	// 白名單為空時允許所有路徑（向下相容）
+	if len(s.allowedRepoPaths) == 0 {
+		return nil
+	}
+
+	// 先清理路徑（防止 .. 目錄遍歷）
+	cleanPath := filepath.Clean(repoPath)
+
+	for _, allowed := range s.allowedRepoPaths {
+		allowedClean := filepath.Clean(allowed)
+		// 檢查 cleanPath 是否在 allowedClean 目錄下
+		if strings.HasPrefix(cleanPath, allowedClean+string(filepath.Separator)) || cleanPath == allowedClean {
+			return nil
+		}
+	}
+
+	return model.NewAppError(403, model.ErrCodeInvalidInput, "repo_path 不在允許的路徑範圍內")
 }


### PR DESCRIPTION
## Summary

Closes #53

Sprint 6 打包的多個小改善項目實作：

- **20-B**: GCal OAuth state 從記憶體 map 改存 DB（`oauth_states` 表），server 重啟後進行中的 OAuth flow 不會失敗
- **20-C**: `config.Load()` 統一驗證 `DATABASE_URL` + `AIBO_ENCRYPTION_KEY`（含格式檢查），選填變數缺失時 log warning
- **20-D**: `GitImportService` 新增 `ALLOWED_REPO_PATHS` 環境變數白名單，含 `filepath.Clean()` 防止 `..` 目錄遍歷攻擊
- **20-E**: 確認 `go.mod` (1.23) 和 `Dockerfile` (`golang:1.23-alpine`) Go 版本已一致，無需修改
- **20-A**: 由 F-017 `cachedClient` per-provider rate limiter 涵蓋，無需額外修改

## Changes

- `dev/src/config/config.go` — 新增環境變數統一驗證 + `AllowedRepoPaths` 解析
- `dev/src/repository/gcal_integration.go` — 新增 `SaveOAuthState` / `ValidateOAuthState` / `CleanExpiredOAuthStates`
- `dev/src/migration/010_create_oauth_states.{up,down}.sql` — 新增 `oauth_states` 表
- `dev/src/service/gcal.go` — OAuth state 改用 DB 持久化，移除 `sync.RWMutex` + 記憶體 map
- `dev/src/service/git_import.go` — 新增 `SetAllowedRepoPaths` + `validateRepoPath` 白名單驗證
- `dev/src/main.go` — 呼叫 `SetAllowedRepoPaths` 傳入設定
- `dev/__tests__/config/config_test.go` — 環境變數驗證 unit tests
- `dev/__tests__/service/git_import_test.go` — repo_path 白名單 unit tests

## Test Plan

- [ ] `go test ./dev/__tests__/config/...` — 環境變數驗證測試
- [ ] `go test ./dev/__tests__/service/...` — repo_path 白名單測試（含目錄遍歷攻擊）
- [ ] 手動驗證：缺少 `AIBO_ENCRYPTION_KEY` 時啟動失敗並顯示明確訊息
- [ ] 手動驗證：設定 `ALLOWED_REPO_PATHS` 後，不在白名單的 repo_path 回傳 403

🤖 Generated with [Claude Code](https://claude.com/claude-code)