### PR TITLE
test(calendar): Sprint 8 e2e 測試骨架

### DIFF
--- a/test/browser/fixtures/calendar.ts
+++ b/test/browser/fixtures/calendar.ts
@@ -1,0 +1,162 @@
+/**
+ * 行事曆測試共用 fixtures 與 helpers（Sprint 8, F-026 / F-027）
+ *
+ * 目前（Wave 0 skeleton 階段）僅提供 TODO 佔位實作；
+ * Wave 3 補完時會：
+ *   1. 呼叫真實 API 建立指定日期的 entries
+ *   2. 透過 gcal mock server 設定指定日期的 events
+ *   3. 提供 X-Timezone header 輔助
+ *
+ * 對應 issue：#85
+ * 對應 spec：
+ *   - specs/features/f026-calendar-view.md
+ *   - specs/features/f027-calendar-frontend.md
+ */
+
+import type { ApiClient } from "../helpers/api-client";
+
+// ---------------------------------------------------------------------------
+// 共用 data-testid 常數（與 engineer 對齊，見 F-027 spec）
+// ---------------------------------------------------------------------------
+
+/**
+ * Calendar 頁面所有 data-testid 命名慣例統一集中於此。
+ * Engineer 在實作 UI 時請沿用這些 testid，避免 spec 中散落字串。
+ */
+export const CALENDAR_TESTIDS = {
+  // 頁面容器
+  page: "calendar-page",
+
+  // Toolbar
+  toolbar: "calendar-toolbar",
+  toolbarTitle: "calendar-toolbar-title", // 例：「2026 年 4 月」
+  prevButton: "calendar-prev-button",
+  nextButton: "calendar-next-button",
+  todayButton: "calendar-today-button",
+  viewTabs: "calendar-view-tabs",
+  viewTabMonth: "calendar-view-tab-month",
+  viewTabWeek: "calendar-view-tab-week",
+  viewTabDay: "calendar-view-tab-day",
+
+  // 月視圖
+  monthView: "calendar-month-view",
+  /** 動態：`calendar-day-cell-2026-04-24` */
+  dayCell: (date: string) => `calendar-day-cell-${date}`,
+  dayCellToday: "calendar-day-cell-today",
+  entryBadge: "calendar-entry-badge",
+  eventBadge: "calendar-event-badge",
+  eventOverflowBadge: "calendar-event-overflow-badge", // 「+1」
+  journalIcon: "calendar-journal-icon",
+
+  // 週/日視圖
+  weekView: "calendar-week-view",
+  dayView: "calendar-day-view",
+
+  // Day Detail Sheet
+  sheet: "calendar-day-sheet",
+  sheetClose: "calendar-day-sheet-close",
+  sheetSectionEntries: "calendar-day-sheet-entries",
+  sheetSectionEvents: "calendar-day-sheet-events",
+  sheetSectionJournal: "calendar-day-sheet-journal",
+  sheetWriteJournalButton: "calendar-day-sheet-write-journal",
+
+  // Gcal event 卡片 + 轉 entry
+  eventCard: "calendar-event-card", // 動態加 gcal_id 亦可
+  eventToEntryButton: "calendar-event-to-entry-button",
+  eventLinkedEntryLink: "calendar-event-linked-entry-link", // 「查看 entry #N」
+  eventActionMenu: "calendar-event-action-menu",
+
+  // Banner / Toast / Degraded 狀態
+  gcalNotConnectedBanner: "calendar-gcal-not-connected-banner",
+  gcalDegradedToast: "calendar-gcal-degraded-toast",
+  gcalDegradedInlineWarning: "calendar-gcal-degraded-inline-warning",
+} as const;
+
+// ---------------------------------------------------------------------------
+// Seed helpers（TODO: Wave 3 實作）
+// ---------------------------------------------------------------------------
+
+export interface SeedEntryAt {
+  /** 日期（YYYY-MM-DD），以使用者 timezone 解釋 */
+  date: string;
+  /** 建立數量 */
+  count: number;
+  /** 自訂 title prefix */
+  titlePrefix?: string;
+}
+
+/**
+ * 於指定日期建立若干 entries。
+ *
+ * Wave 3 實作要點：
+ *   - 直接呼叫 `client.createEntry()`，但需覆寫 `created_at`（後端需支援 admin/test flag，或透過 DB fixture 插入）
+ *   - 若後端不允許覆寫 created_at，改由 gofixture / 測試用路由插入
+ *
+ * 目前（Wave 0）為佔位 no-op。
+ */
+export async function seedEntriesOnDate(
+  _client: ApiClient,
+  _opts: SeedEntryAt
+): Promise<Array<{ id: string }>> {
+  // TODO(Wave 3): 實作跨日 seed；需與 engineer 確認是否提供 test-only endpoint
+  return [];
+}
+
+export interface GcalEventSeed {
+  gcal_id: string;
+  summary: string;
+  /** RFC3339，如 `2026-04-24T09:00:00+08:00` */
+  start: string;
+  end: string;
+  all_day?: boolean;
+  description?: string;
+  location?: string;
+}
+
+/**
+ * 設定 gcal mock server 下次回應的 events 清單。
+ *
+ * Wave 3 實作要點：
+ *   - 沿用 Sprint 5 F-009 的 gcal mock server（見 `test/e2e/f009_gcal_import_test.go`）
+ *   - 透過 mock server 的 admin endpoint（例：`POST http://gcal-mock/__set_events`）
+ *     預設本次測試要回傳的事件
+ *   - 也需能切換到「回 500」「回 404 specific event」等錯誤模式
+ *
+ * 目前（Wave 0）為佔位 no-op。
+ */
+export async function seedGcalEvents(_events: GcalEventSeed[]): Promise<void> {
+  // TODO(Wave 3): 串接 gcal mock server admin API
+}
+
+/**
+ * 將 gcal mock 切為「上游失敗 500」模式，觸發 X-Degraded: gcal。
+ *
+ * 目前（Wave 0）為佔位 no-op。
+ */
+export async function setGcalMockMode(
+  _mode: "normal" | "degraded-500" | "not-connected" | "not-found"
+): Promise<void> {
+  // TODO(Wave 3): 串接 gcal mock server admin API
+}
+
+/**
+ * 取得瀏覽器時區字串（例 `Asia/Taipei`）。
+ *
+ * 測試會以 Playwright `contextOptions.timezoneId` 固定時區，
+ * 此 helper 方便 assertion 時組合日期。
+ */
+export const DEFAULT_TEST_TIMEZONE = "Asia/Taipei";
+
+/**
+ * 產生 YYYY-MM-DD 格式的日期字串（避免時區漂移）
+ */
+export function toDateStr(d: Date, tz = DEFAULT_TEST_TIMEZONE): string {
+  // 使用 Intl.DateTimeFormat 確保依 tz 取得正確日期
+  const fmt = new Intl.DateTimeFormat("en-CA", {
+    timeZone: tz,
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+  });
+  return fmt.format(d); // en-CA 即 YYYY-MM-DD
+}

