### PR TITLE
feat(backend): F-026b 行事曆彙整 API

### DIFF
--- a/dev/__tests__/handler/calendar_aggregate_test.go
+++ b/dev/__tests__/handler/calendar_aggregate_test.go
@@ -1,0 +1,157 @@
+package handler_test
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/gpwork4u/aibo/dto"
+	"github.com/gpwork4u/aibo/handler"
+	"github.com/gpwork4u/aibo/service"
+)
+
+// setupAggregateRouter 組一個最小化的 gin router，含 CalendarHandler（F-026b）。
+//
+// 以 mockEntryRepo / stubGcalRepo（來自 service_test package 之同名 symbol 無法跨 package 共用）
+// 建構 real CalendarService。為了跨 package，這裡只實作必要的 stub。
+type handlerAggregateStubGcalRepo struct{ integration *dummyIntegration }
+type dummyIntegration struct{}
+
+// 小型 repo stub 允許 Get(ctx) → (nil, nil) 代表未連
+type haggStubRepo struct {
+	connected bool
+}
+
+// 遵守 service.GcalIntegrationRepository 介面（實際跨 package 不會共用 ptr，故 import）
+// 其他方法空實作於此。
+
+// setupAggregateRouter 把 service 組合好並 mount route
+func setupAggregateRouter(t *testing.T, connected bool, cacheEnabled bool) *gin.Engine {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+
+	entryRepo := &hEntryRepo{}
+	var gcalRepo hAggGcalRepo
+	gcalRepo.connected = connected
+	gcalSvc := service.NewGcalService(&gcalRepo, nil, nil, &service.GcalConfig{})
+
+	svc := service.NewCalendarService(entryRepo, gcalSvc, cacheEnabled)
+	h := handler.NewCalendarHandler(svc)
+
+	r := gin.New()
+	r.GET("/api/v1/calendar", h.Aggregate)
+	return r
+}
+
+// doGet 發送 GET 並取得 (status, headers, body)
+func doGet(t *testing.T, r *gin.Engine, url string) (int, http.Header, map[string]any) {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodGet, url, nil)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	var body map[string]any
+	if w.Body.Len() > 0 {
+		_ = json.Unmarshal(w.Body.Bytes(), &body)
+	}
+	return w.Code, w.Header(), body
+}
+
+// -----------------------------------------------------------------------------
+// include_gcal=true 明確要求但未連 → 424
+// -----------------------------------------------------------------------------
+func TestAggregate_IncludeGcalExplicitTrue_NotConnected_Returns424(t *testing.T) {
+	r := setupAggregateRouter(t, false, false)
+	status, _, body := doGet(t, r, "/api/v1/calendar?since=2026-04-24&until=2026-04-24&view=day&include_gcal=true")
+	if status != http.StatusFailedDependency {
+		t.Fatalf("預期 424，實際 %d (body=%v)", status, body)
+	}
+	if body["code"] != "GCAL_NOT_CONNECTED" {
+		t.Errorf("預期 code=GCAL_NOT_CONNECTED，實際 %v", body["code"])
+	}
+}
+
+// -----------------------------------------------------------------------------
+// 不帶 include_gcal（預設）未連 → 200 + gcal_connected=false + X-Degraded
+// -----------------------------------------------------------------------------
+func TestAggregate_IncludeGcalOmitted_NotConnected_ReturnsDegraded(t *testing.T) {
+	r := setupAggregateRouter(t, false, false)
+	status, header, body := doGet(t, r, "/api/v1/calendar?since=2026-04-24&until=2026-04-24&view=day")
+	if status != http.StatusOK {
+		t.Fatalf("預期 200 degraded，實際 %d (body=%v)", status, body)
+	}
+	if header.Get("X-Degraded") != "gcal" {
+		t.Errorf("預期 X-Degraded: gcal，實際 %q", header.Get("X-Degraded"))
+	}
+	connected, _ := body["gcal_connected"].(bool)
+	if connected {
+		t.Error("預期 gcal_connected=false")
+	}
+}
+
+// -----------------------------------------------------------------------------
+// include_gcal=false 未連 → 200（完全跳過 gcal，不算 degraded）
+// -----------------------------------------------------------------------------
+func TestAggregate_IncludeGcalFalse_NotConnected_Returns200(t *testing.T) {
+	r := setupAggregateRouter(t, false, false)
+	status, header, _ := doGet(t, r, "/api/v1/calendar?since=2026-04-24&until=2026-04-24&view=day&include_gcal=false")
+	if status != http.StatusOK {
+		t.Fatalf("預期 200，實際 %d", status)
+	}
+	// 跳過 gcal 時不應標 degraded（連都沒嘗試）
+	if header.Get("X-Degraded") != "" {
+		t.Errorf("include_gcal=false 時不應有 X-Degraded header，實際 %q", header.Get("X-Degraded"))
+	}
+}
+
+// -----------------------------------------------------------------------------
+// since/until 缺失 → 400
+// -----------------------------------------------------------------------------
+func TestAggregate_MissingSinceUntil_Returns400(t *testing.T) {
+	r := setupAggregateRouter(t, false, false)
+	status, _, _ := doGet(t, r, "/api/v1/calendar?view=day")
+	if status != http.StatusBadRequest {
+		t.Errorf("預期 400，實際 %d", status)
+	}
+}
+
+// -----------------------------------------------------------------------------
+// view 不合法 → 400
+// -----------------------------------------------------------------------------
+func TestAggregate_InvalidView_Returns400(t *testing.T) {
+	r := setupAggregateRouter(t, false, false)
+	status, _, body := doGet(t, r, "/api/v1/calendar?since=2026-04-24&until=2026-04-24&view=year")
+	if status != http.StatusBadRequest {
+		t.Errorf("預期 400，實際 %d (body=%v)", status, body)
+	}
+}
+
+// -----------------------------------------------------------------------------
+// include_gcal 格式錯誤 → 400
+// -----------------------------------------------------------------------------
+func TestAggregate_InvalidIncludeGcal_Returns400(t *testing.T) {
+	r := setupAggregateRouter(t, false, false)
+	status, _, _ := doGet(t, r, "/api/v1/calendar?since=2026-04-24&until=2026-04-24&view=day&include_gcal=yes")
+	if status != http.StatusBadRequest {
+		t.Errorf("預期 400，實際 %d", status)
+	}
+}
+
+// -----------------------------------------------------------------------------
+// 超過 92 天 → 400
+// -----------------------------------------------------------------------------
+func TestAggregate_Span93Days_Returns400(t *testing.T) {
+	r := setupAggregateRouter(t, false, false)
+	status, _, body := doGet(t, r, "/api/v1/calendar?since=2026-01-01&until=2026-04-03&view=month&include_gcal=false")
+	if status != http.StatusBadRequest {
+		t.Errorf("預期 400（超過 92 天），實際 %d (body=%v)", status, body)
+	}
+}
+
+// 以下為 hAggGcalRepo / hEntryRepo minimal stubs（無法跨 package 使用 service_test 裡的 mockEntryRepo）
+// 透過獨立檔案 handler_calendar_stubs_test.go 提供。
+
+// 這個檔案內用到的 interface 抽象化，避免此檔 import cycle。
+// 具體 stub 定義位於 handler_calendar_stubs_test.go
+var _ dto.ErrorResponse // keep dto import alive

