### PR TITLE
feat(backend): F-026a 行事曆 migration + repo 日期區間查詢

### DIFF
--- a/dev/src/dto/calendar.go
+++ b/dev/src/dto/calendar.go
@@ -1,0 +1,58 @@
+package dto
+
+import (
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// CalendarEntrySummary 行事曆單日內的 entry 精簡表示
+//
+// 用於 GET /api/v1/calendar 與 GET /api/v1/calendar/days/:date 的 entry 區塊。
+// Date 欄位僅用於 service 內部分桶（依 X-Timezone 計算），不對外序列化。
+type CalendarEntrySummary struct {
+	ID         uuid.UUID `json:"id"`
+	Title      *string   `json:"title"`
+	Summary    *string   `json:"summary"`
+	SourceType *string   `json:"source_type"`
+	Tags       []string  `json:"tags"`
+	CreatedAt  time.Time `json:"created_at"`
+	Date       string    `json:"-"` // YYYY-MM-DD，依請求 timezone 計算
+}
+
+// CalendarEventSummary 行事曆單日內的 Google Calendar event 表示
+//
+// 對應 spec §Data Model：不落 DB，read-through 從 gcal API 拿。
+// LinkedEntryID：若該 event 已被轉成 entry（source_type='gcal' 且 source_ref=gcal_id），
+// 則帶入該 entry id；否則為 nil。
+type CalendarEventSummary struct {
+	GcalID        string     `json:"gcal_id"`
+	Summary       string     `json:"summary"`
+	Start         time.Time  `json:"start"`
+	End           time.Time  `json:"end"`
+	AllDay        bool       `json:"all_day"`
+	LinkedEntryID *uuid.UUID `json:"linked_entry_id"`
+	Location      *string    `json:"location,omitempty"`
+	Description   *string    `json:"description,omitempty"`
+}
+
+// CalendarDay 單日彙整
+//
+// 對應 spec §API Contract 的 response.days[*]。
+// HasJournal 目前於 F-026 尚未正式使用（journal 功能於後續 sprint 才會接入），
+// 先保留欄位供 F-026b 填值時使用。
+type CalendarDay struct {
+	Date       string                 `json:"date"`
+	EntryCount int                    `json:"entry_count"`
+	EventCount int                    `json:"event_count"`
+	HasJournal bool                   `json:"has_journal"`
+	Entries    []CalendarEntrySummary `json:"entries"`
+	Events     []CalendarEventSummary `json:"events"`
+}
+
+// CalendarResponse GET /api/v1/calendar 的主回應
+type CalendarResponse struct {
+	Since string        `json:"since"`
+	Until string        `json:"until"`
+	Days  []CalendarDay `json:"days"`
+}

--- a/dev/src/dto/calendar_test.go
+++ b/dev/src/dto/calendar_test.go
@@ -1,0 +1,151 @@
+package dto
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// TestCalendarEntrySummaryJSONTags 驗證 DTO 的 JSON tag 與 spec 完全一致，
+// 特別是 Date 欄位必須以 "-" 標記，不對外序列化（僅供 service 內部分桶）。
+func TestCalendarEntrySummaryJSONTags(t *testing.T) {
+	id := uuid.New()
+	title := "測試條目"
+	summary := "摘要"
+	sourceType := "manual"
+	createdAt := time.Date(2026, 4, 24, 9, 11, 0, 0, time.UTC)
+
+	item := CalendarEntrySummary{
+		ID:         id,
+		Title:      &title,
+		Summary:    &summary,
+		SourceType: &sourceType,
+		Tags:       []string{"golang"},
+		CreatedAt:  createdAt,
+		Date:       "2026-04-24",
+	}
+
+	data, err := json.Marshal(item)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+
+	var parsed map[string]interface{}
+	if err := json.Unmarshal(data, &parsed); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	for _, k := range []string{"id", "title", "summary", "source_type", "tags", "created_at"} {
+		if _, ok := parsed[k]; !ok {
+			t.Errorf("missing key %q in JSON: %s", k, string(data))
+		}
+	}
+	// Date 不應出現於 JSON（tag 為 "-"）
+	if _, ok := parsed["date"]; ok {
+		t.Errorf("expected no 'date' key (internal), got: %s", string(data))
+	}
+	if _, ok := parsed["Date"]; ok {
+		t.Errorf("expected no 'Date' key, got: %s", string(data))
+	}
+}
+
+// TestCalendarEventSummaryJSONTags 驗證 gcal event DTO 的 JSON tag。
+func TestCalendarEventSummaryJSONTags(t *testing.T) {
+	linked := uuid.New()
+	ev := CalendarEventSummary{
+		GcalID:        "abc123",
+		Summary:       "Standup",
+		Start:         time.Date(2026, 4, 24, 9, 0, 0, 0, time.UTC),
+		End:           time.Date(2026, 4, 24, 9, 30, 0, 0, time.UTC),
+		AllDay:        false,
+		LinkedEntryID: &linked,
+	}
+	data, err := json.Marshal(ev)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var parsed map[string]interface{}
+	_ = json.Unmarshal(data, &parsed)
+
+	for _, k := range []string{"gcal_id", "summary", "start", "end", "all_day", "linked_entry_id"} {
+		if _, ok := parsed[k]; !ok {
+			t.Errorf("missing key %q: %s", k, string(data))
+		}
+	}
+	// location / description 為 omitempty，未設值時應不出現
+	if _, ok := parsed["location"]; ok {
+		t.Errorf("expected 'location' omitted when nil, got: %s", string(data))
+	}
+	if _, ok := parsed["description"]; ok {
+		t.Errorf("expected 'description' omitted when nil, got: %s", string(data))
+	}
+}
+
+// TestCalendarEventSummary_OptionalFieldsPresent 驗證設了 location/description 會出現。
+func TestCalendarEventSummary_OptionalFieldsPresent(t *testing.T) {
+	loc := "台北"
+	desc := "說明"
+	ev := CalendarEventSummary{
+		GcalID:      "abc",
+		Summary:     "x",
+		Start:       time.Now(),
+		End:         time.Now(),
+		Location:    &loc,
+		Description: &desc,
+	}
+	data, _ := json.Marshal(ev)
+	var parsed map[string]interface{}
+	_ = json.Unmarshal(data, &parsed)
+	if parsed["location"] != "台北" {
+		t.Errorf("expected location=台北, got %v", parsed["location"])
+	}
+	if parsed["description"] != "說明" {
+		t.Errorf("expected description=說明, got %v", parsed["description"])
+	}
+}
+
+// TestCalendarDayJSONTags 驗證 CalendarDay 的 JSON tag。
+func TestCalendarDayJSONTags(t *testing.T) {
+	day := CalendarDay{
+		Date:       "2026-04-24",
+		EntryCount: 3,
+		EventCount: 2,
+		HasJournal: true,
+		Entries:    []CalendarEntrySummary{},
+		Events:     []CalendarEventSummary{},
+	}
+	data, err := json.Marshal(day)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var parsed map[string]interface{}
+	_ = json.Unmarshal(data, &parsed)
+
+	for _, k := range []string{"date", "entry_count", "event_count", "has_journal", "entries", "events"} {
+		if _, ok := parsed[k]; !ok {
+			t.Errorf("missing key %q: %s", k, string(data))
+		}
+	}
+}
+
+// TestCalendarResponseJSONTags 驗證主 response 結構。
+func TestCalendarResponseJSONTags(t *testing.T) {
+	resp := CalendarResponse{
+		Since: "2026-04-01",
+		Until: "2026-04-30",
+		Days:  []CalendarDay{},
+	}
+	data, err := json.Marshal(resp)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var parsed map[string]interface{}
+	_ = json.Unmarshal(data, &parsed)
+	for _, k := range []string{"since", "until", "days"} {
+		if _, ok := parsed[k]; !ok {
+			t.Errorf("missing key %q: %s", k, string(data))
+		}
+	}
+}

--- a/dev/src/migration/012_add_calendar_indexes.down.sql
+++ b/dev/src/migration/012_add_calendar_indexes.down.sql
@@ -1,0 +1,4 @@
+-- Rollback F-026 行事曆彙整 index
+-- 注意：Step 1 的重複資料刪除無法回復，這是預期行為（down 僅移除 index）
+DROP INDEX IF EXISTS uq_entries_gcal_ref;
+DROP INDEX IF EXISTS idx_entries_created_at_date;

--- a/dev/src/migration/012_add_calendar_indexes.down.sql
+++ b/dev/src/migration/012_add_calendar_indexes.down.sql
@@ -1,4 +1,6 @@
 -- Rollback F-026 行事曆彙整 index
 -- 注意：Step 1 的重複資料刪除無法回復，這是預期行為（down 僅移除 index）
 DROP INDEX IF EXISTS uq_entries_gcal_ref;
+DROP INDEX IF EXISTS idx_entries_created_at;
+-- 舊 index 名（若從先前版本 up 過，一併移除以支援重複 up/down）
 DROP INDEX IF EXISTS idx_entries_created_at_date;

--- a/dev/src/migration/012_add_calendar_indexes.up.sql
+++ b/dev/src/migration/012_add_calendar_indexes.up.sql
@@ -1,0 +1,32 @@
+-- 行事曆彙整 API 相關 index（F-026）
+--
+-- 本 migration 為 Sprint 8 行事曆功能打底：
+--   1. 清理既有因先前 gcal 匯入流程可能殘留的重複 entry（保留最早一筆）
+--   2. 建立「依當地日」查詢用的函數式 index（created_at::date）
+--   3. 建立 gcal event 與 entry 一對一關聯用的 partial unique index
+--
+-- 注意：gcal 唯一性僅限 source_type='gcal' 且 source_ref 非空，
+--       不影響其他 source_type（如 git、manual）可能共用 source_ref 的情境。
+
+-- Step 1: 清理既有 gcal 重複 entry（保留 created_at 最早的一筆）
+--   使用 self-join：刪除「存在另一筆相同 source_ref 但 created_at 更早」的列
+DELETE FROM entries e
+USING entries dup
+WHERE e.source_type = 'gcal'
+  AND dup.source_type = 'gcal'
+  AND e.source_ref IS NOT NULL
+  AND dup.source_ref IS NOT NULL
+  AND e.source_ref = dup.source_ref
+  AND e.created_at > dup.created_at;
+
+-- Step 2: 建立函數式 index：依 UTC 日期查詢用
+--   行事曆 API 常以「某一天」為單位撈資料，此 index 讓 created_at::date 查詢可走 index scan
+CREATE INDEX IF NOT EXISTS idx_entries_created_at_date
+  ON entries ((created_at::date));
+
+-- Step 3: 建立 gcal 關聯 partial unique index
+--   保證「一個 gcal event 最多只能被轉成一筆 entry」
+--   僅對 source_type='gcal' 且 source_ref 非空的列生效
+CREATE UNIQUE INDEX IF NOT EXISTS uq_entries_gcal_ref
+  ON entries (source_ref)
+  WHERE source_type = 'gcal' AND source_ref IS NOT NULL;

--- a/dev/src/migration/012_add_calendar_indexes.up.sql
+++ b/dev/src/migration/012_add_calendar_indexes.up.sql
@@ -10,6 +10,9 @@
 
 -- Step 1: 清理既有 gcal 重複 entry（保留 created_at 最早的一筆）
 --   使用 self-join：刪除「存在另一筆相同 source_ref 但 created_at 更早」的列
+--   Tiebreaker：若兩筆 created_at 完全一致（如同一批匯入 NOW() 同秒），
+--   比較 id 大小決定保留哪筆，避免兩筆都被判為「非最早」而保留，
+--   導致 Step 3 unique index 建立失敗。
 DELETE FROM entries e
 USING entries dup
 WHERE e.source_type = 'gcal'
@@ -17,12 +20,23 @@ WHERE e.source_type = 'gcal'
   AND e.source_ref IS NOT NULL
   AND dup.source_ref IS NOT NULL
   AND e.source_ref = dup.source_ref
-  AND e.created_at > dup.created_at;
+  AND (
+        e.created_at > dup.created_at
+     OR (e.created_at = dup.created_at AND e.id > dup.id)
+  );
 
--- Step 2: 建立函數式 index：依 UTC 日期查詢用
---   行事曆 API 常以「某一天」為單位撈資料，此 index 讓 created_at::date 查詢可走 index scan
-CREATE INDEX IF NOT EXISTS idx_entries_created_at_date
-  ON entries ((created_at::date));
+-- Step 2: 建立 created_at btree index：支援行事曆日期區間查詢
+--
+-- 設計取捨：
+--   先前版本建 functional index on (created_at::date)，但行事曆 query 需支援 X-Timezone
+--   header（以當地日分桶），表達式為 (created_at AT TIME ZONE $tz)::date，
+--   與 functional index 不匹配 → 永遠 seq scan。
+--
+--   改採方案：呼叫端（Go repo 層）在應用層把「tz 下某一天」換算成 UTC 的
+--   [start, end) 時間戳範圍，query 改為 created_at >= $1 AND created_at < $2，
+--   即可完全命中本 btree index，且不受時區影響。
+CREATE INDEX IF NOT EXISTS idx_entries_created_at
+  ON entries (created_at);
 
 -- Step 3: 建立 gcal 關聯 partial unique index
 --   保證「一個 gcal event 最多只能被轉成一筆 entry」

--- a/dev/src/repository/entry.go
+++ b/dev/src/repository/entry.go
@@ -5,9 +5,11 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"log/slog"
 	"strings"
 
 	"github.com/google/uuid"
+	"github.com/gpwork4u/aibo/dto"
 	"github.com/gpwork4u/aibo/model"
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
@@ -435,6 +437,82 @@ func (r *EntryRepository) ExistsBySourceRef(ctx context.Context, sourceType, sou
 		sourceType, sourceRef,
 	).Scan(&exists)
 	return exists, err
+}
+
+// ListByDateRange 依日期區間撈取 entry，供行事曆彙整 API 使用。
+//
+// 參數：
+//   - sinceDate / untilDate：YYYY-MM-DD 字串（以 tz 時區解讀），inclusive
+//   - tz：IANA timezone 名稱（如 "UTC", "Asia/Taipei"），決定「一天」邊界
+//
+// 回傳：
+//   - []dto.CalendarEntrySummary，每筆包含 Date 欄位（依 tz 計算的 YYYY-MM-DD），
+//     呼叫端可據此分桶到 CalendarDay。
+//
+// 行為：
+//   - 排除 is_archived=true
+//   - 以 created_at AT TIME ZONE tz 之「當地日」為過濾基準
+//   - 以 created_at ASC 排序
+//
+// 實作注意：PostgreSQL 的 `timestamptz AT TIME ZONE 'X'` 會把 UTC 時間戳轉成 X 時區的
+// local naked timestamp，因此可直接與 $1::date 比較。
+func (r *EntryRepository) ListByDateRange(
+	ctx context.Context,
+	sinceDate, untilDate string,
+	tz string,
+) ([]dto.CalendarEntrySummary, error) {
+	if tz == "" {
+		tz = "UTC"
+	}
+
+	// to_char + AT TIME ZONE：
+	//   created_at 為 timestamptz，AT TIME ZONE $3 會轉成 tz 的 local timestamp
+	//   to_char 產生該時區下的 YYYY-MM-DD，供呼叫端分桶
+	// 過濾條件：
+	//   當地日 >= sinceDate 且 < (untilDate + 1 day)
+	const query = `
+		SELECT id, title, summary, source_type, tags, created_at,
+		       to_char(created_at AT TIME ZONE $3, 'YYYY-MM-DD') AS local_date
+		FROM entries
+		WHERE is_archived = false
+		  AND (created_at AT TIME ZONE $3) >= ($1::date)::timestamp
+		  AND (created_at AT TIME ZONE $3) <  (($2::date + 1))::timestamp
+		ORDER BY created_at ASC
+	`
+
+	rows, err := r.pool.Query(ctx, query, sinceDate, untilDate, tz)
+	if err != nil {
+		return nil, fmt.Errorf("entries.list_by_date_range query: %w", err)
+	}
+	defer rows.Close()
+
+	items := make([]dto.CalendarEntrySummary, 0)
+	for rows.Next() {
+		var item dto.CalendarEntrySummary
+		if err := rows.Scan(
+			&item.ID,
+			&item.Title,
+			&item.Summary,
+			&item.SourceType,
+			&item.Tags,
+			&item.CreatedAt,
+			&item.Date,
+		); err != nil {
+			return nil, fmt.Errorf("entries.list_by_date_range scan: %w", err)
+		}
+		items = append(items, item)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("entries.list_by_date_range rows: %w", err)
+	}
+
+	slog.InfoContext(ctx, "entries.list_by_date_range",
+		"count", len(items),
+		"since", sinceDate,
+		"until", untilDate,
+		"tz", tz,
+	)
+	return items, nil
 }
 
 // CategoryExists 檢查分類是否存在