--- a/test/browser/specs/calendar-day-sheet.spec.ts
+++ b/test/browser/specs/calendar-day-sheet.spec.ts
@@ -1,0 +1,86 @@
+/**
+ * F-027c — DayDetailSheet 開啟 / 三區渲染 / URL 同步
+ *
+ * 對應 issue：#85（Wave 0 skeleton）
+ * 對應 spec：
+ *   - specs/features/f027-calendar-frontend.md §Scenario: 點日期開啟側邊詳情
+ *   - specs/features/f026-calendar-view.md §Scenario: 取得單日詳情
+ *
+ * 狀態：Wave 0 — 所有 test 先 skip。
+ */
+
+import { test, expect } from "@playwright/test";
+import { CALENDAR_TESTIDS as T } from "../fixtures/calendar";
+
+test.describe("Calendar — Day Detail Sheet（F-027c）", () => {
+  test("Scenario: 點月格 → Sheet 滑出 + URL date 同步", async ({ page }) => {
+    test.skip(true, "Wave 3 — 等 feature 完成再啟用");
+
+    // WHEN 在月視圖點擊 2026-04-24 的格子
+    // THEN
+    //   - 右側 Sheet 滑出（visible）
+    //   - URL 更新為 ?view=month&date=2026-04-24
+    //   - 已呼叫 GET /api/v1/calendar/days/2026-04-24
+    await page.goto("/calendar?view=month&date=2026-04-01");
+    await page.getByTestId(T.dayCell("2026-04-24")).click();
+    await expect(page.getByTestId(T.sheet)).toBeVisible();
+    await expect(page).toHaveURL(/date=2026-04-24/);
+  });
+
+  test("Scenario: Sheet 三區（條目 / 事件 / 日記）全部渲染", async ({ page }) => {
+    test.skip(true, "Wave 3 — 等 feature 完成再啟用");
+
+    // GIVEN 2026-04-24 有 entries + events + journal
+    // WHEN 開啟該日 Sheet
+    // THEN 三個 section 皆可見，且分別顯示對應資料筆數
+    await page.goto("/calendar?view=month&date=2026-04-24");
+    await page.getByTestId(T.dayCell("2026-04-24")).click();
+    const sheet = page.getByTestId(T.sheet);
+    await expect(sheet.getByTestId(T.sheetSectionEntries)).toBeVisible();
+    await expect(sheet.getByTestId(T.sheetSectionEvents)).toBeVisible();
+    await expect(sheet.getByTestId(T.sheetSectionJournal)).toBeVisible();
+  });
+
+  test("Scenario: URL 直接帶 date 可直接開 Sheet", async ({ page }) => {
+    test.skip(true, "Wave 3 — 等 feature 完成再啟用");
+
+    // WHEN 直接訪問 /calendar?view=month&date=2026-04-24
+    // THEN Sheet 已開啟（自動 open）
+    await page.goto("/calendar?view=month&date=2026-04-24");
+    await expect(page.getByTestId(T.sheet)).toBeVisible();
+  });
+
+  test("Scenario: 按 Esc 關閉 Sheet + 清除 URL date 參數", async ({ page }) => {
+    test.skip(true, "Wave 3 — 等 feature 完成再啟用");
+
+    // GIVEN Sheet 已開啟
+    // WHEN 按 Esc
+    // THEN Sheet 關閉，URL 移除 date 參數
+    await page.goto("/calendar?view=month&date=2026-04-24");
+    await page.keyboard.press("Escape");
+    await expect(page.getByTestId(T.sheet)).toBeHidden();
+    await expect(page).not.toHaveURL(/date=2026-04-24/);
+  });
+
+  test("Scenario: 點遮罩關閉 Sheet", async ({ page }) => {
+    test.skip(true, "Wave 3 — 等 feature 完成再啟用");
+
+    // GIVEN Sheet 已開啟
+    // WHEN 點擊 overlay
+    // THEN Sheet 關閉，URL date 被清
+    await page.goto("/calendar?view=month&date=2026-04-24");
+    await page.getByTestId(T.sheetClose).click();
+    await expect(page.getByTestId(T.sheet)).toBeHidden();
+  });
+
+  test("Scenario: Sheet 內「寫日記」CTA 跳 F-028 Journal 頁", async ({ page }) => {
+    test.skip(true, "Wave 3 — 等 feature 完成再啟用");
+
+    // GIVEN Sheet 開啟，且當日沒有 journal
+    // WHEN 點「寫日記」
+    // THEN 跳轉到 /journal/2026-04-24（或相當路徑，以 F-028 為準）
+    await page.goto("/calendar?view=month&date=2026-04-24");
+    await page.getByTestId(T.sheetWriteJournalButton).click();
+    await expect(page).toHaveURL(/\/journal/);
+  });
+});