--- a/dev/__tests__/handler/calendar_stubs_test.go
+++ b/dev/__tests__/handler/calendar_stubs_test.go
@@ -1,0 +1,80 @@
+package handler_test
+
+import (
+	"context"
+
+	"github.com/google/uuid"
+	"github.com/gpwork4u/aibo/dto"
+	"github.com/gpwork4u/aibo/model"
+	"github.com/gpwork4u/aibo/repository"
+	"github.com/gpwork4u/aibo/service"
+)
+
+// hAggGcalRepo implements service.GcalIntegrationRepository
+// connected = true 時 Get() 回 stub integration，代表已連。
+type hAggGcalRepo struct {
+	connected bool
+}
+
+func (h *hAggGcalRepo) Get(_ context.Context) (*model.GcalIntegration, error) {
+	if h.connected {
+		return &model.GcalIntegration{ID: uuid.New()}, nil
+	}
+	return nil, nil
+}
+func (h *hAggGcalRepo) Upsert(_ context.Context, _ *model.GcalIntegration) error { return nil }
+func (h *hAggGcalRepo) UpdateTokens(_ context.Context, _ interface{}, _, _ string, _ interface{}) error {
+	return nil
+}
+func (h *hAggGcalRepo) SaveOAuthState(_ context.Context, _ string) error { return nil }
+func (h *hAggGcalRepo) ValidateOAuthState(_ context.Context, _ string) (bool, error) {
+	return false, nil
+}
+func (h *hAggGcalRepo) CleanExpiredOAuthStates(_ context.Context) error { return nil }
+
+var _ service.GcalIntegrationRepository = (*hAggGcalRepo)(nil)
+
+// hEntryRepo minimal EntryRepository stub
+type hEntryRepo struct{}
+
+func (h *hEntryRepo) ListByDateRange(_ context.Context, _, _ string, _ string) ([]dto.CalendarEntrySummary, error) {
+	return nil, nil
+}
+func (h *hEntryRepo) Create(_ context.Context, _ *model.Entry) error { return nil }
+func (h *hEntryRepo) FindByID(_ context.Context, _ uuid.UUID) (*model.Entry, error) {
+	return nil, nil
+}
+func (h *hEntryRepo) List(_ context.Context, _ model.EntryFilter) (*model.EntryListResult, error) {
+	return nil, nil
+}
+func (h *hEntryRepo) Update(_ context.Context, _ *model.Entry) error { return nil }
+func (h *hEntryRepo) Delete(_ context.Context, _ uuid.UUID) error    { return nil }
+func (h *hEntryRepo) ConfirmEntry(_ context.Context, _ uuid.UUID) (*model.Entry, error) {
+	return nil, nil
+}
+func (h *hEntryRepo) FlagEntry(_ context.Context, _ uuid.UUID, _ string, _ *string) (*model.Entry, *model.EntryFlag, error) {
+	return nil, nil, nil
+}
+func (h *hEntryRepo) GetFlags(_ context.Context, _ uuid.UUID) ([]model.EntryFlag, error) {
+	return nil, nil
+}
+func (h *hEntryRepo) ExistsBySourceRef(_ context.Context, _, _ string) (bool, error) {
+	return false, nil
+}
+func (h *hEntryRepo) CategoryExists(_ context.Context, _ uuid.UUID) (bool, error) {
+	return false, nil
+}
+func (h *hEntryRepo) SupersedeEntry(_ context.Context, _, _ uuid.UUID) (*model.Entry, error) {
+	return nil, nil
+}
+func (h *hEntryRepo) ClearSupersede(_ context.Context, _ uuid.UUID) (*model.Entry, error) {
+	return nil, nil
+}
+func (h *hEntryRepo) GetSupersedeChain(_ context.Context, _ uuid.UUID) ([]repository.HistoryItem, error) {
+	return nil, nil
+}
+func (h *hEntryRepo) CheckCircularSupersede(_ context.Context, _, _ uuid.UUID) (bool, error) {
+	return false, nil
+}
+
+var _ service.EntryRepository = (*hEntryRepo)(nil)

--- a/dev/__tests__/service/calendar_test.go
+++ b/dev/__tests__/service/calendar_test.go
@@ -74,6 +74,43 @@ var _ service.EntryRepository = (*mockEntryRepo)(nil)
 // 確保 pgx import 被使用（interface 內有用到 pgx.Tx 但 mock 不需要）
 var _ = pgx.ErrNoRows
 
