### PR TITLE
fix(frontend): bind fetch to globalThis 避免 Illegal invocation

### DIFF
--- a/dev/frontend/lib/api/client.ts
+++ b/dev/frontend/lib/api/client.ts
@@ -62,7 +62,8 @@ export class ApiClient {
       (typeof process !== "undefined"
         ? process.env.NEXT_PUBLIC_API_URL ?? "http://localhost:8080"
         : "http://localhost:8080");
-    this.fetchImpl = opts.fetchImpl ?? (globalThis.fetch as typeof fetch);
+    // 必須 bind 到 globalThis，否則瀏覽器 fetch 失去 this context，拋出 "Illegal invocation"
+    this.fetchImpl = opts.fetchImpl ?? globalThis.fetch.bind(globalThis);
     this.getApiKey = opts.getApiKey ?? defaultGetApiKey;
     this.onUnauthorized = opts.onUnauthorized ?? defaultOnUnauthorized;
   }


### PR DESCRIPTION
瀏覽器 fetch 需要 Window context，儲存為 class property 後失去 this 會拋出錯誤。用 bind 修復。

Fixes: Bootstrap API Key 頁面建立失敗錯誤

🤖 Generated with [Claude Code](https://claude.com/claude-code)