--- a/test/browser/specs/calendar-gcal-degraded.spec.ts
+++ b/test/browser/specs/calendar-gcal-degraded.spec.ts
@@ -1,0 +1,123 @@
+/**
+ * F-026b / F-027a / F-027c — Gcal 降級 + 未連接路徑
+ *
+ * 對應 issue：#85（Wave 0 skeleton）
+ * 對應 spec：
+ *   - specs/features/f026-calendar-view.md §Scenario: gcal 上游失敗走 degraded
+ *   - specs/features/f026-calendar-view.md §Scenario: 未連 gcal 但要求 include_gcal
+ *   - specs/features/f027-calendar-frontend.md §Error Handling
+ *   - Issue #85 §Gcal degraded 路徑 / 未連 gcal 路徑
+ *
+ * 狀態：Wave 0 — 所有 test 先 skip。
+ */
+
+import { test, expect } from "@playwright/test";
+import { CALENDAR_TESTIDS as T } from "../fixtures/calendar";
+
+test.describe("Calendar — Gcal Degraded（X-Degraded: gcal）", () => {
+  test("Scenario: 上游 500 → X-Degraded header + degraded toast + entries 正常顯示", async ({
+    page,
+  }) => {
+    test.skip(true, "Wave 3 — 等 feature 完成再啟用");
+
+    // GIVEN gcal mock 設為 500
+    // WHEN 載入 /calendar
+    // THEN
+    //   - response header X-Degraded: gcal
+    //   - 顯示 sonner toast「Google Calendar 暫時無法載入，僅顯示知識條目」
+    //   - 月格 events 區塊空，entries 正常
+    await page.goto("/calendar");
+    await expect(page.getByTestId(T.gcalDegradedToast)).toBeVisible();
+    await expect(
+      page.getByText(/Google Calendar 暫時無法載入|僅顯示知識條目/)
+    ).toBeVisible();
+  });
+
+  test("Scenario: Degraded 狀態下開 Day Sheet，事件 section 顯示 inline warning", async ({
+    page,
+  }) => {
+    test.skip(true, "Wave 3 — 等 feature 完成再啟用");
+
+    // GIVEN 月視圖為 degraded 狀態
+    // WHEN 點格子開 Sheet
+    // THEN 事件 section 顯示 inline warning；條目 / 日記 section 仍正常渲染
+    await page.goto("/calendar?view=month&date=2026-04-24");
+    const sheet = page.getByTestId(T.sheet);
+    await expect(
+      sheet.getByTestId(T.gcalDegradedInlineWarning)
+    ).toBeVisible();
+    await expect(sheet.getByTestId(T.sheetSectionEntries)).toBeVisible();
+    await expect(sheet.getByTestId(T.sheetSectionJournal)).toBeVisible();
+  });
+});
+
+test.describe("Calendar — Gcal 未連接路徑", () => {
+  test("Scenario: 首次載入 → banner「尚未連接 Google Calendar」+ /settings 連結", async ({
+    page,
+  }) => {
+    test.skip(true, "Wave 3 — 等 feature 完成再啟用");
+
+    // GIVEN 使用者未完成 gcal OAuth（後端可能回 424 或 200 + gcal_connected=false）
+    // WHEN 載入 /calendar
+    // THEN 頂部 banner 可見，含前往 /settings 的連結
+    await page.goto("/calendar");
+    const banner = page.getByTestId(T.gcalNotConnectedBanner);
+    await expect(banner).toBeVisible();
+    await expect(banner.getByRole("link", { name: /設定|前往/ })).toHaveAttribute(
+      "href",
+      /\/settings/
+    );
+  });
+
+  test("Scenario: 未連接時自動以 include_gcal=false 重試，並寫入 localStorage（TTL 1 小時）", async ({
+    page,
+  }) => {
+    test.skip(true, "Wave 3 — 等 feature 完成再啟用");
+
+    // GIVEN 尚未連 gcal
+    // WHEN 首次載入 /calendar?include_gcal=true
+    // THEN
+    //   - 收 424 / gcal_connected=false 後自動重試 include_gcal=false
+    //   - localStorage 寫入 aibo_gcal_connected=false（含 1h TTL）
+    //   - 後續重整不再打 include_gcal=true
+    await page.goto("/calendar");
+    const stored = await page.evaluate(() =>
+      localStorage.getItem("aibo_gcal_connected")
+    );
+    expect(stored).toContain("false");
+  });
+
+  test("Scenario: localStorage 已記錄 not-connected → 直接以 include_gcal=false 載入", async ({
+    page,
+  }) => {
+    test.skip(true, "Wave 3 — 等 feature 完成再啟用");
+
+    // GIVEN localStorage 已寫 aibo_gcal_connected=false（TTL 未過期）
+    // WHEN 再次載入 /calendar
+    // THEN 不再呼叫 include_gcal=true 的 API（避免 424 噪音）
+    await page.goto("/");
+    await page.evaluate(() => {
+      const payload = { connected: false, expiresAt: Date.now() + 60 * 60 * 1000 };
+      localStorage.setItem("aibo_gcal_connected", JSON.stringify(payload));
+    });
+    // 用 request interception 驗證 include_gcal 參數
+    // TODO(Wave 3): page.route + assert request url 不含 include_gcal=true
+    await page.goto("/calendar");
+    await expect(page.getByTestId(T.gcalNotConnectedBanner)).toBeVisible();
+  });
+
+  test("Scenario: TTL 過期 → 重新嘗試 include_gcal=true", async ({ page }) => {
+    test.skip(true, "Wave 3 — 等 feature 完成再啟用");
+
+    // GIVEN localStorage 中的 TTL 已過期
+    // WHEN 載入 /calendar
+    // THEN 重新嘗試 include_gcal=true
+    await page.goto("/");
+    await page.evaluate(() => {
+      const payload = { connected: false, expiresAt: Date.now() - 1000 };
+      localStorage.setItem("aibo_gcal_connected", JSON.stringify(payload));
+    });
+    // TODO(Wave 3): assert request url 含 include_gcal=true
+    await page.goto("/calendar");
+  });
+});

