### PR TITLE
feat(backend): F-026c gcal event 轉 entry endpoint

### DIFF
--- a/dev/__tests__/handler/calendar_convert_test.go
+++ b/dev/__tests__/handler/calendar_convert_test.go
@@ -1,0 +1,182 @@
+package handler_test
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+	"github.com/gpwork4u/aibo/handler"
+	"github.com/gpwork4u/aibo/model"
+	"github.com/gpwork4u/aibo/repository"
+	"github.com/gpwork4u/aibo/service"
+	gcal "google.golang.org/api/calendar/v3"
+)
+
+// ---------------------------------------------------------------------------
+// Stubs（獨立於 service_test package 的 stubs；handler_test package 不能 import 它）
+// ---------------------------------------------------------------------------
+
+type fetcherStub struct {
+	event *gcal.Event
+	err   error
+}
+
+func (f *fetcherStub) GetEvent(ctx context.Context, calendarID, eventID string) (*gcal.Event, error) {
+	return f.event, f.err
+}
+
+type repoStub struct {
+	createErr error
+}
+
+func (r *repoStub) Create(ctx context.Context, entry *model.Entry) error { return r.createErr }
+func (r *repoStub) FindByID(ctx context.Context, id uuid.UUID) (*model.Entry, error) {
+	return nil, nil
+}
+func (r *repoStub) List(ctx context.Context, filter model.EntryFilter) (*model.EntryListResult, error) {
+	return nil, nil
+}
+func (r *repoStub) Update(ctx context.Context, entry *model.Entry) error { return nil }
+func (r *repoStub) Delete(ctx context.Context, id uuid.UUID) error       { return nil }
+func (r *repoStub) ConfirmEntry(ctx context.Context, id uuid.UUID) (*model.Entry, error) {
+	return nil, nil
+}
+func (r *repoStub) FlagEntry(ctx context.Context, id uuid.UUID, reason string, note *string) (*model.Entry, *model.EntryFlag, error) {
+	return nil, nil, nil
+}
+func (r *repoStub) GetFlags(ctx context.Context, entryID uuid.UUID) ([]model.EntryFlag, error) {
+	return nil, nil
+}
+func (r *repoStub) ExistsBySourceRef(ctx context.Context, sourceType, sourceRef string) (bool, error) {
+	return false, nil
+}
+func (r *repoStub) CategoryExists(ctx context.Context, id uuid.UUID) (bool, error) {
+	return false, nil
+}
+func (r *repoStub) SupersedeEntry(ctx context.Context, oldID, newID uuid.UUID) (*model.Entry, error) {
+	return nil, nil
+}
+func (r *repoStub) ClearSupersede(ctx context.Context, id uuid.UUID) (*model.Entry, error) {
+	return nil, nil
+}
+func (r *repoStub) GetSupersedeChain(ctx context.Context, id uuid.UUID) ([]repository.HistoryItem, error) {
+	return nil, nil
+}
+func (r *repoStub) CheckCircularSupersede(ctx context.Context, oldID, newID uuid.UUID) (bool, error) {
+	return false, nil
+}
+
+// setupRouter 組一個最小化的 gin router，只含 F-026c route，不加 auth middleware。
+func setupRouter(fetcher service.GcalEventFetcher, repo service.EntryRepository) *gin.Engine {
+	gin.SetMode(gin.TestMode)
+	svc := service.NewCalendarConvertService(fetcher, repo)
+	h := handler.NewCalendarConvertHandler(svc)
+
+	r := gin.New()
+	r.POST("/api/v1/calendar/events/:gcal_id/to-entry", h.ConvertToEntry)
+	return r
+}
+
+// 發送 POST 請求並回傳 (status, body)
+func doPost(t *testing.T, r *gin.Engine, path, body string) (int, map[string]any) {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodPost, path, strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	var parsed map[string]any
+	if w.Body.Len() > 0 {
+		_ = json.Unmarshal(w.Body.Bytes(), &parsed)
+	}
+	return w.Code, parsed
+}
+
+// -----------------------------------------------------------------------------
+// 201 Happy
+// -----------------------------------------------------------------------------
+func TestHandlerConvert_201(t *testing.T) {
+	fetcher := &fetcherStub{event: &gcal.Event{Id: "e1", Summary: "Meet"}}
+	repo := &repoStub{}
+	r := setupRouter(fetcher, repo)
+	status, body := doPost(t, r, "/api/v1/calendar/events/e1/to-entry", "{}")
+	if status != http.StatusCreated {
+		t.Fatalf("預期 201，實際 %d (body=%v)", status, body)
+	}
+}
+
+// -----------------------------------------------------------------------------
+// 409 ALREADY_LINKED
+// -----------------------------------------------------------------------------
+func TestHandlerConvert_409(t *testing.T) {
+	fetcher := &fetcherStub{event: &gcal.Event{Id: "edup", Summary: "Dup"}}
+	repo := &repoStub{
+		createErr: model.NewAppError(409, model.ErrCodeAlreadyLinked, "此 Google Calendar event 已轉成 entry"),
+	}
+	r := setupRouter(fetcher, repo)
+	status, body := doPost(t, r, "/api/v1/calendar/events/edup/to-entry", "{}")
+	if status != http.StatusConflict {
+		t.Fatalf("預期 409，實際 %d", status)
+	}
+	if body["code"] != model.ErrCodeAlreadyLinked {
+		t.Errorf("預期 code=%s，實際 %v", model.ErrCodeAlreadyLinked, body["code"])
+	}
+}
+
+// -----------------------------------------------------------------------------
+// 424 GCAL_NOT_CONNECTED
+// -----------------------------------------------------------------------------
+func TestHandlerConvert_424(t *testing.T) {
+	fetcher := &fetcherStub{err: model.NewAppError(424, model.ErrCodeGcalNotConnected, "尚未連接")}
+	r := setupRouter(fetcher, &repoStub{})
+	status, body := doPost(t, r, "/api/v1/calendar/events/e1/to-entry", "{}")
+	if status != http.StatusFailedDependency {
+		t.Fatalf("預期 424，實際 %d", status)
+	}
+	if body["code"] != model.ErrCodeGcalNotConnected {
+		t.Errorf("預期 code=%s，實際 %v", model.ErrCodeGcalNotConnected, body["code"])
+	}
+}
+
+// -----------------------------------------------------------------------------
+// 502 GCAL_UPSTREAM_ERROR
+// -----------------------------------------------------------------------------
+func TestHandlerConvert_502(t *testing.T) {
+	fetcher := &fetcherStub{err: model.NewAppError(502, model.ErrCodeGcalUpstream, "Google 上游錯誤")}
+	r := setupRouter(fetcher, &repoStub{})
+	status, _ := doPost(t, r, "/api/v1/calendar/events/e1/to-entry", "{}")
+	if status != http.StatusBadGateway {
+		t.Fatalf("預期 502，實際 %d", status)
+	}
+}
+
+// -----------------------------------------------------------------------------
+// 404 EVENT_NOT_FOUND
+// -----------------------------------------------------------------------------
+func TestHandlerConvert_404(t *testing.T) {
+	fetcher := &fetcherStub{event: nil}
+	r := setupRouter(fetcher, &repoStub{})
+	status, body := doPost(t, r, "/api/v1/calendar/events/missing/to-entry", "{}")
+	if status != http.StatusNotFound {
+		t.Fatalf("預期 404，實際 %d", status)
+	}
+	if body["code"] != model.ErrCodeEventNotFound {
+		t.Errorf("預期 code=%s，實際 %v", model.ErrCodeEventNotFound, body["code"])
+	}
+}
+
+// -----------------------------------------------------------------------------
+// 空 body 不應 400（body 為 optional）
+// -----------------------------------------------------------------------------
+func TestHandlerConvert_EmptyBody(t *testing.T) {
+	fetcher := &fetcherStub{event: &gcal.Event{Id: "e1", Summary: "Meet"}}
+	r := setupRouter(fetcher, &repoStub{})
+	status, _ := doPost(t, r, "/api/v1/calendar/events/e1/to-entry", "")
+	if status != http.StatusCreated {
+		t.Fatalf("空 body 應 201，實際 %d", status)
+	}
+}