--- a/dev/src/repository/entry.go
+++ b/dev/src/repository/entry.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"log/slog"
 	"strings"
+	"time"
 
 	"github.com/google/uuid"
 	"github.com/gpwork4u/aibo/dto"
@@ -443,7 +444,8 @@ func (r *EntryRepository) ExistsBySourceRef(ctx context.Context, sourceType, sou
 //
 // 參數：
 //   - sinceDate / untilDate：YYYY-MM-DD 字串（以 tz 時區解讀），inclusive
-//   - tz：IANA timezone 名稱（如 "UTC", "Asia/Taipei"），決定「一天」邊界
+//   - tz：IANA timezone 名稱（如 "UTC", "Asia/Taipei"），決定「一天」邊界；
+//     空字串視為 "UTC"；無效 tz 回傳 400 錯誤。
 //
 // 回傳：
 //   - []dto.CalendarEntrySummary，每筆包含 Date 欄位（依 tz 計算的 YYYY-MM-DD），
@@ -451,11 +453,17 @@ func (r *EntryRepository) ExistsBySourceRef(ctx context.Context, sourceType, sou
 //
 // 行為：
 //   - 排除 is_archived=true
-//   - 以 created_at AT TIME ZONE tz 之「當地日」為過濾基準
 //   - 以 created_at ASC 排序
 //
-// 實作注意：PostgreSQL 的 `timestamptz AT TIME ZONE 'X'` 會把 UTC 時間戳轉成 X 時區的
-// local naked timestamp，因此可直接與 $1::date 比較。
+// 實作策略（SQL index 友善）：
+//
+//	本方法在 Go 層把「tz 下 since..until 整日區間」換算成 UTC 的
+//	[startUTC, endUTC) 絕對時間戳範圍，SQL 用 created_at >= $1 AND created_at < $2
+//	過濾，這樣可直接命中 idx_entries_created_at btree index，避免 functional
+//	index + 時區表達式不匹配造成的 seq scan。
+//
+//	Date 欄位仍由 SQL 用 `created_at AT TIME ZONE $3` 轉出當地日字串，
+//	供呼叫端分桶；此欄位出現在 SELECT list，不影響 WHERE 的 index 命中。
 func (r *EntryRepository) ListByDateRange(
 	ctx context.Context,
 	sinceDate, untilDate string,
@@ -465,22 +473,41 @@ func (r *EntryRepository) ListByDateRange(
 		tz = "UTC"
 	}
 
-	// to_char + AT TIME ZONE：
-	//   created_at 為 timestamptz，AT TIME ZONE $3 會轉成 tz 的 local timestamp
-	//   to_char 產生該時區下的 YYYY-MM-DD，供呼叫端分桶
-	// 過濾條件：
-	//   當地日 >= sinceDate 且 < (untilDate + 1 day)
+	// 驗證 tz 為合法 IANA 時區，避免把 Postgres 錯誤訊息洩漏到上層
+	loc, err := time.LoadLocation(tz)
+	if err != nil {
+		return nil, model.NewAppError(400, model.ErrCodeInvalidInput, "無效的時區")
+	}
+
+	// 解析 since / until 為該時區下的當地日期
+	sinceLocal, err := time.ParseInLocation("2006-01-02", sinceDate, loc)
+	if err != nil {
+		return nil, model.NewAppError(400, model.ErrCodeInvalidInput, "無效的 since 日期格式，需 YYYY-MM-DD")
+	}
+	untilLocal, err := time.ParseInLocation("2006-01-02", untilDate, loc)
+	if err != nil {
+		return nil, model.NewAppError(400, model.ErrCodeInvalidInput, "無效的 until 日期格式，需 YYYY-MM-DD")
+	}
+
+	// 換算成 UTC 的 [startUTC, endUTC) 絕對時間戳範圍
+	//   startUTC = since 00:00:00 @tz → UTC
+	//   endUTC   = (until + 1 天) 00:00:00 @tz → UTC（exclusive upper bound）
+	startUTC := sinceLocal.UTC()
+	endUTC := untilLocal.AddDate(0, 0, 1).UTC()
+
+	// WHERE 以 created_at 絕對 timestamptz 範圍過濾（命中 idx_entries_created_at）。
+	// SELECT list 的 to_char(AT TIME ZONE $3) 僅用來產出分桶日期字串，不影響 index。
 	const query = `
 		SELECT id, title, summary, source_type, tags, created_at,
 		       to_char(created_at AT TIME ZONE $3, 'YYYY-MM-DD') AS local_date
 		FROM entries
 		WHERE is_archived = false
-		  AND (created_at AT TIME ZONE $3) >= ($1::date)::timestamp
-		  AND (created_at AT TIME ZONE $3) <  (($2::date + 1))::timestamp
+		  AND created_at >= $1
+		  AND created_at <  $2
 		ORDER BY created_at ASC
 	`
 
-	rows, err := r.pool.Query(ctx, query, sinceDate, untilDate, tz)
+	rows, err := r.pool.Query(ctx, query, startUTC, endUTC, tz)
 	if err != nil {
 		return nil, fmt.Errorf("entries.list_by_date_range query: %w", err)
 	}
@@ -511,6 +538,8 @@ func (r *EntryRepository) ListByDateRange(
 		"since", sinceDate,
 		"until", untilDate,
 		"tz", tz,
+		"start_utc", startUTC.Format(time.RFC3339),
+		"end_utc", endUTC.Format(time.RFC3339),
 	)
 	return items, nil
 }

--- a/dev/src/repository/entry_calendar_test.go
+++ b/dev/src/repository/entry_calendar_test.go
@@ -3,6 +3,7 @@ package repository
 import (
 	"context"
 	"os"
+	"strings"
 	"testing"
 	"time"
 
@@ -12,13 +13,36 @@ import (
 
 // withTestDB 取得測試 DB pool，若未設置 TEST_DATABASE_URL 則跳過整合測試。
 //
-// 預期連到已套用 migration 001 ~ 012 的 Postgres，測試會清空 entries 表作隔離。
+// ⚠️ 安全警告：
+//
+//	本 helper 會執行 `DELETE FROM entries` 清空整張表作為測試隔離手段。
+//	TEST_DATABASE_URL **必須**指向專用的隔離測試 DB（例如 docker-compose 裡的
+//	測試 service，或 dbname 帶有 "_test" 後綴的獨立 DB），**嚴禁**指向
+//	dev / staging / production 資料庫，否則既有資料會全數遺失。
+//
+//	為降低誤用風險，本 helper 做了下列防呆：
+//	  1. dsn 中 dbname 必須包含 "test" 字樣（不分大小寫），否則直接 t.Fatal
+//	     拒絕執行，避免誤連生產 DB。
+//	  2. 使用者若自訂 dbname 不含 "test"，可額外設 ALLOW_NON_TEST_DB=1
+//	     手動承擔風險（不建議）。
+//
+//	理想做法是改成每個 test 開 tx + rollback 隔離，但現行 EntryRepository
+//	建構子接受 *pgxpool.Pool（非 interface），改 tx 需動到 production
+//	code 介面，風險較大。本版本先以 DELETE + 防呆 comment 處理，待後續
+//	refactor 時一併改為 tx 隔離。
 func withTestDB(t *testing.T) *pgxpool.Pool {
 	t.Helper()
 	dsn := os.Getenv("TEST_DATABASE_URL")
 	if dsn == "" {
 		t.Skip("TEST_DATABASE_URL 未設置，跳過行事曆 repo 整合測試")
 	}
+
+	// 防呆：要求 dsn 明確標記為測試用，避免誤連 dev/prod DB
+	if os.Getenv("ALLOW_NON_TEST_DB") != "1" && !strings.Contains(strings.ToLower(dsn), "test") {
+		t.Fatalf("TEST_DATABASE_URL 未包含 'test' 字樣，為安全起見拒絕對此 DB 執行破壞性測試。" +
+			"請改用隔離測試 DB，或在確認安全後設 ALLOW_NON_TEST_DB=1")
+	}
+
 	pool, err := pgxpool.New(context.Background(), dsn)
 	if err != nil {
 		t.Fatalf("連接測試 DB 失敗: %v", err)

--- a/dev/src/repository/entry_calendar_test.go
+++ b/dev/src/repository/entry_calendar_test.go
@@ -1,0 +1,181 @@
+package repository
+
+import (
+	"context"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+// withTestDB 取得測試 DB pool，若未設置 TEST_DATABASE_URL 則跳過整合測試。
+//
+// 預期連到已套用 migration 001 ~ 012 的 Postgres，測試會清空 entries 表作隔離。
+func withTestDB(t *testing.T) *pgxpool.Pool {
+	t.Helper()
+	dsn := os.Getenv("TEST_DATABASE_URL")
+	if dsn == "" {
+		t.Skip("TEST_DATABASE_URL 未設置，跳過行事曆 repo 整合測試")
+	}
+	pool, err := pgxpool.New(context.Background(), dsn)
+	if err != nil {
+		t.Fatalf("連接測試 DB 失敗: %v", err)
+	}
+	if _, err := pool.Exec(context.Background(), "DELETE FROM entries"); err != nil {
+		pool.Close()
+		t.Fatalf("清空 entries 失敗: %v", err)
+	}
+	return pool
+}
+
+// insertCalEntry 插入測試 entry，指定 created_at 與 is_archived。
+func insertCalEntry(t *testing.T, pool *pgxpool.Pool, title string, createdAt time.Time, archived bool) uuid.UUID {
+	t.Helper()
+	id := uuid.New()
+	_, err := pool.Exec(context.Background(),
+		`INSERT INTO entries (id, title, content, tags, domains, is_archived, created_at, updated_at, quality_flags)
+		 VALUES ($1, $2, $3, $4, $5, $6, $7, $7, '[]'::jsonb)`,
+		id, title, "content", []string{}, []string{}, archived, createdAt,
+	)
+	if err != nil {
+		t.Fatalf("插入 entry 失敗: %v", err)
+	}
+	return id
+}
+
+// TestListByDateRange_UTC 驗證 UTC 時區下依日期過濾。
+func TestListByDateRange_UTC(t *testing.T) {
+	pool := withTestDB(t)
+	defer pool.Close()
+	repo := NewEntryRepository(pool)
+
+	insertCalEntry(t, pool, "day-23", time.Date(2026, 4, 23, 12, 0, 0, 0, time.UTC), false)
+	target := insertCalEntry(t, pool, "day-24", time.Date(2026, 4, 24, 12, 0, 0, 0, time.UTC), false)
+	insertCalEntry(t, pool, "day-25", time.Date(2026, 4, 25, 12, 0, 0, 0, time.UTC), false)
+
+	items, err := repo.ListByDateRange(context.Background(), "2026-04-24", "2026-04-24", "UTC")
+	if err != nil {
+		t.Fatalf("ListByDateRange: %v", err)
+	}
+	if len(items) != 1 {
+		t.Fatalf("expected 1 entry, got %d", len(items))
+	}
+	if items[0].ID != target {
+		t.Errorf("expected id=%s, got %s", target, items[0].ID)
+	}
+	if items[0].Date != "2026-04-24" {
+		t.Errorf("expected Date=2026-04-24, got %q", items[0].Date)
+	}
+}
+
+// TestListByDateRange_AsiaTaipei_CrossDay 驗證 Asia/Taipei 時區跨日分桶。
+// UTC 2026-04-24T23:30 → Asia/Taipei 2026-04-25T07:30，應歸屬於 2026-04-25。
+func TestListByDateRange_AsiaTaipei_CrossDay(t *testing.T) {
+	pool := withTestDB(t)
+	defer pool.Close()
+	repo := NewEntryRepository(pool)
+
+	target := insertCalEntry(t, pool, "cross-day",
+		time.Date(2026, 4, 24, 23, 30, 0, 0, time.UTC), false)
+
+	// Asia/Taipei 2026-04-25 → 應命中
+	items, err := repo.ListByDateRange(context.Background(), "2026-04-25", "2026-04-25", "Asia/Taipei")
+	if err != nil {
+		t.Fatalf("ListByDateRange Asia/Taipei: %v", err)
+	}
+	if len(items) != 1 {
+		t.Fatalf("expected 1 entry in Asia/Taipei 2026-04-25, got %d", len(items))
+	}
+	if items[0].ID != target {
+		t.Errorf("expected id=%s, got %s", target, items[0].ID)
+	}
+	if items[0].Date != "2026-04-25" {
+		t.Errorf("expected Date=2026-04-25 (Taipei bucket), got %q", items[0].Date)
+	}
+
+	// 同一筆以 UTC 撈 2026-04-25 → 不應命中（UTC 下屬於 04-24）
+	items, err = repo.ListByDateRange(context.Background(), "2026-04-25", "2026-04-25", "UTC")
+	if err != nil {
+		t.Fatalf("ListByDateRange UTC: %v", err)
+	}
+	if len(items) != 0 {
+		t.Errorf("expected 0 entries in UTC 2026-04-25, got %d", len(items))
+	}
+
+	// 以 UTC 撈 2026-04-24 → 應命中
+	items, err = repo.ListByDateRange(context.Background(), "2026-04-24", "2026-04-24", "UTC")
+	if err != nil {
+		t.Fatalf("ListByDateRange UTC 04-24: %v", err)
+	}
+	if len(items) != 1 {
+		t.Errorf("expected 1 entry in UTC 2026-04-24, got %d", len(items))
+	}
+}
+
+// TestListByDateRange_ExcludesArchived 驗證 is_archived=true 的 entry 被排除。
+func TestListByDateRange_ExcludesArchived(t *testing.T) {
+	pool := withTestDB(t)
+	defer pool.Close()
+	repo := NewEntryRepository(pool)
+
+	insertCalEntry(t, pool, "active", time.Date(2026, 4, 24, 10, 0, 0, 0, time.UTC), false)
+	insertCalEntry(t, pool, "archived", time.Date(2026, 4, 24, 11, 0, 0, 0, time.UTC), true)
+
+	items, err := repo.ListByDateRange(context.Background(), "2026-04-24", "2026-04-24", "UTC")
+	if err != nil {
+		t.Fatalf("ListByDateRange: %v", err)
+	}
+	if len(items) != 1 {
+		t.Fatalf("expected 1 active entry, got %d", len(items))
+	}
+	if items[0].Title == nil || *items[0].Title != "active" {
+		t.Errorf("expected title 'active', got %v", items[0].Title)
+	}
+}
+
+// TestListByDateRange_MultiDayRange 驗證多日區間與 ASC 排序、分桶日期正確。
+func TestListByDateRange_MultiDayRange(t *testing.T) {
+	pool := withTestDB(t)
+	defer pool.Close()
+	repo := NewEntryRepository(pool)
+
+	insertCalEntry(t, pool, "day1", time.Date(2026, 4, 23, 8, 0, 0, 0, time.UTC), false)
+	insertCalEntry(t, pool, "day2", time.Date(2026, 4, 24, 8, 0, 0, 0, time.UTC), false)
+	insertCalEntry(t, pool, "day3", time.Date(2026, 4, 25, 8, 0, 0, 0, time.UTC), false)
+
+	items, err := repo.ListByDateRange(context.Background(), "2026-04-23", "2026-04-25", "UTC")
+	if err != nil {
+		t.Fatalf("ListByDateRange: %v", err)
+	}
+	if len(items) != 3 {
+		t.Fatalf("expected 3 entries, got %d", len(items))
+	}
+	if !(items[0].CreatedAt.Before(items[1].CreatedAt) && items[1].CreatedAt.Before(items[2].CreatedAt)) {
+		t.Errorf("expected ASC order by created_at")
+	}
+	wantDates := []string{"2026-04-23", "2026-04-24", "2026-04-25"}
+	for i, w := range wantDates {
+		if items[i].Date != w {
+			t.Errorf("items[%d].Date: expected %q, got %q", i, w, items[i].Date)
+		}
+	}
+}
+
+// TestListByDateRange_EmptyTzDefaultsUTC 驗證 tz 為空字串時預設當作 UTC。
+func TestListByDateRange_EmptyTzDefaultsUTC(t *testing.T) {
+	pool := withTestDB(t)
+	defer pool.Close()
+	repo := NewEntryRepository(pool)
+
+	insertCalEntry(t, pool, "noon", time.Date(2026, 4, 24, 12, 0, 0, 0, time.UTC), false)
+
+	items, err := repo.ListByDateRange(context.Background(), "2026-04-24", "2026-04-24", "")
+	if err != nil {
+		t.Fatalf("ListByDateRange: %v", err)
+	}
+	if len(items) != 1 {
+		t.Fatalf("expected 1 entry with default tz=UTC, got %d", len(items))
+	}
+}


### PR DESCRIPTION
Closes #79

## 摘要
- Migration 012：新增 idx_entries_created_at_date 與 uq_entries_gcal_ref（含既存資料 cleanup）
- Entry repo 新增日期區間查詢方法（支援 X-Timezone 分桶）
- 新增 Calendar DTOs（CalendarDay / CalendarEvent / CalendarEntryRef）

## 測試
- Unit tests: 全數通過（含 Asia/Taipei 跨日 edge case）
- go build ./... 通過

## 影響
- 為 F-026b / F-026c handler 打底
- uq_entries_gcal_ref 影響既有 gcal import 資料（up.sql 包含 cleanup）