--- a/test/browser/specs/calendar-gcal-to-entry.spec.ts
+++ b/test/browser/specs/calendar-gcal-to-entry.spec.ts
@@ -1,0 +1,93 @@
+/**
+ * F-026c / F-027c — Gcal event 轉 entry（成功 / 409 / 502 / linked_entry_id 顯示）
+ *
+ * 對應 issue：#85（Wave 0 skeleton）
+ * 對應 spec：
+ *   - specs/features/f026-calendar-view.md §POST /events/:gcal_id/to-entry
+ *   - specs/features/f027-calendar-frontend.md §Scenario: 從事件轉為 entry
+ *
+ * 狀態：Wave 0 — 所有 test 先 skip。
+ */
+
+import { test, expect } from "@playwright/test";
+import { CALENDAR_TESTIDS as T } from "../fixtures/calendar";
+
+test.describe("Calendar — Gcal event → Entry（F-026c + F-027c）", () => {
+  test("Scenario: 成功轉換 — toast + event 卡片變「查看 entry」+ 條目列表多一筆", async ({
+    page,
+  }) => {
+    test.skip(true, "Wave 3 — 等 feature 完成再啟用");
+
+    // GIVEN Sheet 開啟，顯示 gcal event「Standup」未關聯
+    // WHEN 點該 event 卡片的「轉成 entry」
+    // THEN
+    //   - 呼叫 POST /api/v1/calendar/events/:gcal_id/to-entry，回 201
+    //   - toast 顯示「已轉為知識條目」
+    //   - 該 event 卡片變成「查看 entry #N」連結（linked_entry_id 顯示）
+    //   - Sheet 條目 section 多一筆新 entry（query 重新 fetch）
+    await page.goto("/calendar?view=month&date=2026-04-24");
+    const eventCard = page.getByTestId(T.eventCard).first();
+    await eventCard.getByTestId(T.eventToEntryButton).click();
+
+    await expect(page.getByText(/已轉為知識條目/)).toBeVisible();
+    await expect(eventCard.getByTestId(T.eventLinkedEntryLink)).toBeVisible();
+  });
+
+  test("Scenario: 重複轉（409 ALREADY_LINKED）顯示「已轉過」toast", async ({ page }) => {
+    test.skip(true, "Wave 3 — 等 feature 完成再啟用");
+
+    // GIVEN event 已被轉過一次
+    // WHEN 再次點「轉成 entry」（可能並發或使用者重複點）
+    // THEN
+    //   - 後端回 409 ALREADY_LINKED
+    //   - toast 顯示「已轉過」
+    //   - React Query invalidate，卡片刷新為「查看 entry #N」
+    await page.goto("/calendar?view=month&date=2026-04-24");
+    const eventCard = page.getByTestId(T.eventCard).first();
+    await eventCard.getByTestId(T.eventToEntryButton).click();
+
+    await expect(page.getByText(/已轉過/)).toBeVisible();
+    await expect(eventCard.getByTestId(T.eventLinkedEntryLink)).toBeVisible();
+  });
+
+  test("Scenario: Gcal 上游失敗（502 GCAL_UPSTREAM_ERROR）顯示錯誤 toast", async ({
+    page,
+  }) => {
+    test.skip(true, "Wave 3 — 等 feature 完成再啟用");
+
+    // GIVEN gcal mock 設為 500（導致後端回 502）
+    // WHEN 點「轉成 entry」
+    // THEN toast 顯示失敗訊息，event 卡片狀態不變
+    await page.goto("/calendar?view=month&date=2026-04-24");
+    const eventCard = page.getByTestId(T.eventCard).first();
+    await eventCard.getByTestId(T.eventToEntryButton).click();
+
+    await expect(page.getByText(/無法轉換|失敗|上游/)).toBeVisible();
+  });
+
+  test("Scenario: 預先已 linked 的 event 直接顯示「查看 entry」不顯示轉換按鈕", async ({
+    page,
+  }) => {
+    test.skip(true, "Wave 3 — 等 feature 完成再啟用");
+
+    // GIVEN /calendar/days API 回傳的 events[].linked_entry_id != null
+    // WHEN 開啟 Sheet
+    // THEN 該 event 卡片僅顯示「查看 entry #N」連結，無「轉成 entry」按鈕
+    await page.goto("/calendar?view=month&date=2026-04-24");
+    const linkedCard = page.getByTestId(T.eventCard).first();
+    await expect(linkedCard.getByTestId(T.eventLinkedEntryLink)).toBeVisible();
+    await expect(linkedCard.getByTestId(T.eventToEntryButton)).toHaveCount(0);
+  });
+
+  test("Scenario: 點「查看 entry」跳轉到該 entry 詳情頁", async ({ page }) => {
+    test.skip(true, "Wave 3 — 等 feature 完成再啟用");
+
+    // GIVEN event 卡片已 linked
+    // WHEN 點「查看 entry #N」
+    // THEN 導航到 /entries/<entry_id>
+    await page.goto("/calendar?view=month&date=2026-04-24");
+    const linkedCard = page.getByTestId(T.eventCard).first();
+    await linkedCard.getByTestId(T.eventLinkedEntryLink).click();
+    await expect(page).toHaveURL(/\/entries\/[0-9a-f-]+/);
+  });
+});