--- a/dev/__tests__/service/calendar_convert_test.go
+++ b/dev/__tests__/service/calendar_convert_test.go
@@ -1,0 +1,250 @@
+package service_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/gpwork4u/aibo/model"
+	"github.com/gpwork4u/aibo/repository"
+	"github.com/gpwork4u/aibo/service"
+	gcal "google.golang.org/api/calendar/v3"
+)
+
+// stubGcalFetcher 提供可控的 GcalEventFetcher 行為
+type stubGcalFetcher struct {
+	event *gcal.Event
+	err   error
+}
+
+func (s *stubGcalFetcher) GetEvent(ctx context.Context, calendarID, eventID string) (*gcal.Event, error) {
+	return s.event, s.err
+}
+
+// stubEntryRepo 最小化實作；只需要 Create，其他方法回 nil / panic
+type stubEntryRepo struct {
+	createErr   error
+	captured    *model.Entry
+	createCalls int
+}
+
+func (s *stubEntryRepo) Create(ctx context.Context, entry *model.Entry) error {
+	s.createCalls++
+	s.captured = entry
+	return s.createErr
+}
+
+func (s *stubEntryRepo) FindByID(ctx context.Context, id uuid.UUID) (*model.Entry, error) {
+	return nil, nil
+}
+func (s *stubEntryRepo) List(ctx context.Context, filter model.EntryFilter) (*model.EntryListResult, error) {
+	return nil, nil
+}
+func (s *stubEntryRepo) Update(ctx context.Context, entry *model.Entry) error { return nil }
+func (s *stubEntryRepo) Delete(ctx context.Context, id uuid.UUID) error       { return nil }
+func (s *stubEntryRepo) ConfirmEntry(ctx context.Context, id uuid.UUID) (*model.Entry, error) {
+	return nil, nil
+}
+func (s *stubEntryRepo) FlagEntry(ctx context.Context, id uuid.UUID, reason string, note *string) (*model.Entry, *model.EntryFlag, error) {
+	return nil, nil, nil
+}
+func (s *stubEntryRepo) GetFlags(ctx context.Context, entryID uuid.UUID) ([]model.EntryFlag, error) {
+	return nil, nil
+}
+func (s *stubEntryRepo) ExistsBySourceRef(ctx context.Context, sourceType, sourceRef string) (bool, error) {
+	return false, nil
+}
+func (s *stubEntryRepo) CategoryExists(ctx context.Context, id uuid.UUID) (bool, error) {
+	return false, nil
+}
+func (s *stubEntryRepo) SupersedeEntry(ctx context.Context, oldID, newID uuid.UUID) (*model.Entry, error) {
+	return nil, nil
+}
+func (s *stubEntryRepo) ClearSupersede(ctx context.Context, id uuid.UUID) (*model.Entry, error) {
+	return nil, nil
+}
+func (s *stubEntryRepo) GetSupersedeChain(ctx context.Context, id uuid.UUID) ([]repository.HistoryItem, error) {
+	return nil, nil
+}
+func (s *stubEntryRepo) CheckCircularSupersede(ctx context.Context, oldID, newID uuid.UUID) (bool, error) {
+	return false, nil
+}
+
+// -----------------------------------------------------------------------------
+// 201 Happy：成功轉換
+// -----------------------------------------------------------------------------
+func TestConvertEventToEntry_Happy(t *testing.T) {
+	event := &gcal.Event{Id: "evt-123", Summary: "Team Sync", Description: "weekly"}
+	fetcher := &stubGcalFetcher{event: event}
+	repo := &stubEntryRepo{}
+	svc := service.NewCalendarConvertService(fetcher, repo)
+
+	entry, err := svc.ConvertEventToEntry(context.Background(), "evt-123", "primary", nil, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if entry == nil {
+		t.Fatal("expected entry, got nil")
+	}
+	if repo.createCalls != 1 {
+		t.Errorf("Create 應被呼叫 1 次，實際 %d", repo.createCalls)
+	}
+	if entry.SourceType == nil || *entry.SourceType != "gcal" {
+		t.Errorf("source_type 應為 gcal")
+	}
+	if entry.SourceRef == nil || *entry.SourceRef != "evt-123" {
+		t.Errorf("source_ref 應為 evt-123，實際 %v", entry.SourceRef)
+	}
+	// 確認 tag 不再 hardcode "meeting"
+	for _, tag := range entry.Tags {
+		if tag == "meeting" {
+			t.Errorf("tags 不應 hardcode meeting")
+		}
+	}
+	foundGcal := false
+	for _, tag := range entry.Tags {
+		if tag == "gcal" {
+			foundGcal = true
+		}
+	}
+	if !foundGcal {
+		t.Error("tags 應含 gcal")
+	}
+}
+
+// -----------------------------------------------------------------------------
+// 409 ALREADY_LINKED：Create 回 409，svc 直接傳回
+// -----------------------------------------------------------------------------
+func TestConvertEventToEntry_AlreadyLinked(t *testing.T) {
+	event := &gcal.Event{Id: "evt-dup", Summary: "已轉過的會議"}
+	fetcher := &stubGcalFetcher{event: event}
+	repo := &stubEntryRepo{
+		createErr: model.NewAppError(409, model.ErrCodeAlreadyLinked, "此 Google Calendar event 已轉成 entry"),
+	}
+	svc := service.NewCalendarConvertService(fetcher, repo)
+
+	_, err := svc.ConvertEventToEntry(context.Background(), "evt-dup", "primary", nil, nil)
+	if err == nil {
+		t.Fatal("預期有 409，實際 nil")
+	}
+	var appErr *model.AppError
+	if !errors.As(err, &appErr) {
+		t.Fatalf("預期 AppError，實際 %T", err)
+	}
+	if appErr.Status != 409 || appErr.Code != model.ErrCodeAlreadyLinked {
+		t.Errorf("預期 409 ALREADY_LINKED，實際 %d %s", appErr.Status, appErr.Code)
+	}
+}
+
+// -----------------------------------------------------------------------------
+// 424 GCAL_NOT_CONNECTED：fetcher 回 424
+// -----------------------------------------------------------------------------
+func TestConvertEventToEntry_GcalNotConnected(t *testing.T) {
+	fetcher := &stubGcalFetcher{
+		err: model.NewAppError(424, model.ErrCodeGcalNotConnected, "尚未連接 Google Calendar"),
+	}
+	repo := &stubEntryRepo{}
+	svc := service.NewCalendarConvertService(fetcher, repo)
+
+	_, err := svc.ConvertEventToEntry(context.Background(), "evt-x", "primary", nil, nil)
+	if err == nil {
+		t.Fatal("預期 424")
+	}
+	var appErr *model.AppError
+	if !errors.As(err, &appErr) {
+		t.Fatalf("預期 AppError，實際 %T", err)
+	}
+	if appErr.Status != 424 || appErr.Code != model.ErrCodeGcalNotConnected {
+		t.Errorf("預期 424 GCAL_NOT_CONNECTED，實際 %d %s", appErr.Status, appErr.Code)
+	}
+	if repo.createCalls != 0 {
+		t.Error("GcalNotConnected 時不應呼叫 Create")
+	}
+}
+
+// -----------------------------------------------------------------------------
+// 502 GCAL_UPSTREAM_ERROR：fetcher 回 502
+// -----------------------------------------------------------------------------
+func TestConvertEventToEntry_GcalUpstream(t *testing.T) {
+	fetcher := &stubGcalFetcher{
+		err: model.NewAppError(502, model.ErrCodeGcalUpstream, "Google Calendar 上游錯誤"),
+	}
+	repo := &stubEntryRepo{}
+	svc := service.NewCalendarConvertService(fetcher, repo)
+
+	_, err := svc.ConvertEventToEntry(context.Background(), "evt-x", "primary", nil, nil)
+	if err == nil {
+		t.Fatal("預期 502")
+	}
+	var appErr *model.AppError
+	if !errors.As(err, &appErr) {
+		t.Fatalf("預期 AppError，實際 %T", err)
+	}
+	if appErr.Status != 502 {
+		t.Errorf("預期 502，實際 %d", appErr.Status)
+	}
+}
+
+// -----------------------------------------------------------------------------
+// 404 EVENT_NOT_FOUND：fetcher 回 nil event
+// -----------------------------------------------------------------------------
+func TestConvertEventToEntry_EventNotFound(t *testing.T) {
+	fetcher := &stubGcalFetcher{event: nil}
+	repo := &stubEntryRepo{}
+	svc := service.NewCalendarConvertService(fetcher, repo)
+
+	_, err := svc.ConvertEventToEntry(context.Background(), "evt-missing", "primary", nil, nil)
+	if err == nil {
+		t.Fatal("預期 404")
+	}
+	var appErr *model.AppError
+	if !errors.As(err, &appErr) {
+		t.Fatalf("預期 AppError，實際 %T", err)
+	}
+	if appErr.Status != 404 || appErr.Code != model.ErrCodeEventNotFound {
+		t.Errorf("預期 404 EVENT_NOT_FOUND，實際 %d %s", appErr.Status, appErr.Code)
+	}
+	if repo.createCalls != 0 {
+		t.Error("EventNotFound 時不應呼叫 Create")
+	}
+}
+
+// -----------------------------------------------------------------------------
+// 400 INVALID_INPUT：空 gcal_id
+// -----------------------------------------------------------------------------
+func TestConvertEventToEntry_EmptyGcalID(t *testing.T) {
+	svc := service.NewCalendarConvertService(&stubGcalFetcher{}, &stubEntryRepo{})
+	_, err := svc.ConvertEventToEntry(context.Background(), "", "primary", nil, nil)
+	if err == nil {
+		t.Fatal("預期 400")
+	}
+	var appErr *model.AppError
+	if !errors.As(err, &appErr) {
+		t.Fatalf("預期 AppError，實際 %T", err)
+	}
+	if appErr.Status != 400 {
+		t.Errorf("預期 400，實際 %d", appErr.Status)
+	}
+}
+
+// 覆蓋 title / content override 路徑
+func TestConvertEventToEntry_WithOverrides(t *testing.T) {
+	event := &gcal.Event{Id: "evt-42", Summary: "Original"}
+	fetcher := &stubGcalFetcher{event: event}
+	repo := &stubEntryRepo{}
+	svc := service.NewCalendarConvertService(fetcher, repo)
+
+	titleOverride := "Custom Title"
+	contentOverride := "Custom body"
+	_, err := svc.ConvertEventToEntry(context.Background(), "evt-42", "primary", &titleOverride, &contentOverride)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if repo.captured == nil || repo.captured.Title == nil || *repo.captured.Title != titleOverride {
+		t.Errorf("title override 失效")
+	}
+	if repo.captured.Content == nil || *repo.captured.Content != contentOverride {
+		t.Errorf("content override 失效")
+	}
+}

--- a/dev/src/dto/calendar.go
+++ b/dev/src/dto/calendar.go
@@ -50,6 +50,18 @@ type CalendarDay struct {
 	Events     []CalendarEventSummary `json:"events"`
 }
 
+// ToEntryRequest POST /api/v1/calendar/events/:gcal_id/to-entry 的請求 body
+//
+// 所有欄位皆為選填：
+//   - CalendarID：預設 "primary"
+//   - TitleOverride：若提供則覆蓋預設標題（"[GCal] " + summary）
+//   - ContentOverride：若提供則覆蓋預設內容（time/location/description 組合）
+type ToEntryRequest struct {
+	CalendarID      *string `json:"calendar_id"`
+	TitleOverride   *string `json:"title_override"`
+	ContentOverride *string `json:"content_override"`
+}
+
 // CalendarResponse GET /api/v1/calendar 的主回應
 type CalendarResponse struct {
 	Since string        `json:"since"`

--- a/dev/src/handler/calendar_to_entry.go
+++ b/dev/src/handler/calendar_to_entry.go
@@ -1,0 +1,75 @@
+package handler
+
+import (
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+	"github.com/gpwork4u/aibo/dto"
+	"github.com/gpwork4u/aibo/model"
+	"github.com/gpwork4u/aibo/service"
+)
+
+// CalendarConvertHandler 負責 POST /api/v1/calendar/events/:gcal_id/to-entry（F-026c）。
+//
+// 為避免與 F-026b 的 CalendarHandler.List/GetDay 衝突，轉換流程單獨放在此 handler。
+type CalendarConvertHandler struct {
+	svc *service.CalendarConvertService
+}
+
+// NewCalendarConvertHandler 建立 handler。
+func NewCalendarConvertHandler(svc *service.CalendarConvertService) *CalendarConvertHandler {
+	return &CalendarConvertHandler{svc: svc}
+}
+
+// ConvertToEntry POST /api/v1/calendar/events/:gcal_id/to-entry
+//
+// 將指定的 Google Calendar event 轉成 entry。
+//
+// 錯誤回應（對應 spec F-026 §API Contract）：
+//   - 400 INVALID_INPUT：gcal_id 為空
+//   - 404 EVENT_NOT_FOUND：Google Calendar 查不到該 event
+//   - 409 ALREADY_LINKED：該 gcal_id 已有對應 entry
+//   - 424 GCAL_NOT_CONNECTED：使用者尚未完成 OAuth
+//   - 502 GCAL_UPSTREAM_ERROR：Google API 非 404 錯誤
+func (h *CalendarConvertHandler) ConvertToEntry(c *gin.Context) {
+	gcalID := c.Param("gcal_id")
+	if gcalID == "" {
+		c.JSON(http.StatusBadRequest, dto.ErrorResponse{
+			Code:    model.ErrCodeInvalidInput,
+			Message: "gcal_id 為必填",
+		})
+		return
+	}
+
+	// body 完全選填：若解析失敗（如 empty body）視為空值，不報錯
+	var req dto.ToEntryRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		req = dto.ToEntryRequest{}
+	}
+
+	calendarID := ""
+	if req.CalendarID != nil {
+		calendarID = *req.CalendarID
+	}
+
+	entry, err := h.svc.ConvertEventToEntry(
+		c.Request.Context(),
+		gcalID,
+		calendarID,
+		req.TitleOverride,
+		req.ContentOverride,
+	)
+	if err != nil {
+		if appErr, ok := err.(*model.AppError); ok {
+			c.JSON(appErr.Status, dto.ErrorResponse{Code: appErr.Code, Message: appErr.Message})
+			return
+		}
+		c.JSON(http.StatusInternalServerError, dto.ErrorResponse{
+			Code:    "INTERNAL_ERROR",
+			Message: "伺服器內部錯誤",
+		})
+		return
+	}
+
+	c.JSON(http.StatusCreated, entry)
+}

--- a/dev/src/main.go
+++ b/dev/src/main.go
@@ -106,6 +106,10 @@ func main() {
 	gcalSvc := service.NewGcalService(gcalRepo, entryRepo, aesCrypto, gcalConfig)
 	gcalHandler := handler.NewGcalHandler(gcalSvc)
 
+	// 行事曆轉換（F-026c）
+	calendarConvertSvc := service.NewCalendarConvertService(gcalSvc, entryRepo)
+	calendarConvertHandler := handler.NewCalendarConvertHandler(calendarConvertSvc)
+
 	// 初始化搜尋服務
 	searchRepo := repository.NewSearchRepository(pool)
 	searchSvc := service.NewSearchService(llmSvc, searchRepo)
@@ -126,7 +130,7 @@ func main() {
 	lifecycleHandler := handler.NewLifecycleHandler(lifecycleSvc)
 
 	// 設定路由
-	r := router.Setup(apiKeySvc, apiKeyHandler, categoryHandler, llmProviderHandler, entryHandler, classifyHandler, searchHandler, gitImportHandler, gcalHandler, confidenceHandler, statsHandler, systemHandler, lifecycleHandler)
+	r := router.Setup(apiKeySvc, apiKeyHandler, categoryHandler, llmProviderHandler, entryHandler, classifyHandler, searchHandler, gitImportHandler, gcalHandler, confidenceHandler, statsHandler, systemHandler, lifecycleHandler, calendarConvertHandler)
 
 	// 啟動 HTTP server（graceful shutdown）
 	srv := &http.Server{

--- a/dev/src/model/error.go
+++ b/dev/src/model/error.go
@@ -17,6 +17,9 @@ const (
 	ErrCodeGcalTokenExpired  = "GCAL_TOKEN_EXPIRED"
 	ErrCodeCalendarNotFound  = "CALENDAR_NOT_FOUND"
 	ErrCodeCircularSupersede = "CIRCULAR_SUPERSEDE"
+	ErrCodeAlreadyLinked     = "ALREADY_LINKED"
+	ErrCodeEventNotFound     = "EVENT_NOT_FOUND"
+	ErrCodeGcalUpstream      = "GCAL_UPSTREAM_ERROR"
 )
 
 // AppError 應用程式錯誤

--- a/dev/src/repository/entry.go
+++ b/dev/src/repository/entry.go
@@ -13,6 +13,7 @@ import (
 	"github.com/gpwork4u/aibo/dto"
 	"github.com/gpwork4u/aibo/model"
 	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/jackc/pgx/v5/pgxpool"
 )
 
@@ -41,6 +42,20 @@ func (r *EntryRepository) Create(ctx context.Context, entry *model.Entry) error 
 		entry.Tags, entry.Domains, entry.Context, entry.IsArchived, qualityFlagsJSON, entry.CreatedAt, entry.UpdatedAt,
 	)
 	if err != nil {
+		// 優先用 pgconn.PgError.ConstraintName 判斷（結構化欄位，
+		// 不受 PG 版本 / lc_messages 影響）
+		var pgErr *pgconn.PgError
+		if errors.As(err, &pgErr) {
+			switch pgErr.ConstraintName {
+			case "uq_entries_gcal_ref":
+				return model.NewAppError(409, model.ErrCodeAlreadyLinked, "此 Google Calendar event 已轉成 entry")
+			case "idx_entries_source":
+				return model.NewAppError(409, model.ErrCodeDuplicateSource, "相同 source_type + source_ref 已存在")
+			case "chk_title_or_content":
+				return model.NewAppError(400, model.ErrCodeInvalidInput, "title 和 content 至少需要填寫一個")
+			}
+		}
+		// Fallback：保留既有 strings.Contains 判斷（涵蓋非 PgError 錯誤路徑）
 		if strings.Contains(err.Error(), "uq_entries_gcal_ref") {
 			return model.NewAppError(409, model.ErrCodeAlreadyLinked, "此 Google Calendar event 已轉成 entry")
 		}

--- a/dev/src/repository/entry.go
+++ b/dev/src/repository/entry.go
@@ -41,6 +41,9 @@ func (r *EntryRepository) Create(ctx context.Context, entry *model.Entry) error 
 		entry.Tags, entry.Domains, entry.Context, entry.IsArchived, qualityFlagsJSON, entry.CreatedAt, entry.UpdatedAt,
 	)
 	if err != nil {
+		if strings.Contains(err.Error(), "uq_entries_gcal_ref") {
+			return model.NewAppError(409, model.ErrCodeAlreadyLinked, "此 Google Calendar event 已轉成 entry")
+		}
 		if strings.Contains(err.Error(), "idx_entries_source") {
 			return model.NewAppError(409, model.ErrCodeDuplicateSource, "相同 source_type + source_ref 已存在")
 		}

--- a/dev/src/router/router.go
+++ b/dev/src/router/router.go
@@ -10,7 +10,7 @@ import (
 )
 
 // Setup 設定路由
-func Setup(apiKeySvc *service.ApiKeyService, apiKeyHandler *handler.ApiKeyHandler, categoryHandler *handler.CategoryHandler, llmProviderHandler *handler.LlmProviderHandler, entryHandler *handler.EntryHandler, classifyHandler *handler.ClassifyHandler, searchHandler *handler.SearchHandler, gitImportHandler *handler.GitImportHandler, gcalHandler *handler.GcalHandler, confidenceHandler *handler.ConfidenceHandler, statsHandler *handler.StatsHandler, systemHandler *handler.SystemHandler, lifecycleHandler *handler.LifecycleHandler) *gin.Engine {
+func Setup(apiKeySvc *service.ApiKeyService, apiKeyHandler *handler.ApiKeyHandler, categoryHandler *handler.CategoryHandler, llmProviderHandler *handler.LlmProviderHandler, entryHandler *handler.EntryHandler, classifyHandler *handler.ClassifyHandler, searchHandler *handler.SearchHandler, gitImportHandler *handler.GitImportHandler, gcalHandler *handler.GcalHandler, confidenceHandler *handler.ConfidenceHandler, statsHandler *handler.StatsHandler, systemHandler *handler.SystemHandler, lifecycleHandler *handler.LifecycleHandler, calendarConvertHandler *handler.CalendarConvertHandler) *gin.Engine {
 	r := gin.Default()
 
 	// CORS middleware — 允許跨網域（前端 localhost:3000 呼叫 API localhost:8080）
@@ -76,6 +76,14 @@ func Setup(apiKeySvc *service.ApiKeyService, apiKeyHandler *handler.ApiKeyHandle
 			// LLM 自動分類
 			entries.POST("/:id/classify", classifyHandler.Classify)
 			entries.POST("/classify-all", classifyHandler.ClassifyAll)
+		}
+
+		// 行事曆（F-026c：gcal event → entry 轉換）
+		//
+		// 此 group 目前只掛 to-entry；F-026b 的 List/GetDay 由另一支 handler 於其 PR 追加。
+		calendar := v1.Group("/calendar")
+		{
+			calendar.POST("/events/:gcal_id/to-entry", calendarConvertHandler.ConvertToEntry)
 		}
 
 		// Google Calendar 整合

--- a/dev/src/service/calendar_to_entry.go
+++ b/dev/src/service/calendar_to_entry.go
@@ -83,7 +83,7 @@ func (s *CalendarConvertService) ConvertEventToEntry(
 	sourceType := "gcal"
 	sourceRef := event.Id
 	source := calendarID
-	tags := []string{"gcal", "meeting"}
+	tags := []string{"gcal"}
 
 	now := time.Now()
 	entry := &model.Entry{

--- a/dev/src/service/calendar_to_entry.go
+++ b/dev/src/service/calendar_to_entry.go
@@ -1,0 +1,124 @@
+package service
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/gpwork4u/aibo/model"
+	gcal "google.golang.org/api/calendar/v3"
+)
+
+// GcalEventFetcher 定義「取得單一 gcal event」的依賴，方便測試替換。
+//
+// 生產環境由 *GcalService.GetEvent 實作；測試則可提供 mock。
+type GcalEventFetcher interface {
+	GetEvent(ctx context.Context, calendarID, eventID string) (*gcal.Event, error)
+}
+
+// CalendarConvertService 負責把 Google Calendar event 轉換成 entry（F-026c）。
+//
+// 流程：
+//  1. 透過 GcalEventFetcher 取得 event（錯誤已由 fetcher 映射成 AppError）
+//  2. 組裝 entry（title、content、tags、source 等）
+//  3. 呼叫 EntryRepository.Create；依賴 DB 上的 uq_entries_gcal_ref partial unique index
+//     保證原子去重（Create 遇重複時會回 ALREADY_LINKED 409）
+//
+// 不做「先 SELECT 再 INSERT」的 race-prone 檢查。
+type CalendarConvertService struct {
+	fetcher   GcalEventFetcher
+	entryRepo EntryRepository
+}
+
+// NewCalendarConvertService 建立 CalendarConvertService。
+func NewCalendarConvertService(fetcher GcalEventFetcher, entryRepo EntryRepository) *CalendarConvertService {
+	return &CalendarConvertService{fetcher: fetcher, entryRepo: entryRepo}
+}
+
+// ConvertEventToEntry 把指定 gcal event 轉成 entry 並回傳。
+//
+// 參數：
+//   - gcalID：Google Calendar event id（必填）
+//   - calendarID：預設 "primary"
+//   - titleOverride / contentOverride：optional，若提供則覆寫預設值
+//
+// 錯誤：
+//   - 404 EVENT_NOT_FOUND：Google API 查無該 event
+//   - 409 ALREADY_LINKED：該 gcal_id 已有對應 entry（由 uq_entries_gcal_ref 保證）
+//   - 424 GCAL_NOT_CONNECTED：使用者尚未完成 OAuth
+//   - 502 GCAL_UPSTREAM_ERROR：Google API 非 404 錯誤
+func (s *CalendarConvertService) ConvertEventToEntry(
+	ctx context.Context,
+	gcalID, calendarID string,
+	titleOverride, contentOverride *string,
+) (*model.Entry, error) {
+	if gcalID == "" {
+		return nil, model.NewAppError(400, model.ErrCodeInvalidInput, "gcal_id 為必填")
+	}
+	if calendarID == "" {
+		calendarID = "primary"
+	}
+
+	event, err := s.fetcher.GetEvent(ctx, calendarID, gcalID)
+	if err != nil {
+		return nil, err
+	}
+	if event == nil {
+		return nil, model.NewAppError(404, model.ErrCodeEventNotFound, "Google Calendar 找不到該 event")
+	}
+
+	// 組裝 title
+	title := buildEventTitle(event)
+	if titleOverride != nil && *titleOverride != "" {
+		title = *titleOverride
+	}
+
+	// 組裝 content
+	content := buildEventContent(event)
+	if contentOverride != nil && *contentOverride != "" {
+		content = *contentOverride
+	}
+
+	sourceType := "gcal"
+	sourceRef := event.Id
+	source := calendarID
+	tags := []string{"gcal", "meeting"}
+
+	now := time.Now()
+	entry := &model.Entry{
+		ID:         uuid.New(),
+		Title:      &title,
+		Content:    &content,
+		Source:     &source,
+		SourceType: &sourceType,
+		SourceRef:  &sourceRef,
+		Tags:       tags,
+		IsArchived: false,
+		CreatedAt:  now,
+		UpdatedAt:  now,
+	}
+
+	if err := s.entryRepo.Create(ctx, entry); err != nil {
+		return nil, err
+	}
+
+	return entry, nil
+}
+
+// buildEventTitle 依慣例產生 entry 標題。
+//
+// 沿用 ImportEvents 的 "[GCal] " + summary 格式；若 event 無 summary 則以 id 代稱。
+func buildEventTitle(event *gcal.Event) string {
+	if event == nil || event.Summary == "" {
+		return fmt.Sprintf("[GCal] %s", eventIDOrUntitled(event))
+	}
+	return "[GCal] " + event.Summary
+}
+
+func eventIDOrUntitled(event *gcal.Event) string {
+	if event == nil || event.Id == "" {
+		return "(未命名事件)"
+	}
+	return event.Id
+}

--- a/dev/src/service/gcal.go
+++ b/dev/src/service/gcal.go
@@ -15,6 +15,7 @@ import (
 	"golang.org/x/oauth2"
 	"golang.org/x/oauth2/google"
 	"google.golang.org/api/calendar/v3"
+	"google.golang.org/api/googleapi"
 	"google.golang.org/api/option"
 )
 
@@ -297,6 +298,105 @@ func (s *GcalService) ImportEvents(ctx context.Context, calendarID string, since
 	)
 
 	return eventsFound, entriesCreated, entriesSkipped, nil
+}
+
+// GetEvent 取得指定 calendar 上的單一 event。
+//
+// 錯誤映射：
+//   - 使用者尚未連 gcal → model.AppError{424, GCAL_NOT_CONNECTED}
+//   - token 過期且 refresh 失敗 → model.AppError{401, GCAL_TOKEN_EXPIRED}
+//   - Google API 回 404 → model.AppError{404, EVENT_NOT_FOUND}
+//   - 其他 Google API 錯誤 → model.AppError{502, GCAL_UPSTREAM_ERROR}
+//
+// 回傳的 *calendar.Event 為 Google API 原始型別，由呼叫端（service 層）自行組裝成 entry。
+func (s *GcalService) GetEvent(ctx context.Context, calendarID, eventID string) (*calendar.Event, error) {
+	if calendarID == "" {
+		calendarID = "primary"
+	}
+
+	// 取得整合資訊
+	integration, err := s.gcalRepo.Get(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("查詢 GcalIntegration 失敗: %w", err)
+	}
+	if integration == nil {
+		return nil, model.NewAppError(http.StatusFailedDependency, model.ErrCodeGcalNotConnected, "Google Calendar 尚未授權")
+	}
+
+	// 解密 tokens
+	accessToken, err := s.aesCrypto.Decrypt(integration.AccessToken)
+	if err != nil {
+		return nil, fmt.Errorf("解密 access_token 失敗: %w", err)
+	}
+	refreshToken, err := s.aesCrypto.Decrypt(integration.RefreshToken)
+	if err != nil {
+		return nil, fmt.Errorf("解密 refresh_token 失敗: %w", err)
+	}
+	clientSecret, err := s.aesCrypto.Decrypt(integration.ClientSecret)
+	if err != nil {
+		return nil, fmt.Errorf("解密 client_secret 失敗: %w", err)
+	}
+
+	token := &oauth2.Token{
+		AccessToken:  accessToken,
+		RefreshToken: refreshToken,
+		TokenType:    "Bearer",
+		Expiry:       integration.TokenExpiry,
+	}
+	oauthCfg := &oauth2.Config{
+		ClientID:     integration.ClientID,
+		ClientSecret: clientSecret,
+		RedirectURL:  s.config.RedirectURL,
+		Scopes:       []string{calendar.CalendarReadonlyScope},
+		Endpoint:     google.Endpoint,
+	}
+
+	tokenSource := oauthCfg.TokenSource(ctx, token)
+	newToken, err := tokenSource.Token()
+	if err != nil {
+		return nil, model.NewAppError(http.StatusUnauthorized, model.ErrCodeGcalTokenExpired, "Token 過期且 refresh 失敗，請重新授權")
+	}
+
+	// refresh 後持久化
+	if newToken.AccessToken != accessToken {
+		slog.Info("Google Calendar token 已自動 refresh")
+		encNewAccess, encErr := s.aesCrypto.Encrypt(newToken.AccessToken)
+		if encErr == nil {
+			encNewRefresh := integration.RefreshToken
+			if newToken.RefreshToken != "" && newToken.RefreshToken != refreshToken {
+				encNewRefresh, _ = s.aesCrypto.Encrypt(newToken.RefreshToken)
+			}
+			_ = s.gcalRepo.UpdateTokens(ctx, integration.ID, encNewAccess, encNewRefresh, newToken.Expiry)
+		}
+	}
+
+	client := oauth2.NewClient(ctx, tokenSource)
+	srv, err := calendar.NewService(ctx, option.WithHTTPClient(client))
+	if err != nil {
+		return nil, fmt.Errorf("建立 Calendar service 失敗: %w", err)
+	}
+
+	event, err := srv.Events.Get(calendarID, eventID).Context(ctx).Do()
+	if err != nil {
+		return nil, mapGcalAPIError(err)
+	}
+	return event, nil
+}
+
+// mapGcalAPIError 將 Google API 錯誤對應到 AppError。
+//
+// 404 → EVENT_NOT_FOUND；其餘 → GCAL_UPSTREAM_ERROR 502。
+func mapGcalAPIError(err error) error {
+	if err == nil {
+		return nil
+	}
+	if gErr, ok := err.(*googleapi.Error); ok {
+		if gErr.Code == http.StatusNotFound {
+			return model.NewAppError(http.StatusNotFound, model.ErrCodeEventNotFound, "Google Calendar 找不到該 event")
+		}
+		return model.NewAppError(http.StatusBadGateway, model.ErrCodeGcalUpstream, fmt.Sprintf("Google Calendar API 錯誤: %d %s", gErr.Code, gErr.Message))
+	}
+	return model.NewAppError(http.StatusBadGateway, model.ErrCodeGcalUpstream, "Google Calendar API 錯誤: "+err.Error())
 }
 
 // buildEventContent 建構事件內容


### PR DESCRIPTION
## Summary
F-026c：新增 Google Calendar event → entry 的單筆轉換 endpoint。使用者可從 inbox / calendar 介面將單一 gcal event 建立成 entry，並避免重複建立。

Closes #81

## Endpoint

`POST /api/v1/calendar/events/:gcal_id/to-entry`

Request body（全部選填）：
```json
{
  "calendar_id": "primary",
  "title_override": "...",
  "content_override": "..."
}
```

Response:
- `201 Created` — 回傳新建立 entry
- `409 ALREADY_LINKED` — 此 gcal event 已轉成 entry（source_type=gcal + source_ref={gcal_id} unique）
- `404 EVENT_NOT_FOUND` — gcal 上找不到該 event
- `424 GCAL_NOT_CONNECTED` — 使用者尚未授權 Google Calendar
- `401 GCAL_TOKEN_EXPIRED` — refresh 失敗，需重新授權
- `502 GCAL_UPSTREAM_ERROR` — Google API 其他錯誤

## Changes
- `dev/src/handler/calendar_to_entry.go`（新）— HTTP handler
- `dev/src/service/calendar_to_entry.go`（新）— 轉換邏輯：讀取 gcal event、組裝 entry、呼叫 repo 建立
- `dev/src/service/gcal.go` — 新增 `GetEvent(ctx, calendarID, eventID)` + `mapGcalAPIError`（統一 gcal API error 映射）
- `dev/src/dto/calendar.go` — 新增 `ToEntryRequest` DTO
- `dev/src/model/error.go` — 新增 error codes：`ALREADY_LINKED`、`EVENT_NOT_FOUND`、`GCAL_UPSTREAM_ERROR`
- `dev/src/repository/entry.go` — Create 遇到 `uq_entries_gcal_ref` unique violation 時回 `409 ALREADY_LINKED`
- `dev/src/router/router.go` — 新增 `/api/v1/calendar/events/:gcal_id/to-entry` route（calendar group；F-026b 的 List/GetDay 由另一支 handler 之後追加）
- `dev/src/main.go` — wire `calendarConvertSvc` + `calendarConvertHandler`

## Scenario 覆蓋
- [x] 成功從 gcal event 建立 entry → 201 + source_type=gcal + source_ref=gcal_id
- [x] 重複轉換同一 event → 409 ALREADY_LINKED
- [x] event 不存在 → 404 EVENT_NOT_FOUND
- [x] 尚未連接 gcal → 424 GCAL_NOT_CONNECTED
- [x] token 過期且 refresh 失敗 → 401 GCAL_TOKEN_EXPIRED
- [x] gcal 上游其他錯誤 → 502 GCAL_UPSTREAM_ERROR
- [x] 支援 title_override / content_override
- [x] calendar_id 預設 primary

## 測試
- `go build ./...` 通過
- Unit test 由 QA 另行覆蓋（已完成骨架，見 test/ 目錄）