+// --------- Stub GcalIntegrationRepository ---------
+//
+// 供 newStubGcalService 使用；Get 回傳 integration=nil 代表「未連 gcal」，
+// 其他方法為空實作（本測試不觸發）。
+type stubGcalRepo struct {
+	integration *model.GcalIntegration
+	getErr      error
+}
+
+func (s *stubGcalRepo) Get(_ context.Context) (*model.GcalIntegration, error) {
+	return s.integration, s.getErr
+}
+func (s *stubGcalRepo) Upsert(_ context.Context, _ *model.GcalIntegration) error { return nil }
+func (s *stubGcalRepo) UpdateTokens(_ context.Context, _ interface{}, _, _ string, _ interface{}) error {
+	return nil
+}
+func (s *stubGcalRepo) SaveOAuthState(_ context.Context, _ string) error { return nil }
+func (s *stubGcalRepo) ValidateOAuthState(_ context.Context, _ string) (bool, error) {
+	return false, nil
+}
+func (s *stubGcalRepo) CleanExpiredOAuthStates(_ context.Context) error { return nil }
+
+// 編譯期介面檢查
+var _ service.GcalIntegrationRepository = (*stubGcalRepo)(nil)
+
+// newStubGcalService 建立可用於單測的 *GcalService：
+//
+//   - 使用 stubGcalRepo（可控 Get 行為模擬已連 / 未連）
+//   - entryRepo = nil（本測試 gcalSvc 不被呼叫 ListEvents / Create）
+//   - aesCrypto = nil（本測試走 IsConnected 路徑，不解密 token）
+//   - config = 空（本測試不走 OAuth 流程）
+//
+// IsConnected() 只讀 gcalRepo.Get，會依 integration 欄位決定 true / false。
+func newStubGcalService(repo *stubGcalRepo) *service.GcalService {
+	return service.NewGcalService(repo, nil, nil, &service.GcalConfig{})
+}
+
 // --------- Helpers ---------
 
 func mkEntry(id uuid.UUID, title string, createdAt time.Time, date string) dto.CalendarEntrySummary {

--- a/dev/__tests__/service/calendar_test.go
+++ b/dev/__tests__/service/calendar_test.go
@@ -1,0 +1,404 @@
+package service_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/gpwork4u/aibo/dto"
+	"github.com/gpwork4u/aibo/model"
+	"github.com/gpwork4u/aibo/repository"
+	"github.com/gpwork4u/aibo/service"
+	"github.com/jackc/pgx/v5"
+)
+
+// --------- Mock EntryRepository ---------
+
+// mockEntryRepo 為 CalendarService 單測提供最小可用 EntryRepository 實作。
+//
+// 僅實作 ListByDateRange；其餘方法回傳 nil / 空結果，單測不觸發。
+type mockEntryRepo struct {
+	entries []dto.CalendarEntrySummary
+	err     error
+}
+
+func (m *mockEntryRepo) ListByDateRange(_ context.Context, _, _ string, _ string) ([]dto.CalendarEntrySummary, error) {
+	if m.err != nil {
+		return nil, m.err
+	}
+	return m.entries, nil
+}
+
+// 其餘 EntryRepository 介面方法：測試用空實作
+func (m *mockEntryRepo) Create(_ context.Context, _ *model.Entry) error { return nil }
+func (m *mockEntryRepo) FindByID(_ context.Context, _ uuid.UUID) (*model.Entry, error) {
+	return nil, nil
+}
+func (m *mockEntryRepo) List(_ context.Context, _ model.EntryFilter) (*model.EntryListResult, error) {
+	return nil, nil
+}
+func (m *mockEntryRepo) Update(_ context.Context, _ *model.Entry) error { return nil }
+func (m *mockEntryRepo) Delete(_ context.Context, _ uuid.UUID) error    { return nil }
+func (m *mockEntryRepo) ConfirmEntry(_ context.Context, _ uuid.UUID) (*model.Entry, error) {
+	return nil, nil
+}
+func (m *mockEntryRepo) FlagEntry(_ context.Context, _ uuid.UUID, _ string, _ *string) (*model.Entry, *model.EntryFlag, error) {
+	return nil, nil, nil
+}
+func (m *mockEntryRepo) GetFlags(_ context.Context, _ uuid.UUID) ([]model.EntryFlag, error) {
+	return nil, nil
+}
+func (m *mockEntryRepo) ExistsBySourceRef(_ context.Context, _, _ string) (bool, error) {
+	return false, nil
+}
+func (m *mockEntryRepo) CategoryExists(_ context.Context, _ uuid.UUID) (bool, error) {
+	return false, nil
+}
+func (m *mockEntryRepo) SupersedeEntry(_ context.Context, _, _ uuid.UUID) (*model.Entry, error) {
+	return nil, nil
+}
+func (m *mockEntryRepo) ClearSupersede(_ context.Context, _ uuid.UUID) (*model.Entry, error) {
+	return nil, nil
+}
+func (m *mockEntryRepo) GetSupersedeChain(_ context.Context, _ uuid.UUID) ([]repository.HistoryItem, error) {
+	return nil, nil
+}
+func (m *mockEntryRepo) CheckCircularSupersede(_ context.Context, _, _ uuid.UUID) (bool, error) {
+	return false, nil
+}
+
+// Compile-time check
+var _ service.EntryRepository = (*mockEntryRepo)(nil)
+
+// 確保 pgx import 被使用（interface 內有用到 pgx.Tx 但 mock 不需要）
+var _ = pgx.ErrNoRows
+
+// --------- Helpers ---------
+
+func mkEntry(id uuid.UUID, title string, createdAt time.Time, date string) dto.CalendarEntrySummary {
+	t := title
+	return dto.CalendarEntrySummary{
+		ID:        id,
+		Title:     &t,
+		Tags:      []string{},
+		CreatedAt: createdAt,
+		Date:      date,
+	}
+}
+
+// --------- Tests ---------
+
+// TestAggregate_HappyPath_EntriesOnly 測試基本彙整（不含 gcal）
+func TestAggregate_HappyPath_EntriesOnly(t *testing.T) {
+	repo := &mockEntryRepo{
+		entries: []dto.CalendarEntrySummary{
+			mkEntry(uuid.New(), "E1", time.Date(2026, 4, 24, 9, 0, 0, 0, time.UTC), "2026-04-24"),
+			mkEntry(uuid.New(), "E2", time.Date(2026, 4, 24, 10, 0, 0, 0, time.UTC), "2026-04-24"),
+			mkEntry(uuid.New(), "E3", time.Date(2026, 4, 25, 8, 0, 0, 0, time.UTC), "2026-04-25"),
+		},
+	}
+	svc := service.NewCalendarService(repo, nil, false)
+
+	result, err := svc.Aggregate(context.Background(), service.AggregateRequest{
+		SinceDate:   "2026-04-20",
+		UntilDate:   "2026-04-26",
+		View:        "week",
+		IncludeGcal: false,
+		Timezone:    "UTC",
+	})
+	if err != nil {
+		t.Fatalf("非預期錯誤: %v", err)
+	}
+	if len(result.Response.Days) != 7 {
+		t.Errorf("預期 7 天，實際 %d 天", len(result.Response.Days))
+	}
+	// 找到 2026-04-24
+	var d24 *dto.CalendarDay
+	for i := range result.Response.Days {
+		if result.Response.Days[i].Date == "2026-04-24" {
+			d24 = &result.Response.Days[i]
+			break
+		}
+	}
+	if d24 == nil {
+		t.Fatal("找不到 2026-04-24")
+	}
+	if d24.EntryCount != 2 {
+		t.Errorf("2026-04-24 entry_count 預期 2，實際 %d", d24.EntryCount)
+	}
+	if len(d24.Entries) != 2 {
+		t.Errorf("week view 應回傳全量 entries（2 筆），實際 %d", len(d24.Entries))
+	}
+	if result.Degraded {
+		t.Error("include_gcal=false 不應 degraded")
+	}
+}
+
+// TestAggregate_MonthView_EntriesCap 測試月視圖每日 entries 上限為 3
+func TestAggregate_MonthView_EntriesCap(t *testing.T) {
+	entries := []dto.CalendarEntrySummary{}
+	for i := 0; i < 10; i++ {
+		entries = append(entries,
+			mkEntry(uuid.New(), "E", time.Date(2026, 4, 24, i, 0, 0, 0, time.UTC), "2026-04-24"),
+		)
+	}
+	repo := &mockEntryRepo{entries: entries}
+	svc := service.NewCalendarService(repo, nil, false)
+
+	result, err := svc.Aggregate(context.Background(), service.AggregateRequest{
+		SinceDate:   "2026-04-01",
+		UntilDate:   "2026-04-30",
+		View:        "month",
+		IncludeGcal: false,
+		Timezone:    "UTC",
+	})
+	if err != nil {
+		t.Fatalf("非預期錯誤: %v", err)
+	}
+
+	var d24 *dto.CalendarDay
+	for i := range result.Response.Days {
+		if result.Response.Days[i].Date == "2026-04-24" {
+			d24 = &result.Response.Days[i]
+			break
+		}
+	}
+	if d24 == nil {
+		t.Fatal("找不到 2026-04-24")
+	}
+	if d24.EntryCount != 10 {
+		t.Errorf("entry_count 預期 10，實際 %d", d24.EntryCount)
+	}
+	if len(d24.Entries) != service.MonthViewEntriesCap {
+		t.Errorf("month view entries 應被截斷到 %d，實際 %d", service.MonthViewEntriesCap, len(d24.Entries))
+	}
+}
+
+// TestAggregate_SpanExceeds92Days 超過 92 天回 400
+func TestAggregate_SpanExceeds92Days(t *testing.T) {
+	repo := &mockEntryRepo{}
+	svc := service.NewCalendarService(repo, nil, false)
+
+	_, err := svc.Aggregate(context.Background(), service.AggregateRequest{
+		SinceDate:   "2026-01-01",
+		UntilDate:   "2026-06-01",
+		View:        "month",
+		IncludeGcal: false,
+		Timezone:    "UTC",
+	})
+	if err == nil {
+		t.Fatal("預期應回錯誤")
+	}
+	appErr, ok := err.(*model.AppError)
+	if !ok {
+		t.Fatalf("預期 AppError，實際 %T", err)
+	}
+	if appErr.Status != 400 || appErr.Code != model.ErrCodeInvalidInput {
+		t.Errorf("預期 400 INVALID_INPUT，實際 %d %s", appErr.Status, appErr.Code)
+	}
+}
+
+// TestAggregate_UntilBeforeSince 測試 until < since 回 400
+func TestAggregate_UntilBeforeSince(t *testing.T) {
+	repo := &mockEntryRepo{}
+	svc := service.NewCalendarService(repo, nil, false)
+
+	_, err := svc.Aggregate(context.Background(), service.AggregateRequest{
+		SinceDate:   "2026-04-10",
+		UntilDate:   "2026-04-01",
+		Timezone:    "UTC",
+		IncludeGcal: false,
+	})
+	if err == nil {
+		t.Fatal("預期應回錯誤")
+	}
+	appErr, ok := err.(*model.AppError)
+	if !ok {
+		t.Fatalf("預期 AppError，實際 %T", err)
+	}
+	if appErr.Status != 400 {
+		t.Errorf("預期 400，實際 %d", appErr.Status)
+	}
+}
+
+// TestAggregate_InvalidTimezone 測試無效時區回 400
+func TestAggregate_InvalidTimezone(t *testing.T) {
+	repo := &mockEntryRepo{}
+	svc := service.NewCalendarService(repo, nil, false)
+
+	_, err := svc.Aggregate(context.Background(), service.AggregateRequest{
+		SinceDate:   "2026-04-01",
+		UntilDate:   "2026-04-30",
+		Timezone:    "Mars/Olympus",
+		IncludeGcal: false,
+	})
+	if err == nil {
+		t.Fatal("預期應回錯誤")
+	}
+	appErr, ok := err.(*model.AppError)
+	if !ok {
+		t.Fatalf("預期 AppError，實際 %T", err)
+	}
+	if appErr.Status != 400 || appErr.Code != model.ErrCodeInvalidInput {
+		t.Errorf("預期 400 INVALID_INPUT，實際 %d %s", appErr.Status, appErr.Code)
+	}
+}
+
+// TestAggregate_InvalidDateFormat 測試日期格式錯誤回 400
+func TestAggregate_InvalidDateFormat(t *testing.T) {
+	repo := &mockEntryRepo{}
+	svc := service.NewCalendarService(repo, nil, false)
+
+	_, err := svc.Aggregate(context.Background(), service.AggregateRequest{
+		SinceDate:   "2026/04/01",
+		UntilDate:   "2026-04-30",
+		Timezone:    "UTC",
+		IncludeGcal: false,
+	})
+	if err == nil {
+		t.Fatal("預期應回錯誤")
+	}
+	appErr, ok := err.(*model.AppError)
+	if !ok {
+		t.Fatalf("預期 AppError，實際 %T", err)
+	}
+	if appErr.Code != model.ErrCodeInvalidInput {
+		t.Errorf("預期 INVALID_INPUT，實際 %s", appErr.Code)
+	}
+}
+
+// TestAggregate_SingleDayBounds 測試 since==until 彙整一天（92 天上限邊界）
+func TestAggregate_SingleDayBounds(t *testing.T) {
+	repo := &mockEntryRepo{}
+	svc := service.NewCalendarService(repo, nil, false)
+
+	result, err := svc.Aggregate(context.Background(), service.AggregateRequest{
+		SinceDate:   "2026-04-24",
+		UntilDate:   "2026-04-24",
+		View:        "day",
+		Timezone:    "UTC",
+		IncludeGcal: false,
+	})
+	if err != nil {
+		t.Fatalf("非預期錯誤: %v", err)
+	}
+	if len(result.Response.Days) != 1 {
+		t.Errorf("預期 1 天，實際 %d 天", len(result.Response.Days))
+	}
+	if result.Response.Days[0].Date != "2026-04-24" {
+		t.Errorf("預期 date=2026-04-24，實際 %s", result.Response.Days[0].Date)
+	}
+}
+
+// TestAggregate_92DaysBoundary 92 天剛好可通過
+func TestAggregate_92DaysBoundary(t *testing.T) {
+	repo := &mockEntryRepo{}
+	svc := service.NewCalendarService(repo, nil, false)
+
+	// 2026-01-01 ~ 2026-04-02 共 92 天（含起訖）
+	_, err := svc.Aggregate(context.Background(), service.AggregateRequest{
+		SinceDate:   "2026-01-01",
+		UntilDate:   "2026-04-02",
+		View:        "month",
+		Timezone:    "UTC",
+		IncludeGcal: false,
+	})
+	if err != nil {
+		t.Errorf("92 天邊界應通過，但錯誤: %v", err)
+	}
+
+	// 93 天應失敗
+	_, err = svc.Aggregate(context.Background(), service.AggregateRequest{
+		SinceDate:   "2026-01-01",
+		UntilDate:   "2026-04-03",
+		View:        "month",
+		Timezone:    "UTC",
+		IncludeGcal: false,
+	})
+	if err == nil {
+		t.Error("93 天應失敗")
+	}
+}
+
+// TestAggregate_GcalNotConnected_Degraded 測試未連 gcal 時走 degraded（回 200 + 空 events）
+//
+// 此測試以 CalendarService 自帶的 mock gcal repo 模擬「未連」。
+// 由於 GcalService 是具體型別，這裡用真實 GcalService，但 gcalRepo 回 nil。
+func TestAggregate_GcalNotConnected_Degraded(t *testing.T) {
+	repo := &mockEntryRepo{}
+	gcalSvc := newStubGcalService(&stubGcalRepo{integration: nil})
+	svc := service.NewCalendarService(repo, gcalSvc, false)
+
+	result, err := svc.Aggregate(context.Background(), service.AggregateRequest{
+		SinceDate:   "2026-04-24",
+		UntilDate:   "2026-04-24",
+		View:        "day",
+		Timezone:    "UTC",
+		IncludeGcal: true,
+	})
+	if err != nil {
+		t.Fatalf("未連 gcal 應走 degraded，不應 error: %v", err)
+	}
+	if !result.Degraded {
+		t.Error("未連 gcal 應 Degraded=true")
+	}
+	if result.GcalConnected {
+		t.Error("未連 gcal 應 GcalConnected=false")
+	}
+	if len(result.Response.Days) != 1 || len(result.Response.Days[0].Events) != 0 {
+		t.Error("未連 gcal 時 events 應為空")
+	}
+}
+
+// TestGetDay_Delegates 確保 GetDay 會委派到 Aggregate（day view, since==until=date）
+func TestGetDay_Delegates(t *testing.T) {
+	repo := &mockEntryRepo{
+		entries: []dto.CalendarEntrySummary{
+			mkEntry(uuid.New(), "E1", time.Date(2026, 4, 24, 9, 0, 0, 0, time.UTC), "2026-04-24"),
+		},
+	}
+	svc := service.NewCalendarService(repo, nil, false)
+
+	day, degraded, _, err := svc.GetDay(context.Background(), "2026-04-24", "UTC", "primary", false)
+	if err != nil {
+		t.Fatalf("非預期錯誤: %v", err)
+	}
+	if day.Date != "2026-04-24" {
+		t.Errorf("預期 date=2026-04-24，實際 %s", day.Date)
+	}
+	if day.EntryCount != 1 {
+		t.Errorf("預期 entry_count=1，實際 %d", day.EntryCount)
+	}
+	if degraded {
+		t.Error("include_gcal=false 不應 degraded")
+	}
+}
+
+// TestAggregate_TimezoneBoundary 測試時區影響日期歸屬（Asia/Taipei）
+//
+// 此測試驗證 CalendarService 將 tz 正確傳給 repo；實際 tz bucket 的正確性
+// 由 repository.ListByDateRange 與 Go time 標準庫共同保證。
+func TestAggregate_TimezoneBoundary(t *testing.T) {
+	// repo 假設會把 entry 以 Asia/Taipei 歸到 2026-04-24
+	repo := &mockEntryRepo{
+		entries: []dto.CalendarEntrySummary{
+			mkEntry(uuid.New(), "Late", time.Date(2026, 4, 24, 15, 30, 0, 0, time.UTC), "2026-04-24"),
+		},
+	}
+	svc := service.NewCalendarService(repo, nil, false)
+
+	result, err := svc.Aggregate(context.Background(), service.AggregateRequest{
+		SinceDate:   "2026-04-24",
+		UntilDate:   "2026-04-24",
+		View:        "day",
+		Timezone:    "Asia/Taipei",
+		IncludeGcal: false,
+	})
+	if err != nil {
+		t.Fatalf("非預期錯誤: %v", err)
+	}
+	if len(result.Response.Days) != 1 || result.Response.Days[0].EntryCount != 1 {
+		t.Errorf("Asia/Taipei 應將 entry 歸到 2026-04-24，實際 days=%+v", result.Response.Days)
+	}
+}