--- a/test/browser/specs/calendar-month-view.spec.ts
+++ b/test/browser/specs/calendar-month-view.spec.ts
@@ -1,0 +1,97 @@
+/**
+ * F-026 / F-027 — 月視圖載入、格子顯示、今日高亮
+ *
+ * 對應 issue：#85（Wave 0 skeleton）
+ * 對應 spec：
+ *   - specs/features/f026-calendar-view.md §Scenarios / Happy Path
+ *   - specs/features/f027-calendar-frontend.md §Scenario: 開啟行事曆預設為當月
+ *
+ * 狀態：Wave 0 — 所有 test 先 skip，等 Wave 1/2 feature 完成後由 Wave 3 補 assertion。
+ */
+
+import { test, expect } from "@playwright/test";
+import { CALENDAR_TESTIDS as T } from "../fixtures/calendar";
+
+test.describe("Calendar — 月視圖（F-026b + F-027a）", () => {
+  test("Scenario: 預設載入當月月視圖 + toolbar 年月", async ({ page }) => {
+    test.skip(true, "Wave 3 — 等 feature 完成再啟用");
+
+    // WHEN 使用者 navigate 到 /calendar
+    // THEN
+    //   - 顯示 6×7 月視圖
+    //   - toolbar 顯示「<當前年> 年 <當前月> 月」
+    //   - 已呼叫 GET /api/v1/calendar?since=...&until=...&view=month
+    //   - request header 含 X-Timezone=<browser tz>
+    await page.goto("/calendar");
+    await expect(page.getByTestId(T.monthView)).toBeVisible();
+    await expect(page.getByTestId(T.toolbarTitle)).toContainText(/\d{4}\s*年\s*\d{1,2}\s*月/);
+  });
+
+  test("Scenario: 今天格子有高亮樣式", async ({ page }) => {
+    test.skip(true, "Wave 3 — 等 feature 完成再啟用");
+
+    // WHEN 月視圖渲染完成
+    // THEN 當日格子帶有 data-testid="calendar-day-cell-today" 或 aria-current="date"
+    await page.goto("/calendar");
+    await expect(page.getByTestId(T.dayCellToday)).toBeVisible();
+  });
+
+  test("Scenario: 月格顯示 entry badge / event title / journal icon", async ({ page }) => {
+    test.skip(true, "Wave 3 — 等 feature 完成再啟用");
+
+    // GIVEN 2026-04-24 有 3 筆 entries + 3 筆 gcal events + 1 筆 journal
+    // WHEN 載入 /calendar?view=month&date=2026-04-24
+    // THEN 該格：
+    //   - entry badge 顯示「3」
+    //   - 前 2 個 event title 可見
+    //   - 第 3 個以「+1」overflow badge 呈現
+    //   - journal icon 可見
+    await page.goto("/calendar?view=month&date=2026-04-24");
+    const cell = page.getByTestId(T.dayCell("2026-04-24"));
+    await expect(cell.getByTestId(T.entryBadge)).toContainText("3");
+    await expect(cell.getByTestId(T.eventBadge)).toHaveCount(2);
+    await expect(cell.getByTestId(T.eventOverflowBadge)).toContainText("+1");
+    await expect(cell.getByTestId(T.journalIcon)).toBeVisible();
+  });
+
+  test("Scenario: 點「下個月」/「上個月」更新 URL 並重新 fetch", async ({ page }) => {
+    test.skip(true, "Wave 3 — 等 feature 完成再啟用");
+
+    // WHEN 點「下個月」
+    // THEN URL date 參數往後 1 個月，toolbar 年月更新
+    await page.goto("/calendar?view=month&date=2026-04-15");
+    await page.getByTestId(T.nextButton).click();
+    await expect(page).toHaveURL(/date=2026-05/);
+    await expect(page.getByTestId(T.toolbarTitle)).toContainText("2026 年 5 月");
+  });
+
+  test("Scenario: 點「今天」按鈕回到當月", async ({ page }) => {
+    test.skip(true, "Wave 3 — 等 feature 完成再啟用");
+
+    // GIVEN 使用者已切到 2026-01
+    // WHEN 點「今天」
+    // THEN URL date 參數變為當日，月視圖切回當月
+    await page.goto("/calendar?view=month&date=2026-01-10");
+    await page.getByTestId(T.todayButton).click();
+    await expect(page.getByTestId(T.dayCellToday)).toBeVisible();
+  });
+
+  test("Scenario: 側邊欄「行事曆」項目導航 + active 樣式", async ({ page }) => {
+    test.skip(true, "Wave 3 — 等 feature 完成再啟用");
+
+    // WHEN 點 sidebar「行事曆」
+    // THEN 導航到 /calendar，該 nav item 取得 active 樣式
+    await page.goto("/");
+    await page.getByRole("link", { name: /行事曆/ }).click();
+    await expect(page).toHaveURL(/\/calendar/);
+  });
+
+  test("Scenario: URL 直接指定 date 參數可正確顯示該月", async ({ page }) => {
+    test.skip(true, "Wave 3 — 等 feature 完成再啟用");
+
+    // WHEN 直接訪問 /calendar?view=month&date=2026-03-15
+    // THEN 顯示 2026-03 月視圖，toolbar 標題為「2026 年 3 月」
+    await page.goto("/calendar?view=month&date=2026-03-15");
+    await expect(page.getByTestId(T.toolbarTitle)).toContainText("2026 年 3 月");
+  });
+});

