### PR TITLE
fix(frontend): 修正錯誤的 API 路徑 (404)

### DIFF
--- a/dev/frontend/app/(dashboard)/layout.tsx
+++ b/dev/frontend/app/(dashboard)/layout.tsx
@@ -11,6 +11,7 @@ import { AppHeader } from "@/components/app-header";
 interface InboxCountResponse {
   count?: number;
   total?: number;
+  pagination?: { total?: number };
 }
 
 export default function DashboardLayout({
@@ -32,16 +33,20 @@ export default function DashboardLayout({
     queryKey: ["inbox", "count"],
     queryFn: async () => {
       try {
-        return await apiClient.get<InboxCountResponse>("/api/v1/inbox/count");
+        // Inbox = category_id=null 且 is_archived=false 的 entries
+        return await apiClient.get<InboxCountResponse>(
+          "/api/v1/entries?category_id=null&is_archived=false&per_page=1",
+        );
       } catch {
-        return { count: 0 };
+        return { count: 0, pagination: { total: 0 } };
       }
     },
     enabled: !!apiKey,
     staleTime: 60_000,
   });
 
-  const inboxCount = data?.count ?? data?.total ?? 0;
+  const inboxCount =
+    data?.pagination?.total ?? data?.count ?? data?.total ?? 0;
 
   if (hydrated && !apiKey) {
     return null;

--- a/dev/frontend/lib/api/bootstrap.ts
+++ b/dev/frontend/lib/api/bootstrap.ts
@@ -1,4 +1,4 @@
-import { apiClient } from "./client";
+import { apiClient, ApiError } from "./client";
 
 export interface BootstrapStatus {
   bootstrapped: boolean;
@@ -11,15 +11,32 @@ export interface BootstrapResult {
   created_at: string;
 }
 
+// Bootstrap 狀態：嘗試未認證呼叫 POST /api/v1/auth/api-keys 建立（空 name 會 400），
+// 若 401 代表已 bootstrapped，400/其他代表可以 bootstrap。
+// 實際實作：用一個試探性 GET /api/v1/auth/api-keys（需認證，若 bootstrap 未完成會得到什麼？）
+// 最簡單做法：直接嘗試建立，若 401 轉向提示輸入已有的 key。
 export async function fetchBootstrapStatus(): Promise<BootstrapStatus> {
-  return apiClient.get<BootstrapStatus>("/api/v1/bootstrap/status", {
-    // status endpoint does not require auth
-  });
+  // 探測：嘗試列 api-keys（不帶 auth）。已 bootstrap 會 401，未 bootstrap 也會 401（所有 v1 都需 auth 除了建立第一把）
+  // 改用另一個探測：嘗試建立但帶無效 body → 若 400 (INVALID_INPUT) 表示 bootstrap 可用；若 401 表示已 bootstrapped
+  try {
+    await apiClient.post(
+      "/api/v1/auth/api-keys",
+      {}, // 空 body 會被 400 或 201（若 bootstrap 且 name 空則 INVALID_INPUT）
+      { skipAuth: true },
+    );
+    return { bootstrapped: false };
+  } catch (err) {
+    if (err instanceof ApiError) {
+      if (err.status === 401) return { bootstrapped: true };
+      if (err.status === 400) return { bootstrapped: false };
+    }
+    throw err;
+  }
 }
 
 export async function createFirstApiKey(name: string): Promise<BootstrapResult> {
   return apiClient.post<BootstrapResult>(
-    "/api/v1/bootstrap",
+    "/api/v1/auth/api-keys",
     { name },
     { skipAuth: true },
   );


### PR DESCRIPTION
後端沒有 /api/v1/bootstrap 和 /api/v1/inbox/count，修正為使用既有的 /api/v1/auth/api-keys 和 /api/v1/entries。

🤖 Generated with [Claude Code](https://claude.com/claude-code)