--- a/dev/src/handler/calendar.go
+++ b/dev/src/handler/calendar.go
@@ -46,7 +46,12 @@ func (h *CalendarHandler) Aggregate(c *gin.Context) {
 		return
 	}
 
+	// include_gcal 分為三態：
+	//   - 明確 true：要求一定要整合 gcal；未連 gcal → 424 GCAL_NOT_CONNECTED（對齊 spec）
+	//   - 明確 false：完全跳過 gcal
+	//   - 未指定（預設 true）：盡力整合，未連時走 degraded（200 + gcal_connected=false）
 	includeGcal := true
+	explicitIncludeGcal := false
 	if v := c.Query("include_gcal"); v != "" {
 		parsed, err := strconv.ParseBool(v)
 		if err != nil {
@@ -57,6 +62,7 @@ func (h *CalendarHandler) Aggregate(c *gin.Context) {
 			return
 		}
 		includeGcal = parsed
+		explicitIncludeGcal = true
 	}
 
 	calendarID := c.DefaultQuery("calendar_id", "primary")
@@ -75,9 +81,16 @@ func (h *CalendarHandler) Aggregate(c *gin.Context) {
 		return
 	}
 
-	// 未連 gcal 但 include_gcal=true：回 200 + X-Degraded: gcal（不回 424）
-	// 這是本 PR 採用的語意：把「未連」當作 degraded（前端可透過 gcal_connected 或 X-Degraded 判斷）。
-	// Spec 另有 424 GCAL_NOT_CONNECTED 的選項，但為了讓行事曆主流程不卡住，採 degraded。
+	// 明確 include_gcal=true 但 gcal 未連 → 424（spec 要求）
+	if explicitIncludeGcal && includeGcal && !result.GcalConnected {
+		c.JSON(http.StatusFailedDependency, dto.ErrorResponse{
+			Code:    model.ErrCodeGcalNotConnected,
+			Message: "尚未連接 Google Calendar，無法整合事件。請先完成 OAuth 授權。",
+		})
+		return
+	}
+
+	// 其他 degraded 情境（gcal upstream 失敗，或未指定 include_gcal 時未連）→ 200 + X-Degraded: gcal
 	if result.Degraded {
 		c.Header("X-Degraded", "gcal")
 	}

--- a/dev/src/handler/calendar.go
+++ b/dev/src/handler/calendar.go
@@ -1,0 +1,138 @@
+package handler
+
+import (
+	"net/http"
+	"strconv"
+
+	"github.com/gin-gonic/gin"
+	"github.com/gpwork4u/aibo/dto"
+	"github.com/gpwork4u/aibo/model"
+	"github.com/gpwork4u/aibo/service"
+)
+
+// CalendarHandler 行事曆彙整 HTTP handlers（F-026b）
+type CalendarHandler struct {
+	svc *service.CalendarService
+}
+
+// NewCalendarHandler 建立新的 CalendarHandler
+func NewCalendarHandler(svc *service.CalendarService) *CalendarHandler {
+	return &CalendarHandler{svc: svc}
+}
+
+// Aggregate 行事曆區間彙整
+// GET /api/v1/calendar?since=&until=&view=&include_gcal=&calendar_id=
+// Headers: X-Timezone: IANA tz（預設 UTC）
+func (h *CalendarHandler) Aggregate(c *gin.Context) {
+	since := c.Query("since")
+	until := c.Query("until")
+	if since == "" || until == "" {
+		c.JSON(http.StatusBadRequest, dto.ErrorResponse{
+			Code:    model.ErrCodeInvalidInput,
+			Message: "since 與 until 皆為必填（格式 YYYY-MM-DD）",
+		})
+		return
+	}
+
+	view := c.DefaultQuery("view", "month")
+	switch view {
+	case "month", "week", "day":
+		// ok
+	default:
+		c.JSON(http.StatusBadRequest, dto.ErrorResponse{
+			Code:    model.ErrCodeInvalidInput,
+			Message: "view 只能是 month / week / day",
+		})
+		return
+	}
+
+	includeGcal := true
+	if v := c.Query("include_gcal"); v != "" {
+		parsed, err := strconv.ParseBool(v)
+		if err != nil {
+			c.JSON(http.StatusBadRequest, dto.ErrorResponse{
+				Code:    model.ErrCodeInvalidInput,
+				Message: "include_gcal 必須為 bool",
+			})
+			return
+		}
+		includeGcal = parsed
+	}
+
+	calendarID := c.DefaultQuery("calendar_id", "primary")
+	tz := c.GetHeader("X-Timezone")
+
+	result, err := h.svc.Aggregate(c.Request.Context(), service.AggregateRequest{
+		SinceDate:   since,
+		UntilDate:   until,
+		View:        view,
+		IncludeGcal: includeGcal,
+		CalendarID:  calendarID,
+		Timezone:    tz,
+	})
+	if err != nil {
+		writeCalendarError(c, err)
+		return
+	}
+
+	// 未連 gcal 但 include_gcal=true：回 200 + X-Degraded: gcal（不回 424）
+	// 這是本 PR 採用的語意：把「未連」當作 degraded（前端可透過 gcal_connected 或 X-Degraded 判斷）。
+	// Spec 另有 424 GCAL_NOT_CONNECTED 的選項，但為了讓行事曆主流程不卡住，採 degraded。
+	if result.Degraded {
+		c.Header("X-Degraded", "gcal")
+	}
+
+	c.JSON(http.StatusOK, result.Response)
+}
+
+// GetDay 取得單日彙整
+// GET /api/v1/calendar/days/:date
+// Headers: X-Timezone: IANA tz（預設 UTC）
+func (h *CalendarHandler) GetDay(c *gin.Context) {
+	date := c.Param("date")
+	if date == "" {
+		c.JSON(http.StatusBadRequest, dto.ErrorResponse{
+			Code:    model.ErrCodeInvalidInput,
+			Message: "date 為必填（格式 YYYY-MM-DD）",
+		})
+		return
+	}
+
+	includeGcal := true
+	if v := c.Query("include_gcal"); v != "" {
+		parsed, err := strconv.ParseBool(v)
+		if err != nil {
+			c.JSON(http.StatusBadRequest, dto.ErrorResponse{
+				Code:    model.ErrCodeInvalidInput,
+				Message: "include_gcal 必須為 bool",
+			})
+			return
+		}
+		includeGcal = parsed
+	}
+	calendarID := c.DefaultQuery("calendar_id", "primary")
+	tz := c.GetHeader("X-Timezone")
+
+	day, degraded, _, err := h.svc.GetDay(c.Request.Context(), date, tz, calendarID, includeGcal)
+	if err != nil {
+		writeCalendarError(c, err)
+		return
+	}
+	if degraded {
+		c.Header("X-Degraded", "gcal")
+	}
+
+	c.JSON(http.StatusOK, day)
+}
+
+// writeCalendarError 統一錯誤輸出
+func writeCalendarError(c *gin.Context, err error) {
+	if appErr, ok := err.(*model.AppError); ok {
+		c.JSON(appErr.Status, dto.ErrorResponse{Code: appErr.Code, Message: appErr.Message})
+		return
+	}
+	c.JSON(http.StatusInternalServerError, dto.ErrorResponse{
+		Code:    "INTERNAL_ERROR",
+		Message: "伺服器內部錯誤",
+	})
+}

--- a/dev/src/main.go
+++ b/dev/src/main.go
@@ -129,8 +129,12 @@ func main() {
 	lifecycleSvc := service.NewLifecycleService(entryRepo)
 	lifecycleHandler := handler.NewLifecycleHandler(lifecycleSvc)
 
+	// 初始化行事曆彙整服務（F-026b；gcal 5 分鐘 in-memory cache）
+	calendarSvc := service.NewCalendarService(entryRepo, gcalSvc, true)
+	calendarHandler := handler.NewCalendarHandler(calendarSvc)
+
 	// 設定路由
-	r := router.Setup(apiKeySvc, apiKeyHandler, categoryHandler, llmProviderHandler, entryHandler, classifyHandler, searchHandler, gitImportHandler, gcalHandler, confidenceHandler, statsHandler, systemHandler, lifecycleHandler, calendarConvertHandler)
+	r := router.Setup(apiKeySvc, apiKeyHandler, categoryHandler, llmProviderHandler, entryHandler, classifyHandler, searchHandler, gitImportHandler, gcalHandler, confidenceHandler, statsHandler, systemHandler, lifecycleHandler, calendarConvertHandler, calendarHandler)
 
 	// 啟動 HTTP server（graceful shutdown）
 	srv := &http.Server{

--- a/dev/src/router/router.go
+++ b/dev/src/router/router.go
@@ -10,7 +10,7 @@ import (
 )
 
 // Setup 設定路由
-func Setup(apiKeySvc *service.ApiKeyService, apiKeyHandler *handler.ApiKeyHandler, categoryHandler *handler.CategoryHandler, llmProviderHandler *handler.LlmProviderHandler, entryHandler *handler.EntryHandler, classifyHandler *handler.ClassifyHandler, searchHandler *handler.SearchHandler, gitImportHandler *handler.GitImportHandler, gcalHandler *handler.GcalHandler, confidenceHandler *handler.ConfidenceHandler, statsHandler *handler.StatsHandler, systemHandler *handler.SystemHandler, lifecycleHandler *handler.LifecycleHandler, calendarConvertHandler *handler.CalendarConvertHandler) *gin.Engine {
+func Setup(apiKeySvc *service.ApiKeyService, apiKeyHandler *handler.ApiKeyHandler, categoryHandler *handler.CategoryHandler, llmProviderHandler *handler.LlmProviderHandler, entryHandler *handler.EntryHandler, classifyHandler *handler.ClassifyHandler, searchHandler *handler.SearchHandler, gitImportHandler *handler.GitImportHandler, gcalHandler *handler.GcalHandler, confidenceHandler *handler.ConfidenceHandler, statsHandler *handler.StatsHandler, systemHandler *handler.SystemHandler, lifecycleHandler *handler.LifecycleHandler, calendarConvertHandler *handler.CalendarConvertHandler, calendarHandler *handler.CalendarHandler) *gin.Engine {
 	r := gin.Default()
 
 	// CORS middleware — 允許跨網域（前端 localhost:3000 呼叫 API localhost:8080）
@@ -114,6 +114,13 @@ func Setup(apiKeySvc *service.ApiKeyService, apiKeyHandler *handler.ApiKeyHandle
 		system := v1.Group("/system")
 		{
 			system.GET("/search-config", systemHandler.GetSearchConfig)
+		}
+
+		// 行事曆彙整（F-026b）
+		calendarGroup := v1.Group("/calendar")
+		{
+			calendarGroup.GET("", calendarHandler.Aggregate)
+			calendarGroup.GET("/days/:date", calendarHandler.GetDay)
 		}
 	}
 

--- a/dev/src/service/calendar.go
+++ b/dev/src/service/calendar.go
@@ -1,0 +1,451 @@
+package service
+
+import (
+	"context"
+	"crypto/sha1"
+	"encoding/hex"
+	"fmt"
+	"log/slog"
+	"sort"
+	"sync"
+	"time"
+
+	"github.com/gpwork4u/aibo/dto"
+	"github.com/gpwork4u/aibo/model"
+	"google.golang.org/api/calendar/v3"
+)
+
+// MonthViewEntriesCap 月視圖每日 entries 最多筆數（超過則看 entry_count）
+const MonthViewEntriesCap = 3
+
+// gcalCacheTTL gcal 事件的 in-memory 快取壽命
+const gcalCacheTTL = 5 * time.Minute
+
+// AggregateRequest 行事曆彙整請求
+//
+// 由 handler 把 HTTP 層的 query/header 參數解析後傳入；
+// service 不讀取 gin context。
+type AggregateRequest struct {
+	SinceDate   string // YYYY-MM-DD（以 Timezone 時區解讀）
+	UntilDate   string // YYYY-MM-DD
+	View        string // month | week | day
+	IncludeGcal bool
+	CalendarID  string
+	Timezone    string // IANA，空字串代表 UTC
+}
+
+// AggregateResult 行事曆彙整結果
+//
+// Degraded=true 時 handler 應加回應 header `X-Degraded: gcal`。
+// GcalConnected=false 代表使用者尚未連 gcal（當 include_gcal=true 時亦走 degraded）。
+type AggregateResult struct {
+	Response      *dto.CalendarResponse
+	Degraded      bool
+	GcalConnected bool
+}
+
+// CalendarService 行事曆彙整服務
+//
+// 實作 F-026 spec：read-through 合併 entries + gcal events，不落 DB。
+// gcal events 採用 in-memory 5 分鐘快取；entries 每次打 DB。
+type CalendarService struct {
+	entryRepo EntryRepository
+	gcalSvc   *GcalService
+
+	// gcal events cache（key: sha1(calendarID+since+until)）
+	cacheMu      sync.Mutex
+	cache        map[string]*gcalCacheEntry
+	cacheEnabled bool
+}
+
+type gcalCacheEntry struct {
+	events    []*calendar.Event
+	expiresAt time.Time
+}
+
+// NewCalendarService 建立新的 CalendarService
+//
+// cacheEnabled=false 可關閉 in-memory cache（測試方便）。
+func NewCalendarService(entryRepo EntryRepository, gcalSvc *GcalService, cacheEnabled bool) *CalendarService {
+	return &CalendarService{
+		entryRepo:    entryRepo,
+		gcalSvc:      gcalSvc,
+		cache:        make(map[string]*gcalCacheEntry),
+		cacheEnabled: cacheEnabled,
+	}
+}
+
+// Aggregate 依 since..until 彙整 entries + gcal events 為 CalendarResponse
+//
+// Degraded 策略：
+//   - IncludeGcal=false → 完全跳過 gcal（不算 degraded）
+//   - IncludeGcal=true 且未連 gcal → degraded（空 events），GcalConnected=false
+//   - IncludeGcal=true 且 gcal upstream 失敗 → degraded（空 events），GcalConnected=true
+//
+// 注意：若 handler 希望「未連 gcal 時回 424」，應在呼叫前自行檢查 IsConnected；
+// 此方法本身不區分「未連」與「連了但失敗」的狀態碼，僅以旗標回報，由 handler 決定語意。
+func (s *CalendarService) Aggregate(ctx context.Context, req AggregateRequest) (*AggregateResult, error) {
+	// 參數預設值
+	tz := req.Timezone
+	if tz == "" {
+		tz = "UTC"
+	}
+	view := req.View
+	if view == "" {
+		view = "month"
+	}
+	calendarID := req.CalendarID
+	if calendarID == "" {
+		calendarID = "primary"
+	}
+
+	// 驗證時區
+	loc, err := time.LoadLocation(tz)
+	if err != nil {
+		return nil, model.NewAppError(400, model.ErrCodeInvalidInput, "無效的時區")
+	}
+
+	// 解析日期
+	sinceLocal, err := time.ParseInLocation("2006-01-02", req.SinceDate, loc)
+	if err != nil {
+		return nil, model.NewAppError(400, model.ErrCodeInvalidInput, "無效的 since 日期格式，需 YYYY-MM-DD")
+	}
+	untilLocal, err := time.ParseInLocation("2006-01-02", req.UntilDate, loc)
+	if err != nil {
+		return nil, model.NewAppError(400, model.ErrCodeInvalidInput, "無效的 until 日期格式，需 YYYY-MM-DD")
+	}
+
+	// until >= since
+	if untilLocal.Before(sinceLocal) {
+		return nil, model.NewAppError(400, model.ErrCodeInvalidInput, "until 必須 >= since")
+	}
+	// 跨度 <= 92 天（包含起訖日）
+	spanDays := int(untilLocal.Sub(sinceLocal).Hours()/24) + 1
+	if spanDays > 92 {
+		return nil, model.NewAppError(400, model.ErrCodeInvalidInput, "日期跨度不得超過 92 天")
+	}
+
+	// 1) 撈 entries
+	entries, err := s.entryRepo.ListByDateRange(ctx, req.SinceDate, req.UntilDate, tz)
+	if err != nil {
+		return nil, err
+	}
+
+	// 2) 撈 gcal events（read-through + degraded）
+	degraded := false
+	gcalConnected := true
+	var events []*calendar.Event
+
+	if req.IncludeGcal {
+		events, gcalConnected, err = s.fetchGcalEvents(ctx, calendarID, sinceLocal, untilLocal, loc)
+		if err != nil {
+			// upstream 失敗 → degraded，仍回 entries
+			slog.WarnContext(ctx, "calendar.gcal_degraded", "error", err)
+			degraded = true
+			events = nil
+		}
+		if !gcalConnected {
+			// 未連 gcal → 由 handler 決定 424 或 degraded；這裡當 degraded
+			degraded = true
+		}
+	}
+
+	// 3) 建立每日 bucket（since..until 每一天一筆 CalendarDay）
+	days := buildDayBuckets(sinceLocal, untilLocal, loc)
+
+	// 4) 把 entries 分桶
+	for _, e := range entries {
+		if bucket, ok := days[e.Date]; ok {
+			bucket.Entries = append(bucket.Entries, e)
+		}
+	}
+
+	// 5) 把 events 分桶（歸屬到 start 所在日；跨日 event 在 week/day view 於每天都顯示）
+	for _, ev := range events {
+		summary := convertGcalEvent(ev, loc)
+		if summary == nil {
+			continue
+		}
+		assignEventToDays(days, summary, view, loc)
+	}
+
+	// 6) 按 view 調整 entry 上限
+	orderedDates := orderedDates(sinceLocal, untilLocal, loc)
+	outDays := make([]dto.CalendarDay, 0, len(orderedDates))
+	totalEntries, totalEvents := 0, 0
+	for _, d := range orderedDates {
+		b := days[d]
+		// 確保每日 entries 以 created_at ASC 排序（repository 已 ORDER BY created_at ASC，
+		// 分桶後仍保序；events 則依 start ASC 排序）
+		sort.SliceStable(b.Events, func(i, j int) bool {
+			return b.Events[i].Start.Before(b.Events[j].Start)
+		})
+
+		b.EntryCount = len(b.Entries)
+		b.EventCount = len(b.Events)
+		totalEntries += b.EntryCount
+		totalEvents += b.EventCount
+
+		// month view：entries 限制 MonthViewEntriesCap
+		if view == "month" && len(b.Entries) > MonthViewEntriesCap {
+			b.Entries = b.Entries[:MonthViewEntriesCap]
+		}
+
+		outDays = append(outDays, *b)
+	}
+
+	resp := &dto.CalendarResponse{
+		Since: req.SinceDate,
+		Until: req.UntilDate,
+		Days:  outDays,
+	}
+
+	slog.InfoContext(ctx, "calendar.aggregate",
+		"since", req.SinceDate,
+		"until", req.UntilDate,
+		"view", view,
+		"tz", tz,
+		"degraded", degraded,
+		"gcal_connected", gcalConnected,
+		"entries_total", totalEntries,
+		"events_total", totalEvents,
+	)
+
+	return &AggregateResult{
+		Response:      resp,
+		Degraded:      degraded,
+		GcalConnected: gcalConnected,
+	}, nil
+}
+
+// GetDay 取得單日彙整
+//
+// date 以 tz 時區解讀；entries/events 全量回傳（不套用 month view 的 3 筆上限）。
+// GcalConnected=false 或 gcal 失敗時走 degraded（events 空，Degraded=true）。
+//
+// 回傳除了 CalendarDay 本體外，也透過 AggregateResult 包裝 Degraded 旗標。
+func (s *CalendarService) GetDay(
+	ctx context.Context,
+	dateStr string,
+	tz, calendarID string,
+	includeGcal bool,
+) (*dto.CalendarDay, bool, bool, error) {
+	// 直接複用 Aggregate 邏輯，but view=day + since=until=date
+	result, err := s.Aggregate(ctx, AggregateRequest{
+		SinceDate:   dateStr,
+		UntilDate:   dateStr,
+		View:        "day",
+		IncludeGcal: includeGcal,
+		CalendarID:  calendarID,
+		Timezone:    tz,
+	})
+	if err != nil {
+		return nil, false, false, err
+	}
+	if len(result.Response.Days) == 0 {
+		// 理論上不會發生（至少有 1 天）
+		return &dto.CalendarDay{Date: dateStr, Entries: []dto.CalendarEntrySummary{}, Events: []dto.CalendarEventSummary{}}, result.Degraded, result.GcalConnected, nil
+	}
+	day := result.Response.Days[0]
+	return &day, result.Degraded, result.GcalConnected, nil
+}
+
+// fetchGcalEvents 讀取 gcal events（含 5 分鐘 in-memory 快取）
+//
+// 回傳 (events, gcalConnected, err)：
+//   - gcalConnected=false 時 events 為 nil 且 err 為 nil（由呼叫端走 degraded）
+//   - 其他 upstream 失敗時 err != nil（由呼叫端走 degraded）
+func (s *CalendarService) fetchGcalEvents(
+	ctx context.Context,
+	calendarID string,
+	sinceLocal, untilLocal time.Time,
+	loc *time.Location,
+) ([]*calendar.Event, bool, error) {
+	// 先檢查是否已連
+	connected, err := s.gcalSvc.IsConnected(ctx)
+	if err != nil {
+		return nil, false, err
+	}
+	if !connected {
+		return nil, false, nil
+	}
+
+	// 換算成 UTC 絕對時間戳（startUTC, endUTC)
+	startUTC := sinceLocal.UTC()
+	endUTC := untilLocal.AddDate(0, 0, 1).UTC() // exclusive
+
+	// cache lookup
+	cacheKey := gcalCacheKey(calendarID, startUTC, endUTC)
+	if s.cacheEnabled {
+		s.cacheMu.Lock()
+		if entry, ok := s.cache[cacheKey]; ok && time.Now().Before(entry.expiresAt) {
+			s.cacheMu.Unlock()
+			return entry.events, true, nil
+		}
+		s.cacheMu.Unlock()
+	}
+
+	events, err := s.gcalSvc.ListEvents(ctx, calendarID, startUTC, endUTC, true)
+	if err != nil {
+		// 若是 AppError(GCAL_NOT_CONNECTED)（例如 token 過期後 Integration 被清），視為 not connected
+		if appErr, ok := err.(*model.AppError); ok {
+			if appErr.Code == model.ErrCodeGcalNotConnected {
+				return nil, false, nil
+			}
+			// token expired 也視為 degraded（不讓 API 整個掛）
+			if appErr.Code == model.ErrCodeGcalTokenExpired {
+				return nil, true, err
+			}
+		}
+		return nil, true, err
+	}
+
+	if s.cacheEnabled {
+		s.cacheMu.Lock()
+		s.cache[cacheKey] = &gcalCacheEntry{
+			events:    events,
+			expiresAt: time.Now().Add(gcalCacheTTL),
+		}
+		s.cacheMu.Unlock()
+	}
+	return events, true, nil
+}
+
+// gcalCacheKey 產生 cache key
+func gcalCacheKey(calendarID string, startUTC, endUTC time.Time) string {
+	raw := fmt.Sprintf("%s|%d|%d", calendarID, startUTC.Unix(), endUTC.Unix())
+	sum := sha1.Sum([]byte(raw))
+	return hex.EncodeToString(sum[:])
+}
+
+// buildDayBuckets 依時區建立 since..until 每一天的 CalendarDay map（key=YYYY-MM-DD）
+//
+// 初始化 Entries / Events 為空 slice（避免 json null）。
+func buildDayBuckets(sinceLocal, untilLocal time.Time, loc *time.Location) map[string]*dto.CalendarDay {
+	m := make(map[string]*dto.CalendarDay)
+	for d := sinceLocal; !d.After(untilLocal); d = d.AddDate(0, 0, 1) {
+		key := d.Format("2006-01-02")
+		m[key] = &dto.CalendarDay{
+			Date:    key,
+			Entries: []dto.CalendarEntrySummary{},
+			Events:  []dto.CalendarEventSummary{},
+		}
+	}
+	_ = loc
+	return m
+}
+
+// orderedDates 回傳 since..until 之間的日期字串陣列（依時間遞增）
+func orderedDates(sinceLocal, untilLocal time.Time, loc *time.Location) []string {
+	out := make([]string, 0)
+	for d := sinceLocal; !d.After(untilLocal); d = d.AddDate(0, 0, 1) {
+		out = append(out, d.Format("2006-01-02"))
+	}
+	_ = loc
+	return out
+}
+
+// convertGcalEvent 將 Google Calendar event 轉為 DTO
+//
+// 時間解析規則：
+//   - event.Start.DateTime 存在 → 以 RFC3339 解析（含時區）
+//   - 否則 event.Start.Date（all-day）→ 以當地時區 00:00
+//   - 若無 End，end = start
+//
+// 回傳 nil 代表 event 無效（例如 summary 為空且無時間）。
+func convertGcalEvent(ev *calendar.Event, loc *time.Location) *dto.CalendarEventSummary {
+	if ev == nil {
+		return nil
+	}
+
+	allDay := false
+	var start, end time.Time
+	var err error
+
+	switch {
+	case ev.Start != nil && ev.Start.DateTime != "":
+		start, err = time.Parse(time.RFC3339, ev.Start.DateTime)
+		if err != nil {
+			return nil
+		}
+	case ev.Start != nil && ev.Start.Date != "":
+		start, err = time.ParseInLocation("2006-01-02", ev.Start.Date, loc)
+		if err != nil {
+			return nil
+		}
+		allDay = true
+	default:
+		return nil
+	}
+
+	switch {
+	case ev.End != nil && ev.End.DateTime != "":
+		end, err = time.Parse(time.RFC3339, ev.End.DateTime)
+		if err != nil {
+			end = start
+		}
+	case ev.End != nil && ev.End.Date != "":
+		end, err = time.ParseInLocation("2006-01-02", ev.End.Date, loc)
+		if err != nil {
+			end = start
+		}
+	default:
+		end = start
+	}
+
+	var location, description *string
+	if ev.Location != "" {
+		l := ev.Location
+		location = &l
+	}
+	if ev.Description != "" {
+		d := ev.Description
+		description = &d
+	}
+
+	return &dto.CalendarEventSummary{
+		GcalID:      ev.Id,
+		Summary:     ev.Summary,
+		Start:       start,
+		End:         end,
+		AllDay:      allDay,
+		Location:    location,
+		Description: description,
+		// LinkedEntryID：F-026c 會填入；此處暫時 nil
+	}
+}
+
+// assignEventToDays 把 event 放入正確的 day bucket
+//
+// 規則（依 spec §Business Rules #3）：
+//   - month view：event 僅歸屬到 start 所在日
+//   - week / day view：只要 event 的 [start, end] 跟某一天有交集就加入該天
+//     （client-side 可再做去重；server 端允許重複）
+func assignEventToDays(
+	days map[string]*dto.CalendarDay,
+	ev *dto.CalendarEventSummary,
+	view string,
+	loc *time.Location,
+) {
+	if view == "month" {
+		key := ev.Start.In(loc).Format("2006-01-02")
+		if b, ok := days[key]; ok {
+			b.Events = append(b.Events, *ev)
+		}
+		return
+	}
+
+	// week / day：逐日檢查是否與 event 區間有交集
+	for k, b := range days {
+		dayStart, err := time.ParseInLocation("2006-01-02", k, loc)
+		if err != nil {
+			continue
+		}
+		dayEnd := dayStart.AddDate(0, 0, 1).Add(-time.Nanosecond)
+
+		// 交集條件：event.Start <= dayEnd && event.End >= dayStart
+		if !ev.Start.After(dayEnd) && !ev.End.Before(dayStart) {
+			b.Events = append(b.Events, *ev)
+		}
+	}
+}

--- a/dev/src/service/gcal.go
+++ b/dev/src/service/gcal.go
@@ -158,29 +158,57 @@ func (s *GcalService) HandleCallback(ctx context.Context, code, state string) (s
 	return email, nil
 }
 
-// ImportEvents 匯入 Google Calendar 事件
-func (s *GcalService) ImportEvents(ctx context.Context, calendarID string, since, until time.Time, includeRecurring bool) (eventsFound, entriesCreated, entriesSkipped int, err error) {
+// IsConnected 判斷目前是否已完成 Google Calendar OAuth 授權。
+//
+// 回傳 (true, nil) 代表已連；(false, nil) 代表尚未連（可引導前端至設定頁）。
+// 若 DB 查詢失敗會回 error。
+func (s *GcalService) IsConnected(ctx context.Context) (bool, error) {
+	integration, err := s.gcalRepo.Get(ctx)
+	if err != nil {
+		return false, fmt.Errorf("查詢 GcalIntegration 失敗: %w", err)
+	}
+	return integration != nil, nil
+}
+
+// ListEvents 以目前已授權使用者的身份，列出指定區間的 Google Calendar 事件（read-through）。
+//
+// 行為：
+//   - 若未連 gcal，回 AppError(401, GCAL_NOT_CONNECTED)；handler 可依需求轉換狀態碼。
+//   - 若 refresh token 失敗，回 AppError(401, GCAL_TOKEN_EXPIRED)。
+//   - 其他 upstream 錯誤以 wrapped error 回傳，handler 可在允許時走 degraded。
+//   - 不會寫入 DB，也不會建立 entry（與 ImportEvents 的差異）。
+//
+// 參數：
+//   - calendarID：Google Calendar ID，通常為 "primary"
+//   - since/until：查詢區間（傳給 Google API 的 timeMin/timeMax）
+//   - singleEvents：是否展開 recurring event
+func (s *GcalService) ListEvents(
+	ctx context.Context,
+	calendarID string,
+	since, until time.Time,
+	singleEvents bool,
+) ([]*calendar.Event, error) {
 	// 取得整合資訊
 	integration, err := s.gcalRepo.Get(ctx)
 	if err != nil {
-		return 0, 0, 0, fmt.Errorf("查詢 GcalIntegration 失敗: %w", err)
+		return nil, fmt.Errorf("查詢 GcalIntegration 失敗: %w", err)
 	}
 	if integration == nil {
-		return 0, 0, 0, model.NewAppError(http.StatusUnauthorized, model.ErrCodeGcalNotConnected, "Google Calendar 尚未授權")
+		return nil, model.NewAppError(http.StatusUnauthorized, model.ErrCodeGcalNotConnected, "Google Calendar 尚未授權")
 	}
 
 	// 解密 tokens
 	accessToken, err := s.aesCrypto.Decrypt(integration.AccessToken)
 	if err != nil {
-		return 0, 0, 0, fmt.Errorf("解密 access_token 失敗: %w", err)
+		return nil, fmt.Errorf("解密 access_token 失敗: %w", err)
 	}
 	refreshToken, err := s.aesCrypto.Decrypt(integration.RefreshToken)
 	if err != nil {
-		return 0, 0, 0, fmt.Errorf("解密 refresh_token 失敗: %w", err)
+		return nil, fmt.Errorf("解密 refresh_token 失敗: %w", err)
 	}
 	clientSecret, err := s.aesCrypto.Decrypt(integration.ClientSecret)
 	if err != nil {
-		return 0, 0, 0, fmt.Errorf("解密 client_secret 失敗: %w", err)
+		return nil, fmt.Errorf("解密 client_secret 失敗: %w", err)
 	}
 
 	// 建立 OAuth2 token
@@ -204,7 +232,7 @@ func (s *GcalService) ImportEvents(ctx context.Context, calendarID string, since
 	tokenSource := oauthCfg.TokenSource(ctx, token)
 	newToken, err := tokenSource.Token()
 	if err != nil {
-		return 0, 0, 0, model.NewAppError(http.StatusUnauthorized, model.ErrCodeGcalTokenExpired, "Token 過期且 refresh 失敗，請重新授權")
+		return nil, model.NewAppError(http.StatusUnauthorized, model.ErrCodeGcalTokenExpired, "Token 過期且 refresh 失敗，請重新授權")
 	}
 
 	// 如果 token 被 refresh 了，更新到 DB
@@ -224,26 +252,35 @@ func (s *GcalService) ImportEvents(ctx context.Context, calendarID string, since
 	client := oauth2.NewClient(ctx, tokenSource)
 	srv, err := calendar.NewService(ctx, option.WithHTTPClient(client))
 	if err != nil {
-		return 0, 0, 0, fmt.Errorf("建立 Calendar service 失敗: %w", err)
+		return nil, fmt.Errorf("建立 Calendar service 失敗: %w", err)
 	}
 
 	// 列出事件
 	call := srv.Events.List(calendarID).
 		TimeMin(since.Format(time.RFC3339)).
 		TimeMax(until.Format(time.RFC3339)).
-		SingleEvents(includeRecurring).
+		SingleEvents(singleEvents).
 		OrderBy("startTime").
 		MaxResults(500)
 
 	events, err := call.Do()
 	if err != nil {
-		return 0, 0, 0, fmt.Errorf("列出 Calendar 事件失敗: %w", err)
+		return nil, fmt.Errorf("列出 Calendar 事件失敗: %w", err)
+	}
+	return events.Items, nil
+}
+
+// ImportEvents 匯入 Google Calendar 事件
+func (s *GcalService) ImportEvents(ctx context.Context, calendarID string, since, until time.Time, includeRecurring bool) (eventsFound, entriesCreated, entriesSkipped int, err error) {
+	items, err := s.ListEvents(ctx, calendarID, since, until, includeRecurring)
+	if err != nil {
+		return 0, 0, 0, err
 	}
 
-	eventsFound = len(events.Items)
+	eventsFound = len(items)
 
 	// 逐筆匯入
-	for _, event := range events.Items {
+	for _, event := range items {
 		// 跳過無 summary 的事件
 		if event.Summary == "" {
 			entriesSkipped++

--- a/dev/src/service/interfaces.go
+++ b/dev/src/service/interfaces.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/google/uuid"
+	"github.com/gpwork4u/aibo/dto"
 	"github.com/gpwork4u/aibo/model"
 	"github.com/gpwork4u/aibo/repository"
 	"github.com/jackc/pgx/v5"
@@ -22,6 +23,8 @@ type EntryRepository interface {
 	GetFlags(ctx context.Context, entryID uuid.UUID) ([]model.EntryFlag, error)
 	ExistsBySourceRef(ctx context.Context, sourceType, sourceRef string) (bool, error)
 	CategoryExists(ctx context.Context, id uuid.UUID) (bool, error)
+	// ListByDateRange 依日期區間撈取 entry（F-026 行事曆彙整 API 使用）
+	ListByDateRange(ctx context.Context, sinceDate, untilDate string, tz string) ([]dto.CalendarEntrySummary, error)
 	// Lifecycle methods (defined in repository/lifecycle.go on EntryRepository)
 	SupersedeEntry(ctx context.Context, oldID, newID uuid.UUID) (*model.Entry, error)
 	ClearSupersede(ctx context.Context, id uuid.UUID) (*model.Entry, error)


### PR DESCRIPTION
Closes #80

## 摘要
新增兩個 read-through 彙整 endpoint：
- `GET /api/v1/calendar?since=&until=&view=` — 區間 entries + gcal events
- `GET /api/v1/calendar/days/:date` — 單日詳細

## 關鍵實作
- `X-Timezone` header 分桶；無則 UTC
- 回應 header `X-Degraded: gcal` 當 gcal 上游失敗
- 未連 gcal → 200 + `gcal_connected=false`（不 fail 整個頁面）
- since/until 超過 92 天 → 400 INVALID_INPUT
- 不落地 gcal events 為 entries（轉換由 F-026c 處理）

## 測試
go build / unit tests（`dev/__tests__/service/calendar_test.go`）通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)