--- a/test/browser/specs/calendar-timezone.spec.ts
+++ b/test/browser/specs/calendar-timezone.spec.ts
@@ -1,0 +1,76 @@
+/**
+ * F-026b — Asia/Taipei 時區下跨日 entry / event 分桶
+ *
+ * 對應 issue：#85（Wave 0 skeleton）
+ * 對應 spec：
+ *   - specs/features/f026-calendar-view.md §Scenario: 不同時區下的日期歸屬
+ *   - specs/features/f026-calendar-view.md §Business Rules #1
+ *
+ * 狀態：Wave 0 — 所有 test 先 skip。
+ */
+
+import { test, expect } from "@playwright/test";
+import { CALENDAR_TESTIDS as T, DEFAULT_TEST_TIMEZONE } from "../fixtures/calendar";
+
+// 固定瀏覽器時區到 Asia/Taipei，讓 X-Timezone header 固定
+test.use({ timezoneId: DEFAULT_TEST_TIMEZONE });
+
+test.describe("Calendar — 時區分桶（F-026b, Asia/Taipei）", () => {
+  test("Scenario: 23:30 建立的 entry 歸屬於當日（非隔日 UTC）", async ({ page }) => {
+    test.skip(true, "Wave 3 — 等 feature 完成再啟用");
+
+    // GIVEN entry created_at = 2026-04-24T23:30:00+08:00
+    //   （對應 UTC 2026-04-24T15:30:00Z —— 若誤用 UTC 會歸到 04-24，仍正確；
+    //    但若 created_at = 2026-04-25T00:30:00+08:00，UTC 是 04-24T16:30Z，
+    //    需 Asia/Taipei 才能正確歸到 04-25）
+    // WHEN 以 X-Timezone: Asia/Taipei 載入該月
+    // THEN 2026-04-24 格的 entry_count 包含該 entry
+    await page.goto("/calendar?view=month&date=2026-04-24");
+    const cell = page.getByTestId(T.dayCell("2026-04-24"));
+    await expect(cell.getByTestId(T.entryBadge)).toContainText(/[1-9]/);
+  });
+
+  test("Scenario: 跨午夜 event（23:30–00:30）在 24 與 25 兩格都顯示", async ({ page }) => {
+    test.skip(true, "Wave 3 — 等 feature 完成再啟用");
+
+    // GIVEN event start=2026-04-24T23:30+08:00, end=2026-04-25T00:30+08:00
+    // WHEN 載入月視圖，X-Timezone: Asia/Taipei
+    // THEN 2026-04-24 與 2026-04-25 兩格的 events 皆含該 event
+    await page.goto("/calendar?view=month&date=2026-04-24");
+    const day24 = page.getByTestId(T.dayCell("2026-04-24"));
+    const day25 = page.getByTestId(T.dayCell("2026-04-25"));
+    await expect(day24.getByTestId(T.eventBadge).first()).toBeVisible();
+    await expect(day25.getByTestId(T.eventBadge).first()).toBeVisible();
+  });
+
+  test("Scenario: 跨日 event 在 day view 的 2026-04-25 Sheet 中仍可見", async ({ page }) => {
+    test.skip(true, "Wave 3 — 等 feature 完成再啟用");
+
+    // GIVEN event 23:30–00:30 跨越 04-24 → 04-25
+    // WHEN 以 view=day&date=2026-04-25 載入
+    // THEN Sheet 事件 section 含該 event
+    await page.goto("/calendar?view=day&date=2026-04-25");
+    await expect(
+      page.getByTestId(T.sheetSectionEvents).getByTestId(T.eventCard).first()
+    ).toBeVisible();
+  });
+
+  test("Scenario: X-Timezone header 為 Asia/Taipei（由瀏覽器 timezoneId 決定）", async ({
+    page,
+  }) => {
+    test.skip(true, "Wave 3 — 等 feature 完成再啟用");
+
+    // WHEN 載入 /calendar
+    // THEN 所有對 /api/v1/calendar* 的 request header X-Timezone = Asia/Taipei
+    // TODO(Wave 3): 用 page.route 攔截 request，assert header
+    const requests: string[] = [];
+    page.on("request", (req) => {
+      if (req.url().includes("/api/v1/calendar")) {
+        requests.push(req.headers()["x-timezone"] ?? "");
+      }
+    });
+    await page.goto("/calendar");
+    expect(requests.length).toBeGreaterThan(0);
+    expect(requests[0]).toBe("Asia/Taipei");
+  });
+});

--- a/test/browser/specs/calendar-view-switch.spec.ts
+++ b/test/browser/specs/calendar-view-switch.spec.ts
@@ -1,0 +1,101 @@
+/**
+ * F-027b — month / week / day 視圖切換 + 鍵盤快捷鍵 + 手機 fallback
+ *
+ * 對應 issue：#85（Wave 0 skeleton）
+ * 對應 spec：
+ *   - specs/features/f027-calendar-frontend.md §Scenarios / Edge Cases
+ *
+ * 狀態：Wave 0 — 所有 test 先 skip。
+ */
+
+import { test, expect } from "@playwright/test";
+import { CALENDAR_TESTIDS as T } from "../fixtures/calendar";
+
+test.describe("Calendar — 視圖切換（F-027b）", () => {
+  test("Scenario: 點 toolbar「週」tab 切到週視圖，URL 同步", async ({ page }) => {
+    test.skip(true, "Wave 3 — 等 feature 完成再啟用");
+
+    // GIVEN 月視圖
+    // WHEN 點擊「週」tab
+    // THEN URL view=week，畫面渲染 WeekView
+    await page.goto("/calendar?view=month&date=2026-04-24");
+    await page.getByTestId(T.viewTabWeek).click();
+    await expect(page).toHaveURL(/view=week/);
+    await expect(page.getByTestId(T.weekView)).toBeVisible();
+  });
+
+  test("Scenario: 點「日」tab 切到日視圖", async ({ page }) => {
+    test.skip(true, "Wave 3 — 等 feature 完成再啟用");
+
+    await page.goto("/calendar?view=month&date=2026-04-24");
+    await page.getByTestId(T.viewTabDay).click();
+    await expect(page).toHaveURL(/view=day/);
+    await expect(page.getByTestId(T.dayView)).toBeVisible();
+  });
+
+  test("Scenario: 鍵盤快捷鍵 m / w / d 切換視圖", async ({ page }) => {
+    test.skip(true, "Wave 3 — 等 feature 完成再啟用");
+
+    // WHEN 分別按下 m/w/d
+    // THEN view 切換到 month/week/day，URL 同步
+    await page.goto("/calendar");
+    await page.keyboard.press("w");
+    await expect(page).toHaveURL(/view=week/);
+    await page.keyboard.press("d");
+    await expect(page).toHaveURL(/view=day/);
+    await page.keyboard.press("m");
+    await expect(page).toHaveURL(/view=month/);
+  });
+
+  test("Scenario: 鍵盤快捷鍵 t 回到今天", async ({ page }) => {
+    test.skip(true, "Wave 3 — 等 feature 完成再啟用");
+
+    // GIVEN 切到 2026-01
+    // WHEN 按下 t
+    // THEN URL date 變為今日，today 格高亮可見
+    await page.goto("/calendar?view=month&date=2026-01-10");
+    await page.keyboard.press("t");
+    await expect(page.getByTestId(T.dayCellToday)).toBeVisible();
+  });
+
+  test("Scenario: 切到週視圖保留原選日期所在週", async ({ page }) => {
+    test.skip(true, "Wave 3 — 等 feature 完成再啟用");
+
+    // GIVEN 月視圖選中 2026-04-24（週五）
+    // WHEN 切換到 week
+    // THEN 顯示該週（週一 2026-04-20 ~ 週日 2026-04-26）
+    await page.goto("/calendar?view=month&date=2026-04-24");
+    await page.getByTestId(T.viewTabWeek).click();
+    await expect(page.getByTestId(T.weekView)).toBeVisible();
+    // TODO(Wave 3): assert 週視圖顯示的起始日 = 2026-04-20
+  });
+
+  test("Scenario: 左右方向鍵切換日", async ({ page }) => {
+    test.skip(true, "Wave 3 — 等 feature 完成再啟用");
+
+    // WHEN 按右方向鍵
+    // THEN 選日往後 1 天；URL date 同步
+    await page.goto("/calendar?view=day&date=2026-04-24");
+    await page.keyboard.press("ArrowRight");
+    await expect(page).toHaveURL(/date=2026-04-25/);
+    await page.keyboard.press("ArrowLeft");
+    await expect(page).toHaveURL(/date=2026-04-24/);
+  });
+});
+
+test.describe("Calendar — 手機版 fallback（F-027b）", () => {
+  // 以 viewport override 模擬手機
+  test.use({ viewport: { width: 390, height: 844 } });
+
+  test("Scenario: viewport < 768px 自動切 day view + toolbar 隱藏 view tabs", async ({ page }) => {
+    test.skip(true, "Wave 3 — 等 feature 完成再啟用");
+
+    // WHEN 以手機尺寸訪問 /calendar
+    // THEN
+    //   - 自動切到 view=day
+    //   - toolbar 的 view tabs 隱藏
+    await page.goto("/calendar");
+    await expect(page).toHaveURL(/view=day/);
+    await expect(page.getByTestId(T.viewTabs)).toBeHidden();
+  });
+});


### PR DESCRIPTION
## Summary

Wave 0 skeleton — 建立 Sprint 8 行事曆 e2e 測試的 6 個 Playwright spec 檔與共用 fixtures。

**本 PR 僅含 skeleton，所有 test 目前 skip**（`test.skip(true, 'Wave 3 — 等 feature 完成再啟用')`），等 Wave 1/2 feature 實作完成後由 Wave 3 補齊 assertion。

Closes #85（Wave 0 skeleton 部分，完整 assertion 留 Wave 3）

> 註：issue #85 寫「預計建立於 `test/e2e/`」，但該目錄目前是 Sprint 1–6 的 Go e2e tests；所有 Playwright browser specs 依既有慣例（Sprint 7 F-021–F-025）統一放在 `test/browser/specs/`，與 `playwright.config.ts` 的 `testDir: './specs'` 對齊。

## 檔案

### 新增 Playwright specs（共 35 個 test，全部 skip）

| File | Scenarios | 對應 spec |
|------|-----------|----------|
| `test/browser/specs/calendar-month-view.spec.ts` | 7 | F-026b + F-027a 月視圖載入、格子內容、導航 |
| `test/browser/specs/calendar-view-switch.spec.ts` | 7 | F-027b month/week/day toggle + 鍵盤 m/w/d/t + 方向鍵 + 手機 fallback |
| `test/browser/specs/calendar-day-sheet.spec.ts` | 6 | F-027c Sheet 開關、三區、URL 同步、Esc/overlay 關閉 |
| `test/browser/specs/calendar-gcal-to-entry.spec.ts` | 5 | F-026c + F-027c 轉 entry（201 / 409 / 502 / linked_entry_id 顯示） |
| `test/browser/specs/calendar-gcal-degraded.spec.ts` | 6 | X-Degraded: gcal / 未連接 banner / localStorage TTL 1h |
| `test/browser/specs/calendar-timezone.spec.ts` | 4 | Asia/Taipei 跨午夜 entry/event 分桶、X-Timezone header |

### 共用 fixtures

- `test/browser/fixtures/calendar.ts`
  - `CALENDAR_TESTIDS` — 所有 calendar 頁 `data-testid` 常數（toolbar / month view / day cell / sheet / event card / banner 等），供 engineer 實作 UI 時對齊
  - `seedEntriesOnDate()` / `seedGcalEvents()` / `setGcalMockMode()` — Wave 3 待實作的 seed helper（目前為 TODO 佔位 no-op）
  - `DEFAULT_TEST_TIMEZONE = 'Asia/Taipei'` + `toDateStr()` helper

## 驗證

\`\`\`bash
cd test/browser
npx playwright test calendar- --project=chromium --reporter=list
# → 35 skipped
\`\`\`

所有 35 個 calendar scenario test 皆被 Playwright 正確識別並 skip，未觸發任何實際 browser 行為。

## Wave 3 待辦（不在本 PR 範圍）

- [ ] 實作 `fixtures/calendar.ts` 中的 seed helpers（串接 gcal mock server + entry created_at 覆寫）
- [ ] 解開所有 `test.skip`，逐一補齊 assertion
- [ ] 補上 `page.route` request interception（驗證 `X-Timezone` header、`include_gcal` 參數）
- [ ] 加入 mobile-chromium project 的 test match 涵蓋 calendar 手機 fallback
- [ ] CI 綠（Chromium + Mobile Chrome 全通過）

## Test plan

- [x] `npx playwright test --list` 列出 6 個 calendar spec 檔的所有 test
- [x] `npx playwright test calendar- --project=chromium` 全部 skipped（0 failed）
- [ ] Wave 3：feature 完成後補 assertion 並全綠