### PR TITLE
feat(frontend): F-027a 行事曆頁面月視圖 + sidebar

### DIFF
--- a/dev/frontend/__tests__/lib/calendar/date-utils.test.ts
+++ b/dev/frontend/__tests__/lib/calendar/date-utils.test.ts
@@ -1,0 +1,183 @@
+import { describe, expect, it } from "vitest";
+import {
+  addDays,
+  addMonths,
+  addWeeks,
+  buildMonthGridDays,
+  formatDayTitle,
+  formatMonthTitle,
+  formatWeekTitle,
+  formatYmd,
+  fromYmdUtc,
+  getMonthGridRange,
+  getWeekRange,
+  getZonedComponents,
+  parseYmd,
+  todayInTz,
+} from "@/lib/calendar/date-utils";
+
+describe("date-utils.formatYmd", () => {
+  it("輸出該 tz 下的 YYYY-MM-DD（Asia/Taipei）", () => {
+    // 2026-04-24 15:30 UTC → Asia/Taipei 2026-04-24 23:30
+    const d = new Date("2026-04-24T15:30:00Z");
+    expect(formatYmd(d, "Asia/Taipei")).toBe("2026-04-24");
+  });
+
+  it("跨日處理：2026-04-24T23:30+08:00（= 15:30Z）在 Asia/Taipei 為 04-24，在 UTC 為 04-24", () => {
+    const d = new Date("2026-04-24T23:30:00+08:00");
+    expect(formatYmd(d, "Asia/Taipei")).toBe("2026-04-24");
+    expect(formatYmd(d, "UTC")).toBe("2026-04-24");
+  });
+
+  it("UTC 凌晨 01:00 在 Asia/Taipei 為當日 09:00（同日）", () => {
+    const d = new Date("2026-04-24T01:00:00Z");
+    expect(formatYmd(d, "Asia/Taipei")).toBe("2026-04-24");
+    expect(formatYmd(d, "UTC")).toBe("2026-04-24");
+  });
+
+  it("UTC 2026-04-24T23:00 在 Asia/Taipei 為隔日 07:00 → 2026-04-25", () => {
+    const d = new Date("2026-04-24T23:00:00Z");
+    expect(formatYmd(d, "Asia/Taipei")).toBe("2026-04-25");
+    expect(formatYmd(d, "UTC")).toBe("2026-04-24");
+  });
+});
+
+describe("date-utils.parseYmd / fromYmdUtc", () => {
+  it("合法 YMD 回傳 UTC 00:00", () => {
+    const d = parseYmd("2026-04-24");
+    expect(d).not.toBeNull();
+    expect(d!.getUTCFullYear()).toBe(2026);
+    expect(d!.getUTCMonth()).toBe(3);
+    expect(d!.getUTCDate()).toBe(24);
+  });
+  it("不合法 → null", () => {
+    expect(parseYmd("")).toBeNull();
+    expect(parseYmd(null)).toBeNull();
+    expect(parseYmd("2026-13-01")).toBeNull();
+    expect(parseYmd("2026-02-30")).toBeNull();
+    expect(parseYmd("2026/04/24")).toBeNull();
+  });
+  it("fromYmdUtc 一致", () => {
+    const d = fromYmdUtc("2026-04-24");
+    expect(d.toISOString()).toBe("2026-04-24T00:00:00.000Z");
+  });
+});
+
+describe("date-utils.getZonedComponents", () => {
+  it("tz=UTC", () => {
+    const c = getZonedComponents(new Date("2026-04-24T10:00:00Z"), "UTC");
+    expect(c).toEqual({ year: 2026, month: 4, day: 24 });
+  });
+  it("tz=Asia/Taipei 跨日", () => {
+    const c = getZonedComponents(
+      new Date("2026-04-24T17:00:00Z"),
+      "Asia/Taipei",
+    );
+    // 17:00Z → Taipei 01:00（隔日）
+    expect(c).toEqual({ year: 2026, month: 4, day: 25 });
+  });
+});
+
+describe("date-utils.getMonthGridRange (週一為起)", () => {
+  it("2026 年 4 月：4/1 為週三，週起回推至 2026-03-30", () => {
+    const anchor = fromYmdUtc("2026-04-15");
+    const r = getMonthGridRange(anchor, "UTC", 1);
+    expect(r.sinceYmd).toBe("2026-03-30");
+    // since + 41 天
+    expect(r.untilYmd).toBe("2026-05-10");
+  });
+
+  it("2026 年 2 月：2/1 為週日，週起回推至 2026-01-26", () => {
+    const anchor = fromYmdUtc("2026-02-10");
+    const r = getMonthGridRange(anchor, "UTC", 1);
+    expect(r.sinceYmd).toBe("2026-01-26");
+    expect(r.untilYmd).toBe("2026-03-08");
+  });
+
+  it("週日為起：2026-04 → since=2026-03-29", () => {
+    const anchor = fromYmdUtc("2026-04-15");
+    const r = getMonthGridRange(anchor, "UTC", 0);
+    expect(r.sinceYmd).toBe("2026-03-29");
+    expect(r.untilYmd).toBe("2026-05-09");
+  });
+});
+
+describe("date-utils.buildMonthGridDays", () => {
+  it("產出 42 格，且本月日標示正確", () => {
+    const anchor = fromYmdUtc("2026-04-15");
+    const cells = buildMonthGridDays(anchor, "UTC", 1);
+    expect(cells).toHaveLength(42);
+    expect(cells[0].ymd).toBe("2026-03-30");
+    expect(cells[41].ymd).toBe("2026-05-10");
+    // 本月日（4 月）應該不是 outside
+    const apr24 = cells.find((c) => c.ymd === "2026-04-24")!;
+    expect(apr24.isOutsideMonth).toBe(false);
+    // 3 月 30 日應該是 outside
+    const mar30 = cells.find((c) => c.ymd === "2026-03-30")!;
+    expect(mar30.isOutsideMonth).toBe(true);
+  });
+});
+
+describe("date-utils.getWeekRange", () => {
+  it("2026-04-24（週五）→ since=2026-04-20（週一）、until=2026-04-26（週日）", () => {
+    const anchor = fromYmdUtc("2026-04-24");
+    const r = getWeekRange(anchor, "UTC", 1);
+    expect(r.sinceYmd).toBe("2026-04-20");
+    expect(r.untilYmd).toBe("2026-04-26");
+  });
+
+  it("週日為起：2026-04-24 → since=2026-04-19", () => {
+    const anchor = fromYmdUtc("2026-04-24");
+    const r = getWeekRange(anchor, "UTC", 0);
+    expect(r.sinceYmd).toBe("2026-04-19");
+    expect(r.untilYmd).toBe("2026-04-25");
+  });
+});
+
+describe("date-utils.addMonths / addWeeks / addDays", () => {
+  it("addMonths 跨月日", () => {
+    const d = fromYmdUtc("2026-01-31");
+    // +1 個月在 2 月沒有 31 日 → 取 2 月最後一天 2026-02-28
+    const r = addMonths(d, 1, "UTC");
+    expect(formatYmd(r, "UTC")).toBe("2026-02-28");
+  });
+  it("addMonths 正常", () => {
+    const d = fromYmdUtc("2026-04-24");
+    expect(formatYmd(addMonths(d, 1, "UTC"), "UTC")).toBe("2026-05-24");
+    expect(formatYmd(addMonths(d, -1, "UTC"), "UTC")).toBe("2026-03-24");
+  });
+  it("addWeeks / addDays", () => {
+    const d = fromYmdUtc("2026-04-24");
+    expect(formatYmd(addWeeks(d, 1, "UTC"), "UTC")).toBe("2026-05-01");
+    expect(formatYmd(addDays(d, -3, "UTC"), "UTC")).toBe("2026-04-21");
+  });
+});
+
+describe("date-utils.todayInTz", () => {
+  it("以指定 now 計算今日", () => {
+    const now = new Date("2026-04-24T17:00:00Z");
+    expect(formatYmd(todayInTz("UTC", now), "UTC")).toBe("2026-04-24");
+    expect(formatYmd(todayInTz("Asia/Taipei", now), "Asia/Taipei")).toBe(
+      "2026-04-25",
+    );
+  });
+});
+
+describe("date-utils.formatters", () => {
+  it("formatMonthTitle 輸出「YYYY 年 M 月」", () => {
+    const d = fromYmdUtc("2026-04-15");
+    expect(formatMonthTitle(d, "UTC")).toBe("2026 年 4 月");
+  });
+  it("formatDayTitle 含星期", () => {
+    const d = fromYmdUtc("2026-04-24");
+    const s = formatDayTitle(d, "UTC");
+    expect(s).toMatch(/2026/);
+    expect(s).toMatch(/4/);
+    expect(s).toMatch(/24/);
+  });
+  it("formatWeekTitle 含起訖", () => {
+    const d = fromYmdUtc("2026-04-24");
+    const s = formatWeekTitle(d, "UTC");
+    expect(s).toMatch(/–/);
+  });
+});

--- a/dev/frontend/app/(dashboard)/calendar/page.tsx
+++ b/dev/frontend/app/(dashboard)/calendar/page.tsx
@@ -1,0 +1,211 @@
+"use client";
+
+import * as React from "react";
+import { useRouter, useSearchParams } from "next/navigation";
+import { toast } from "sonner";
+import { CalendarToolbar } from "@/components/calendar/calendar-toolbar";
+import { MonthView } from "@/components/calendar/month-view";
+import { GcalBanner } from "@/components/calendar/gcal-banner";
+import { ErrorState } from "@/components/error-state";
+import {
+  addDays,
+  addMonths,
+  addWeeks,
+  formatDayTitle,
+  formatMonthTitle,
+  formatWeekTitle,
+  formatYmd,
+  getMonthGridRange,
+  getWeekRange,
+  parseYmd,
+  todayInTz,
+} from "@/lib/calendar/date-utils";
+import { useCalendar } from "@/lib/hooks/use-calendar";
+import type { CalendarDay } from "@/lib/api/calendar";
+import type { CalendarView } from "@/components/calendar/calendar-toolbar";
+import { CALENDAR_TESTIDS } from "@/lib/calendar/testids";
+
+function resolveTimezone(): string {
+  try {
+    return Intl.DateTimeFormat().resolvedOptions().timeZone ?? "UTC";
+  } catch {
+    return "UTC";
+  }
+}
+
+function parseView(v: string | null): CalendarView {
+  return v === "week" || v === "day" ? v : "month";
+}
+
+export default function CalendarPage() {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const tz = React.useMemo(resolveTimezone, []);
+
+  const viewParam = searchParams.get("view");
+  const dateParam = searchParams.get("date");
+  const view: CalendarView = parseView(viewParam);
+  const parsedDate = parseYmd(dateParam);
+  const anchorDate = parsedDate ?? todayInTz(tz);
+  const selectedYmd = parsedDate ? formatYmd(parsedDate, tz) : undefined;
+  const todayYmd = formatYmd(todayInTz(tz), tz);
+
+  // 計算本次要 fetch 的區間（本 PR 只實作 month；week/day 為 placeholder）
+  const range = React.useMemo(() => {
+    if (view === "month") return getMonthGridRange(anchorDate, tz);
+    if (view === "week") return getWeekRange(anchorDate, tz);
+    const ymd = formatYmd(anchorDate, tz);
+    return { sinceYmd: ymd, untilYmd: ymd };
+  }, [view, anchorDate, tz]);
+
+  const { data, isLoading, isError, error, gcalConnected, degraded } = useCalendar({
+    since: range.sinceYmd,
+    until: range.untilYmd,
+    view,
+    tz,
+  });
+
+  // X-Degraded: gcal → 顯示 sonner toast（每次 key 變化只提示一次）
+  const lastDegradedKeyRef = React.useRef<string | null>(null);
+  React.useEffect(() => {
+    if (!degraded) return;
+    const key = `${range.sinceYmd}-${range.untilYmd}-${view}`;
+    if (lastDegradedKeyRef.current === key) return;
+    lastDegradedKeyRef.current = key;
+    toast.warning("Google Calendar 暫時無法載入，僅顯示知識條目", {
+      id: CALENDAR_TESTIDS.gcalDegradedToast,
+    });
+  }, [degraded, range.sinceYmd, range.untilYmd, view]);
+
+  // 資料 → map
+  const daysMap = React.useMemo(() => {
+    const m = new Map<string, CalendarDay>();
+    data?.data.days.forEach((d) => m.set(d.date, d));
+    return m;
+  }, [data]);
+
+  // 標題
+  const title = React.useMemo(() => {
+    if (view === "month") return formatMonthTitle(anchorDate, tz);
+    if (view === "week") return formatWeekTitle(anchorDate, tz);
+    return formatDayTitle(anchorDate, tz);
+  }, [view, anchorDate, tz]);
+
+  // URL 同步工具
+  const updateUrl = React.useCallback(
+    (next: { view?: CalendarView; date?: string | null }) => {
+      const sp = new URLSearchParams(searchParams.toString());
+      if (next.view) sp.set("view", next.view);
+      if (next.date === null) sp.delete("date");
+      else if (next.date) sp.set("date", next.date);
+      router.replace(`/calendar?${sp.toString()}`);
+    },
+    [router, searchParams],
+  );
+
+  const handlePrev = () => {
+    let nextDate: Date;
+    if (view === "month") nextDate = addMonths(anchorDate, -1, tz);
+    else if (view === "week") nextDate = addWeeks(anchorDate, -1, tz);
+    else nextDate = addDays(anchorDate, -1, tz);
+    updateUrl({ date: formatYmd(nextDate, tz) });
+  };
+
+  const handleNext = () => {
+    let nextDate: Date;
+    if (view === "month") nextDate = addMonths(anchorDate, 1, tz);
+    else if (view === "week") nextDate = addWeeks(anchorDate, 1, tz);
+    else nextDate = addDays(anchorDate, 1, tz);
+    updateUrl({ date: formatYmd(nextDate, tz) });
+  };
+
+  const handleToday = () => {
+    updateUrl({ date: todayYmd });
+  };
+
+  const handleViewChange = (v: CalendarView) => {
+    updateUrl({ view: v });
+  };
+
+  const handleSelectDate = (ymd: string) => {
+    // 本 PR 只同步 URL date（Sheet 由 F-027c 實作）
+    updateUrl({ date: ymd });
+  };
+
+  // 手機版強制 day view
+  React.useEffect(() => {
+    if (typeof window === "undefined") return;
+    if (window.matchMedia && window.matchMedia("(max-width: 767px)").matches) {
+      if (view !== "day") {
+        updateUrl({ view: "day" });
+      }
+    }
+    // 僅在 mount 時檢查一次
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  const hideViewTabs =
+    typeof window !== "undefined" &&
+    window.matchMedia &&
+    window.matchMedia("(max-width: 767px)").matches;
+
+  return (
+    <div data-testid={CALENDAR_TESTIDS.page} className="flex flex-col gap-4">
+      <CalendarToolbar
+        view={view}
+        onViewChange={handleViewChange}
+        title={title}
+        onPrev={handlePrev}
+        onNext={handleNext}
+        onToday={handleToday}
+        timezone={tz}
+        hideViewTabs={hideViewTabs}
+        isLoading={isLoading}
+      />
+
+      {gcalConnected === false && <GcalBanner mode="not-connected" />}
+      {degraded === "gcal" && <GcalBanner mode="degraded" />}
+
+      {isError ? (
+        <ErrorState
+          message={error instanceof Error ? error.message : "無法載入行事曆資料"}
+        />
+      ) : view === "month" ? (
+        <MonthView
+          anchorDate={anchorDate}
+          timezone={tz}
+          todayYmd={todayYmd}
+          daysMap={daysMap}
+          selectedDate={selectedYmd}
+          onSelectDate={handleSelectDate}
+        />
+      ) : view === "week" ? (
+        <WeekViewPlaceholder />
+      ) : (
+        <DayViewPlaceholder />
+      )}
+    </div>
+  );
+}
+
+function WeekViewPlaceholder() {
+  return (
+    <div
+      data-testid={CALENDAR_TESTIDS.weekView}
+      className="rounded-md border bg-muted/20 p-8 text-center text-sm text-muted-foreground"
+    >
+      週視圖即將推出（F-027b）
+    </div>
+  );
+}
+
+function DayViewPlaceholder() {
+  return (
+    <div
+      data-testid={CALENDAR_TESTIDS.dayView}
+      className="rounded-md border bg-muted/20 p-8 text-center text-sm text-muted-foreground"
+    >
+      日視圖即將推出（F-027b）
+    </div>
+  );
+}

--- a/dev/frontend/components/app-sidebar.tsx
+++ b/dev/frontend/components/app-sidebar.tsx
@@ -4,6 +4,7 @@ import Link from "next/link";
 import { usePathname } from "next/navigation";
 import {
   Bot,
+  Calendar,
   FileText,
   FolderTree,
   Inbox,
@@ -33,6 +34,7 @@ export function AppSidebar({ inboxCount = 0, open, onClose }: AppSidebarProps) {
 
   const main: NavItem[] = [
     { label: "Inbox", href: "/inbox", icon: Inbox, badge: inboxCount || undefined },
+    { label: "行事曆", href: "/calendar", icon: Calendar },
     { label: "知識條目", href: "/entries", icon: FileText },
     { label: "分類管理", href: "/categories", icon: FolderTree },
     { label: "搜尋", href: "/search", icon: Search },

--- a/dev/frontend/components/calendar/calendar-toolbar.tsx
+++ b/dev/frontend/components/calendar/calendar-toolbar.tsx
@@ -1,0 +1,133 @@
+"use client";
+
+import * as React from "react";
+import { ChevronLeft, ChevronRight } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { CALENDAR_TESTIDS } from "@/lib/calendar/testids";
+import { cn } from "@/lib/utils";
+
+export type CalendarView = "month" | "week" | "day";
+
+export interface CalendarToolbarProps {
+  view: CalendarView;
+  onViewChange: (v: CalendarView) => void;
+  title: string;
+  onPrev: () => void;
+  onNext: () => void;
+  onToday: () => void;
+  /** 例：Asia/Taipei */
+  timezone: string;
+  /** 是否隱藏 view Tabs（mobile < 768px 強制 day view）。 */
+  hideViewTabs?: boolean;
+  isLoading?: boolean;
+}
+
+export function CalendarToolbar({
+  view,
+  onViewChange,
+  title,
+  onPrev,
+  onNext,
+  onToday,
+  timezone,
+  hideViewTabs = false,
+  isLoading = false,
+}: CalendarToolbarProps) {
+  const prevLabel =
+    view === "month" ? "前一個月" : view === "week" ? "前一週" : "前一天";
+  const nextLabel =
+    view === "month" ? "後一個月" : view === "week" ? "後一週" : "後一天";
+
+  return (
+    <div
+      data-testid={CALENDAR_TESTIDS.toolbar}
+      className={cn(
+        "sticky top-0 z-10 flex items-center justify-between gap-2 border-b bg-background px-4 py-2",
+        isLoading && "opacity-60",
+      )}
+    >
+      <div className="flex items-center gap-2">
+        <Button
+          variant="outline"
+          size="icon"
+          onClick={onPrev}
+          disabled={isLoading}
+          aria-label={prevLabel}
+          data-testid={CALENDAR_TESTIDS.prevButton}
+        >
+          <ChevronLeft className="h-4 w-4" />
+        </Button>
+        <Button
+          variant="outline"
+          size="icon"
+          onClick={onNext}
+          disabled={isLoading}
+          aria-label={nextLabel}
+          data-testid={CALENDAR_TESTIDS.nextButton}
+        >
+          <ChevronRight className="h-4 w-4" />
+        </Button>
+        <Button
+          variant="ghost"
+          size="sm"
+          onClick={onToday}
+          disabled={isLoading}
+          title="T"
+          aria-label="回到今天"
+          data-testid={CALENDAR_TESTIDS.todayButton}
+        >
+          今天
+        </Button>
+      </div>
+
+      <h2
+        aria-live="polite"
+        className="text-base font-semibold tabular-nums"
+        data-testid={CALENDAR_TESTIDS.toolbarTitle}
+      >
+        {title}
+      </h2>
+
+      <div className="flex items-center gap-3">
+        {!hideViewTabs && (
+          <Tabs
+            value={view}
+            onValueChange={(v) => onViewChange(v as CalendarView)}
+            data-testid={CALENDAR_TESTIDS.viewTabs}
+          >
+            <TabsList>
+              <TabsTrigger
+                value="month"
+                data-testid={CALENDAR_TESTIDS.viewTabMonth}
+                title="M"
+              >
+                月
+              </TabsTrigger>
+              <TabsTrigger
+                value="week"
+                data-testid={CALENDAR_TESTIDS.viewTabWeek}
+                title="W"
+              >
+                週
+              </TabsTrigger>
+              <TabsTrigger
+                value="day"
+                data-testid={CALENDAR_TESTIDS.viewTabDay}
+                title="D"
+              >
+                日
+              </TabsTrigger>
+            </TabsList>
+          </Tabs>
+        )}
+        <span
+          className="hidden text-xs text-muted-foreground sm:inline"
+          title={timezone}
+        >
+          {timezone}
+        </span>
+      </div>
+    </div>
+  );
+}

--- a/dev/frontend/components/calendar/day-cell.tsx
+++ b/dev/frontend/components/calendar/day-cell.tsx
@@ -1,0 +1,160 @@
+"use client";
+
+import * as React from "react";
+import { BookOpen, Link as LinkIcon } from "lucide-react";
+import { Badge } from "@/components/ui/badge";
+import { CALENDAR_TESTIDS } from "@/lib/calendar/testids";
+import { cn } from "@/lib/utils";
+import type { CalendarDay, CalendarEventSummary } from "@/lib/api/calendar";
+
+export interface DayCellProps {
+  ymd: string;
+  /** 顯示的日數（1-31）。 */
+  dayNumber: number;
+  isOutsideMonth: boolean;
+  isToday: boolean;
+  isSelected: boolean;
+  /** 該日的聚合資料（若 undefined 則 entry_count=0, events=[]）。 */
+  day?: CalendarDay;
+  /** 提供給 aria-label 的完整日期字串，例如「2026 年 4 月 24 日」。 */
+  fullDateLabel: string;
+  /** tz 用來格式化 event 時間。 */
+  timezone: string;
+  onSelect: (ymd: string) => void;
+}
+
+export function DayCell({
+  ymd,
+  dayNumber,
+  isOutsideMonth,
+  isToday,
+  isSelected,
+  day,
+  fullDateLabel,
+  timezone,
+  onSelect,
+}: DayCellProps) {
+  const entryCount = day?.entry_count ?? 0;
+  const eventCount = day?.event_count ?? 0;
+  const events = day?.events ?? [];
+  const hasJournal = day?.has_journal ?? false;
+  const visibleEvents = events.slice(0, 2);
+  const overflow = Math.max(0, eventCount - visibleEvents.length);
+
+  const ariaLabel = `${fullDateLabel}，${entryCount} 筆條目，${eventCount} 筆事件${hasJournal ? "，有日記" : ""}`;
+
+  return (
+    <button
+      type="button"
+      role="gridcell"
+      aria-label={ariaLabel}
+      aria-selected={isSelected}
+      tabIndex={isSelected || isToday ? 0 : -1}
+      data-testid={CALENDAR_TESTIDS.dayCell(ymd)}
+      data-today={isToday || undefined}
+      onClick={() => onSelect(ymd)}
+      className={cn(
+        "relative flex min-h-[96px] flex-col gap-1 p-1.5 text-left bg-card transition-colors",
+        "hover:bg-muted/60",
+        "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-inset",
+        "md:min-h-[112px]",
+        isOutsideMonth && "bg-muted/30 text-muted-foreground/60",
+        isToday && "ring-1 ring-inset ring-primary/50",
+        isSelected && "bg-primary/10 ring-2 ring-inset ring-primary",
+      )}
+    >
+      {/* Header：日期數字 | entry count badge | journal icon */}
+      <div className="flex items-center gap-1">
+        {isToday ? (
+          <span
+            className="inline-flex h-5 w-5 items-center justify-center rounded-full bg-primary text-[11px] font-semibold text-primary-foreground"
+            data-testid={CALENDAR_TESTIDS.dayCellToday}
+          >
+            {dayNumber}
+          </span>
+        ) : (
+          <span className="text-xs font-medium tabular-nums">{dayNumber}</span>
+        )}
+        {entryCount > 0 && (
+          <Badge
+            variant="secondary"
+            className="h-4 rounded-full px-1 text-[10px]"
+            data-testid={CALENDAR_TESTIDS.entryBadge}
+            aria-label={`${entryCount} 筆條目`}
+          >
+            {entryCount}
+          </Badge>
+        )}
+        {hasJournal && (
+          <BookOpen
+            className="h-3 w-3 text-primary"
+            aria-hidden="true"
+            data-testid={CALENDAR_TESTIDS.journalIcon}
+          />
+        )}
+      </div>
+
+      {/* Event rows（最多 2 列） */}
+      <div className="flex flex-col gap-0.5">
+        {visibleEvents.map((ev) => (
+          <EventChip key={ev.gcal_id} event={ev} timezone={timezone} />
+        ))}
+        {overflow > 0 && (
+          <span
+            className="text-[10px] text-muted-foreground"
+            data-testid={CALENDAR_TESTIDS.eventOverflowBadge}
+          >
+            +{overflow} 更多
+          </span>
+        )}
+      </div>
+    </button>
+  );
+}
+
+function EventChip({
+  event,
+  timezone,
+}: {
+  event: CalendarEventSummary;
+  timezone: string;
+}) {
+  const startStr = event.all_day ? null : formatTimeShort(event.start, timezone);
+  const isLinked = !!event.linked_entry_id;
+  return (
+    <div
+      data-testid={CALENDAR_TESTIDS.eventBadge}
+      className={cn(
+        "flex items-center gap-1 truncate rounded-sm px-1 py-0.5 text-[11px]",
+        isLinked
+          ? "border border-success/30 bg-success/10"
+          : "border border-dashed border-border bg-muted/60",
+      )}
+      title={`${startStr ?? "全天"} ${event.summary}`}
+    >
+      {event.all_day ? (
+        <span className="shrink-0 rounded bg-primary/10 px-1 text-[10px] text-primary">
+          全天
+        </span>
+      ) : (
+        <span className="shrink-0 tabular-nums text-muted-foreground">{startStr}</span>
+      )}
+      <span className="truncate">{event.summary}</span>
+      {isLinked && <LinkIcon className="h-3 w-3 shrink-0 text-success" />}
+    </div>
+  );
+}
+
+function formatTimeShort(iso: string, tz: string): string {
+  try {
+    const fmt = new Intl.DateTimeFormat("en-GB", {
+      timeZone: tz,
+      hour: "2-digit",
+      minute: "2-digit",
+      hour12: false,
+    });
+    return fmt.format(new Date(iso));
+  } catch {
+    return "";
+  }
+}

--- a/dev/frontend/components/calendar/gcal-banner.tsx
+++ b/dev/frontend/components/calendar/gcal-banner.tsx
@@ -1,0 +1,56 @@
+"use client";
+
+import * as React from "react";
+import Link from "next/link";
+import { AlertTriangle, Calendar as CalendarIcon } from "lucide-react";
+import { CALENDAR_TESTIDS } from "@/lib/calendar/testids";
+import { cn } from "@/lib/utils";
+
+export type GcalBannerMode = "not-connected" | "degraded";
+
+export interface GcalBannerProps {
+  mode: GcalBannerMode;
+  className?: string;
+}
+
+export function GcalBanner({ mode, className }: GcalBannerProps) {
+  if (mode === "not-connected") {
+    return (
+      <div
+        data-testid={CALENDAR_TESTIDS.gcalNotConnectedBanner}
+        role="status"
+        className={cn(
+          "flex items-center gap-2 rounded-md border border-dashed border-warning/50 bg-warning/10 px-3 py-2 text-sm text-foreground",
+          className,
+        )}
+      >
+        <CalendarIcon className="h-4 w-4 shrink-0 text-warning" />
+        <span className="flex-1">
+          尚未連接 Google Calendar，行事曆僅顯示知識條目。
+        </span>
+        <Link
+          href="/settings"
+          className="text-sm font-medium text-primary underline-offset-4 hover:underline"
+        >
+          前往設定
+        </Link>
+      </div>
+    );
+  }
+  // degraded
+  return (
+    <div
+      data-testid={CALENDAR_TESTIDS.gcalDegradedInlineWarning}
+      role="status"
+      className={cn(
+        "flex items-center gap-2 rounded-md border border-warning/40 bg-warning/5 px-3 py-2 text-sm text-foreground",
+        className,
+      )}
+    >
+      <AlertTriangle className="h-4 w-4 shrink-0 text-warning" />
+      <span className="flex-1">
+        Google Calendar 暫時無法載入，僅顯示知識條目。
+      </span>
+    </div>
+  );
+}

--- a/dev/frontend/components/calendar/month-view.tsx
+++ b/dev/frontend/components/calendar/month-view.tsx
@@ -1,0 +1,98 @@
+"use client";
+
+import * as React from "react";
+import { DayCell } from "./day-cell";
+import { CALENDAR_TESTIDS } from "@/lib/calendar/testids";
+import { buildMonthGridDays, formatYmd, todayInTz } from "@/lib/calendar/date-utils";
+import type { CalendarDay } from "@/lib/api/calendar";
+
+export interface MonthViewProps {
+  /** 錨點日期（決定顯示哪一個月） */
+  anchorDate: Date;
+  /** 使用者時區 */
+  timezone: string;
+  /** 該 tz 下當前「今天」 ymd（例 `2026-04-24`）；省略則以 todayInTz 計算 */
+  todayYmd?: string;
+  /** API 回傳的 days 資料（依 ymd 對應） */
+  daysMap: Map<string, CalendarDay>;
+  /** 使用者選中的日期（YYYY-MM-DD），為 undefined 則不高亮 */
+  selectedDate?: string;
+  onSelectDate: (ymd: string) => void;
+  /** 週起日：1=週一（預設）、0=週日 */
+  weekStartsOn?: 0 | 1;
+}
+
+const WEEKDAY_LABELS_MON_START = ["一", "二", "三", "四", "五", "六", "日"];
+const WEEKDAY_LABELS_SUN_START = ["日", "一", "二", "三", "四", "五", "六"];
+
+export function MonthView({
+  anchorDate,
+  timezone,
+  todayYmd,
+  daysMap,
+  selectedDate,
+  onSelectDate,
+  weekStartsOn = 1,
+}: MonthViewProps) {
+  const today =
+    todayYmd ?? formatYmd(todayInTz(timezone), timezone);
+  const weekLabels =
+    weekStartsOn === 1 ? WEEKDAY_LABELS_MON_START : WEEKDAY_LABELS_SUN_START;
+  const cells = React.useMemo(
+    () => buildMonthGridDays(anchorDate, timezone, weekStartsOn),
+    [anchorDate, timezone, weekStartsOn],
+  );
+
+  return (
+    <div
+      role="grid"
+      aria-label="月視圖"
+      data-testid={CALENDAR_TESTIDS.monthView}
+      className="overflow-hidden rounded-md border"
+    >
+      {/* WeekdayHeader */}
+      <div
+        className="grid grid-cols-7 bg-muted/30 text-xs font-medium text-muted-foreground"
+        role="row"
+      >
+        {weekLabels.map((label, idx) => {
+          // 對應的實際星期位置：若 weekStartsOn=1 則 idx=5/6 為六/日（0-indexed: 週六 dayIdx=5, 週日 dayIdx=6）
+          const isWeekend =
+            weekStartsOn === 1 ? idx >= 5 : idx === 0 || idx === 6;
+          return (
+            <div
+              key={label}
+              role="columnheader"
+              className={`py-2 text-center ${isWeekend ? "text-muted-foreground/80" : ""}`}
+            >
+              {label}
+            </div>
+          );
+        })}
+      </div>
+
+      {/* 6 週 × 7 天 = 42 格 */}
+      <div className="grid grid-cols-7 gap-px bg-border">
+        {cells.map((cell) => {
+          const day = daysMap.get(cell.ymd);
+          const dayNumber = cell.date.getUTCDate();
+          const fullDateLabel = `${cell.date.getUTCFullYear()} 年 ${cell.date.getUTCMonth() + 1} 月 ${dayNumber} 日`;
+          return (
+            <DayCell
+              key={cell.ymd}
+              ymd={cell.ymd}
+              dayNumber={dayNumber}
+              isOutsideMonth={cell.isOutsideMonth}
+              isToday={cell.ymd === today}
+              isSelected={selectedDate === cell.ymd}
+              day={day}
+              fullDateLabel={fullDateLabel}
+              timezone={timezone}
+              onSelect={onSelectDate}
+            />
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/dev/frontend/components/ui/tabs.tsx
+++ b/dev/frontend/components/ui/tabs.tsx
@@ -1,0 +1,54 @@
+"use client";
+
+import * as React from "react";
+import * as TabsPrimitive from "@radix-ui/react-tabs";
+import { cn } from "@/lib/utils";
+
+const Tabs = TabsPrimitive.Root;
+
+const TabsList = React.forwardRef<
+  React.ElementRef<typeof TabsPrimitive.List>,
+  React.ComponentPropsWithoutRef<typeof TabsPrimitive.List>
+>(({ className, ...props }, ref) => (
+  <TabsPrimitive.List
+    ref={ref}
+    className={cn(
+      "inline-flex h-9 items-center justify-center rounded-md bg-muted p-1 text-muted-foreground",
+      className,
+    )}
+    {...props}
+  />
+));
+TabsList.displayName = TabsPrimitive.List.displayName;
+
+const TabsTrigger = React.forwardRef<
+  React.ElementRef<typeof TabsPrimitive.Trigger>,
+  React.ComponentPropsWithoutRef<typeof TabsPrimitive.Trigger>
+>(({ className, ...props }, ref) => (
+  <TabsPrimitive.Trigger
+    ref={ref}
+    className={cn(
+      "inline-flex items-center justify-center whitespace-nowrap rounded-sm px-3 py-1 text-sm font-medium ring-offset-background transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 data-[state=active]:bg-background data-[state=active]:text-foreground data-[state=active]:shadow",
+      className,
+    )}
+    {...props}
+  />
+));
+TabsTrigger.displayName = TabsPrimitive.Trigger.displayName;
+
+const TabsContent = React.forwardRef<
+  React.ElementRef<typeof TabsPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof TabsPrimitive.Content>
+>(({ className, ...props }, ref) => (
+  <TabsPrimitive.Content
+    ref={ref}
+    className={cn(
+      "mt-2 ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
+      className,
+    )}
+    {...props}
+  />
+));
+TabsContent.displayName = TabsPrimitive.Content.displayName;
+
+export { Tabs, TabsList, TabsTrigger, TabsContent };

--- a/dev/frontend/lib/api/calendar.ts
+++ b/dev/frontend/lib/api/calendar.ts
@@ -1,0 +1,174 @@
+/**
+ * Calendar API client。
+ *
+ * 為了能讀取 response header（X-Degraded），這裡直接使用 fetch 而非 apiClient.get（apiClient.get
+ * 僅回傳 body）。仍共用 apiClient 的 baseURL 與 X-API-Key 取得策略。
+ */
+
+import { ApiError, API_KEY_STORAGE, UNAUTHORIZED_EVENT } from "./client";
+
+export type CalendarView = "month" | "week" | "day";
+
+export interface CalendarEntrySummary {
+  id: string;
+  title: string | null;
+  summary: string | null;
+  source_type: string | null;
+  tags: string[];
+  created_at: string;
+}
+
+export interface CalendarEventSummary {
+  gcal_id: string;
+  summary: string;
+  start: string;
+  end: string;
+  all_day: boolean;
+  linked_entry_id: string | null;
+}
+
+export interface CalendarJournal {
+  id: string;
+  mood?: string | null;
+}
+
+export interface CalendarDay {
+  date: string;
+  entry_count: number;
+  event_count: number;
+  has_journal: boolean;
+  entries: CalendarEntrySummary[];
+  events: CalendarEventSummary[];
+  journal?: CalendarJournal | null;
+}
+
+export interface CalendarResponse {
+  since: string;
+  until: string;
+  days: CalendarDay[];
+}
+
+export interface FetchCalendarParams {
+  since: string;
+  until: string;
+  view: CalendarView;
+  include_gcal?: boolean;
+  calendar_id?: string;
+  tz: string;
+}
+
+export interface FetchCalendarResult {
+  data: CalendarResponse;
+  /** response header `X-Degraded` 的值（若有，例如 "gcal"）。 */
+  degraded: string | null;
+  /** 若 API 回 424 GCAL_NOT_CONNECTED，則 gcalConnected=false 且 data 為 empty（上層需以 include_gcal=false 重打）。 */
+  gcalConnected: boolean;
+}
+
+export interface CalendarApiErrorBody {
+  code?: string;
+  message?: string;
+}
+
+function getApiKey(): string | null {
+  if (typeof window === "undefined") return null;
+  try {
+    return window.localStorage.getItem(API_KEY_STORAGE);
+  } catch {
+    return null;
+  }
+}
+
+function handleUnauthorized() {
+  if (typeof window === "undefined") return;
+  try {
+    window.localStorage.removeItem(API_KEY_STORAGE);
+  } catch {
+    /* ignore */
+  }
+  window.dispatchEvent(new CustomEvent(UNAUTHORIZED_EVENT));
+}
+
+function getBaseUrl(): string {
+  return (
+    (typeof process !== "undefined"
+      ? process.env.NEXT_PUBLIC_API_URL
+      : undefined) ?? "http://localhost:8080"
+  );
+}
+
+/**
+ * 取得行事曆彙整資料。
+ *
+ * 行為：
+ *   - 正常：回傳 `{ data, degraded, gcalConnected: true }`（degraded 可能為 "gcal"）
+ *   - 424 GCAL_NOT_CONNECTED：不拋錯，回傳 `{ data: emptyEnvelope, gcalConnected: false }`
+ *     由上層決定是否再以 include_gcal=false 重打
+ *   - 其他非 2xx：拋 ApiError
+ */
+export async function fetchCalendar(
+  params: FetchCalendarParams,
+): Promise<FetchCalendarResult> {
+  const sp = new URLSearchParams();
+  sp.set("since", params.since);
+  sp.set("until", params.until);
+  sp.set("view", params.view);
+  if (params.include_gcal !== undefined) {
+    sp.set("include_gcal", String(params.include_gcal));
+  }
+  if (params.calendar_id) sp.set("calendar_id", params.calendar_id);
+
+  const url = `${getBaseUrl()}/api/v1/calendar?${sp.toString()}`;
+  const headers = new Headers({
+    "X-Timezone": params.tz,
+  });
+  const key = getApiKey();
+  if (key) headers.set("X-API-Key", key);
+
+  const res = await fetch(url, { method: "GET", headers });
+
+  if (res.status === 401) {
+    handleUnauthorized();
+    const body = await safeJson(res);
+    throw new ApiError("Unauthorized", 401, body);
+  }
+
+  if (res.status === 424) {
+    const body = (await safeJson(res)) as CalendarApiErrorBody | null;
+    if (body?.code === "GCAL_NOT_CONNECTED") {
+      return {
+        data: {
+          since: params.since,
+          until: params.until,
+          days: [],
+        },
+        degraded: null,
+        gcalConnected: false,
+      };
+    }
+    throw new ApiError(body?.message ?? "Failed dependency", 424, body);
+  }
+
+  if (!res.ok) {
+    const body = await safeJson(res);
+    const message =
+      body && typeof body === "object" && "message" in body
+        ? String((body as { message: unknown }).message)
+        : res.statusText || `HTTP ${res.status}`;
+    throw new ApiError(message, res.status, body);
+  }
+
+  const degraded = res.headers.get("X-Degraded");
+  const data = (await safeJson(res)) as CalendarResponse;
+  return { data, degraded, gcalConnected: true };
+}
+
+async function safeJson(res: Response): Promise<unknown> {
+  const text = await res.text();
+  if (!text) return null;
+  try {
+    return JSON.parse(text);
+  } catch {
+    return text;
+  }
+}

--- a/dev/frontend/lib/calendar/date-utils.ts
+++ b/dev/frontend/lib/calendar/date-utils.ts
@@ -1,0 +1,212 @@
+/**
+ * Calendar 日期工具（純函式、無 React 相依）
+ *
+ * 時區策略：所有 date 以「該時區下的該日」為準
+ *   - `formatYmd(date, tz)`：輸出該 tz 下的 YYYY-MM-DD
+ *   - `getMonthGridRange(date, tz)`：以該 tz 下的 date 為錨點，計算月視圖 6×7 覆蓋區間
+ *   - `getWeekRange(date, tz, weekStartsOn=1)`：計算該 tz 下的那一週範圍
+ *
+ * 注意：這裡的 `Date` 物件代表「時間瞬間」。真正的「該時區下的日曆日」
+ * 經由 Intl.DateTimeFormat 提取年月日，再以 UTC 建構新 Date 進行運算，
+ * 避免 host 時區偏移帶來的錯誤。
+ */
+
+export type DateComponents = { year: number; month: number; day: number };
+
+/** 以 tz 解釋 date，回傳該 tz 下的年月日（month 為 1-12）。 */
+export function getZonedComponents(date: Date, tz: string): DateComponents {
+  const fmt = new Intl.DateTimeFormat("en-CA", {
+    timeZone: tz,
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+  });
+  // en-CA 格式：YYYY-MM-DD
+  const [y, m, d] = fmt.format(date).split("-").map(Number);
+  return { year: y, month: m, day: d };
+}
+
+/** 以 tz 輸出 YYYY-MM-DD（避免 host 時區漂移）。 */
+export function formatYmd(date: Date, tz: string): string {
+  const { year, month, day } = getZonedComponents(date, tz);
+  return `${year}-${pad2(month)}-${pad2(day)}`;
+}
+
+/** 以 YYYY-MM-DD 建立「該日 UTC 00:00」的 Date。 */
+export function fromYmdUtc(ymd: string): Date {
+  const [y, m, d] = ymd.split("-").map(Number);
+  return new Date(Date.UTC(y, m - 1, d));
+}
+
+/**
+ * 回傳該錨點日期所屬月份的月視圖覆蓋區間（以 week start 為起、完整 6 週）。
+ *
+ * - `since`: 覆蓋當月第一天所在那週的週起日（以 `weekStartsOn` 為準）
+ * - `until`: 自 since 起往後 41 天（共 42 日 = 6 週 × 7 天）
+ * - 回傳的 Date 以 UTC 00:00 為時刻，其 YMD 值即代表該日（不隨 host tz 漂移）。
+ */
+export function getMonthGridRange(
+  date: Date,
+  tz: string,
+  weekStartsOn: 0 | 1 = 1,
+): { since: Date; until: Date; sinceYmd: string; untilYmd: string } {
+  const { year, month } = getZonedComponents(date, tz);
+  // 當月第一天（UTC 00:00 代表該日）
+  const firstOfMonth = new Date(Date.UTC(year, month - 1, 1));
+  // firstOfMonth 對應的星期（0=週日、1=週一、...、6=週六），用 UTC 取得以避免 host tz 漂移
+  const firstDow = firstOfMonth.getUTCDay();
+  // 距離 week start 的天數
+  const offset = (firstDow - weekStartsOn + 7) % 7;
+  const since = new Date(firstOfMonth);
+  since.setUTCDate(since.getUTCDate() - offset);
+  const until = new Date(since);
+  until.setUTCDate(until.getUTCDate() + 41);
+  return {
+    since,
+    until,
+    sinceYmd: ymdFromUtc(since),
+    untilYmd: ymdFromUtc(until),
+  };
+}
+
+/** 回傳該日期所屬那週的範圍（7 天）。 */
+export function getWeekRange(
+  date: Date,
+  tz: string,
+  weekStartsOn: 0 | 1 = 1,
+): { since: Date; until: Date; sinceYmd: string; untilYmd: string } {
+  const { year, month, day } = getZonedComponents(date, tz);
+  const base = new Date(Date.UTC(year, month - 1, day));
+  const dow = base.getUTCDay();
+  const offset = (dow - weekStartsOn + 7) % 7;
+  const since = new Date(base);
+  since.setUTCDate(since.getUTCDate() - offset);
+  const until = new Date(since);
+  until.setUTCDate(until.getUTCDate() + 6);
+  return {
+    since,
+    until,
+    sinceYmd: ymdFromUtc(since),
+    untilYmd: ymdFromUtc(until),
+  };
+}
+
+/** 月視圖 42 格的日期清單（YMD 字串 + 是否為本月）。 */
+export function buildMonthGridDays(
+  anchor: Date,
+  tz: string,
+  weekStartsOn: 0 | 1 = 1,
+): Array<{ ymd: string; date: Date; isOutsideMonth: boolean }> {
+  const { year, month } = getZonedComponents(anchor, tz);
+  const { since } = getMonthGridRange(anchor, tz, weekStartsOn);
+  const days: Array<{ ymd: string; date: Date; isOutsideMonth: boolean }> = [];
+  for (let i = 0; i < 42; i++) {
+    const d = new Date(since);
+    d.setUTCDate(d.getUTCDate() + i);
+    days.push({
+      ymd: ymdFromUtc(d),
+      date: d,
+      isOutsideMonth: !(d.getUTCFullYear() === year && d.getUTCMonth() + 1 === month),
+    });
+  }
+  return days;
+}
+
+/** 回傳某錨點日期前/後一個月的 Date（回傳的 Date 以 UTC 00:00 代表該日）。 */
+export function addMonths(date: Date, months: number, tz: string): Date {
+  const { year, month, day } = getZonedComponents(date, tz);
+  // 以 UTC 計算避免漂移；若下個月沒有同一天則用當月最後一天
+  const target = new Date(Date.UTC(year, month - 1 + months, 1));
+  const lastDay = new Date(
+    Date.UTC(target.getUTCFullYear(), target.getUTCMonth() + 1, 0),
+  ).getUTCDate();
+  target.setUTCDate(Math.min(day, lastDay));
+  return target;
+}
+
+/** 回傳某錨點日期前/後 N 週的 Date。 */
+export function addWeeks(date: Date, weeks: number, tz: string): Date {
+  const { year, month, day } = getZonedComponents(date, tz);
+  const base = new Date(Date.UTC(year, month - 1, day));
+  base.setUTCDate(base.getUTCDate() + weeks * 7);
+  return base;
+}
+
+/** 回傳某錨點日期前/後 N 天的 Date。 */
+export function addDays(date: Date, days: number, tz: string): Date {
+  const { year, month, day } = getZonedComponents(date, tz);
+  const base = new Date(Date.UTC(year, month - 1, day));
+  base.setUTCDate(base.getUTCDate() + days);
+  return base;
+}
+
+/** 「今天」在該 tz 下的 Date（UTC 00:00 代表該日）。 */
+export function todayInTz(tz: string, now: Date = new Date()): Date {
+  const { year, month, day } = getZonedComponents(now, tz);
+  return new Date(Date.UTC(year, month - 1, day));
+}
+
+/** 傳入 YYYY-MM-DD，若合法回傳 Date（UTC 00:00），否則 null。 */
+export function parseYmd(ymd: string | null | undefined): Date | null {
+  if (!ymd) return null;
+  const m = /^(\d{4})-(\d{2})-(\d{2})$/.exec(ymd);
+  if (!m) return null;
+  const y = Number(m[1]);
+  const mo = Number(m[2]);
+  const d = Number(m[3]);
+  if (mo < 1 || mo > 12 || d < 1 || d > 31) return null;
+  const dt = new Date(Date.UTC(y, mo - 1, d));
+  // 驗證日是否合法（例如 2026-02-30 會漂到 3 月）
+  if (
+    dt.getUTCFullYear() !== y ||
+    dt.getUTCMonth() !== mo - 1 ||
+    dt.getUTCDate() !== d
+  ) {
+    return null;
+  }
+  return dt;
+}
+
+/** 以 `zh-TW` locale + 指定 tz 格式化標題，例如「2026 年 4 月」。 */
+export function formatMonthTitle(date: Date, tz: string): string {
+  const { year, month } = getZonedComponents(date, tz);
+  return `${year} 年 ${month} 月`;
+}
+
+/** 格式化為「2026 年 4 月 24 日 星期五」。 */
+export function formatDayTitle(date: Date, tz: string): string {
+  const fmt = new Intl.DateTimeFormat("zh-TW", {
+    timeZone: tz,
+    year: "numeric",
+    month: "long",
+    day: "numeric",
+    weekday: "long",
+  });
+  return fmt.format(date);
+}
+
+/** 格式化週區間，例如「2026 年 4 月 20 日 – 4 月 26 日」。 */
+export function formatWeekTitle(date: Date, tz: string): string {
+  const { since, until } = getWeekRange(date, tz);
+  const fmtFull = new Intl.DateTimeFormat("zh-TW", {
+    timeZone: tz,
+    year: "numeric",
+    month: "long",
+    day: "numeric",
+  });
+  const fmtShort = new Intl.DateTimeFormat("zh-TW", {
+    timeZone: tz,
+    month: "long",
+    day: "numeric",
+  });
+  return `${fmtFull.format(since)} – ${fmtShort.format(until)}`;
+}
+
+/** 由 UTC Date（代表某一日）輸出 YYYY-MM-DD。 */
+function ymdFromUtc(d: Date): string {
+  return `${d.getUTCFullYear()}-${pad2(d.getUTCMonth() + 1)}-${pad2(d.getUTCDate())}`;
+}
+
+function pad2(n: number): string {
+  return n < 10 ? `0${n}` : `${n}`;
+}

--- a/dev/frontend/lib/calendar/testids.ts
+++ b/dev/frontend/lib/calendar/testids.ts
@@ -1,0 +1,53 @@
+/**
+ * Calendar 頁面 data-testid 常數。
+ *
+ * 內容必須與 `test/browser/fixtures/calendar.ts` 的 `CALENDAR_TESTIDS` 保持一致，
+ * 以確保 Wave 3 e2e 測試能對齊。修改時請同步更新兩邊。
+ */
+export const CALENDAR_TESTIDS = {
+  // 頁面容器
+  page: "calendar-page",
+
+  // Toolbar
+  toolbar: "calendar-toolbar",
+  toolbarTitle: "calendar-toolbar-title",
+  prevButton: "calendar-prev-button",
+  nextButton: "calendar-next-button",
+  todayButton: "calendar-today-button",
+  viewTabs: "calendar-view-tabs",
+  viewTabMonth: "calendar-view-tab-month",
+  viewTabWeek: "calendar-view-tab-week",
+  viewTabDay: "calendar-view-tab-day",
+
+  // 月視圖
+  monthView: "calendar-month-view",
+  dayCell: (date: string) => `calendar-day-cell-${date}`,
+  dayCellToday: "calendar-day-cell-today",
+  entryBadge: "calendar-entry-badge",
+  eventBadge: "calendar-event-badge",
+  eventOverflowBadge: "calendar-event-overflow-badge",
+  journalIcon: "calendar-journal-icon",
+
+  // 週/日視圖
+  weekView: "calendar-week-view",
+  dayView: "calendar-day-view",
+
+  // Day Detail Sheet
+  sheet: "calendar-day-sheet",
+  sheetClose: "calendar-day-sheet-close",
+  sheetSectionEntries: "calendar-day-sheet-entries",
+  sheetSectionEvents: "calendar-day-sheet-events",
+  sheetSectionJournal: "calendar-day-sheet-journal",
+  sheetWriteJournalButton: "calendar-day-sheet-write-journal",
+
+  // Gcal event 卡片 + 轉 entry
+  eventCard: "calendar-event-card",
+  eventToEntryButton: "calendar-event-to-entry-button",
+  eventLinkedEntryLink: "calendar-event-linked-entry-link",
+  eventActionMenu: "calendar-event-action-menu",
+
+  // Banner / Toast / Degraded 狀態
+  gcalNotConnectedBanner: "calendar-gcal-not-connected-banner",
+  gcalDegradedToast: "calendar-gcal-degraded-toast",
+  gcalDegradedInlineWarning: "calendar-gcal-degraded-inline-warning",
+} as const;

--- a/dev/frontend/lib/hooks/use-calendar.ts
+++ b/dev/frontend/lib/hooks/use-calendar.ts
@@ -1,0 +1,131 @@
+"use client";
+
+import * as React from "react";
+import { useQuery } from "@tanstack/react-query";
+import {
+  fetchCalendar,
+  type CalendarView,
+  type FetchCalendarResult,
+} from "@/lib/api/calendar";
+
+const GCAL_CONNECTED_CACHE_KEY = "aibo_gcal_connected";
+const GCAL_CACHE_TTL_MS = 60 * 60 * 1000; // 1 小時
+
+interface GcalConnectedCache {
+  connected: boolean;
+  until: number;
+}
+
+function readGcalCache(): GcalConnectedCache | null {
+  if (typeof window === "undefined") return null;
+  try {
+    const raw = window.localStorage.getItem(GCAL_CONNECTED_CACHE_KEY);
+    if (!raw) return null;
+    const parsed = JSON.parse(raw) as GcalConnectedCache;
+    if (
+      typeof parsed?.connected !== "boolean" ||
+      typeof parsed?.until !== "number"
+    ) {
+      return null;
+    }
+    if (parsed.until < Date.now()) return null;
+    return parsed;
+  } catch {
+    return null;
+  }
+}
+
+function writeGcalCache(connected: boolean) {
+  if (typeof window === "undefined") return;
+  try {
+    const data: GcalConnectedCache = {
+      connected,
+      until: Date.now() + GCAL_CACHE_TTL_MS,
+    };
+    window.localStorage.setItem(GCAL_CONNECTED_CACHE_KEY, JSON.stringify(data));
+  } catch {
+    /* ignore */
+  }
+}
+
+/** 供 banner 讀取「是否已知 gcal 未連接」。 */
+export function useGcalConnectedCache(): {
+  connected: boolean | null;
+  setConnected: (v: boolean) => void;
+} {
+  const [state, setState] = React.useState<boolean | null>(() => {
+    const c = readGcalCache();
+    return c ? c.connected : null;
+  });
+
+  const setConnected = React.useCallback((v: boolean) => {
+    writeGcalCache(v);
+    setState(v);
+  }, []);
+
+  return { connected: state, setConnected };
+}
+
+export const calendarKey = (
+  since: string,
+  until: string,
+  view: CalendarView,
+  includeGcal: boolean,
+) => ["calendar", since, until, view, includeGcal] as const;
+
+export interface UseCalendarParams {
+  since: string;
+  until: string;
+  view: CalendarView;
+  tz: string;
+  /**
+   * 若 undefined，會依 localStorage 快取決定（若已知未連 gcal 則以 false 打，避免重複 424）。
+   */
+  includeGcal?: boolean;
+  enabled?: boolean;
+}
+
+/**
+ * 取得行事曆彙整資料的 React Query hook。
+ *
+ * 錯誤處理：
+ *   - API 回 424 GCAL_NOT_CONNECTED → hook 將 `gcalConnected` 設為 false，並在 localStorage
+ *     記 1 小時避免下次重打；UI 應顯示 banner 並提示連接。
+ *   - API 回 X-Degraded: gcal → `degraded === "gcal"`，UI 應顯示 toast/inline warning。
+ */
+export function useCalendar(params: UseCalendarParams) {
+  const { connected, setConnected } = useGcalConnectedCache();
+  // 若 includeGcal 未指定：
+  //   連接狀態未知 → true
+  //   已知未連 → false
+  const effectiveIncludeGcal =
+    params.includeGcal !== undefined ? params.includeGcal : connected === false ? false : true;
+
+  const query = useQuery<FetchCalendarResult>({
+    queryKey: calendarKey(params.since, params.until, params.view, effectiveIncludeGcal),
+    queryFn: async () => {
+      const result = await fetchCalendar({
+        since: params.since,
+        until: params.until,
+        view: params.view,
+        tz: params.tz,
+        include_gcal: effectiveIncludeGcal,
+      });
+      // 寫回 localStorage 供下次使用
+      if (!result.gcalConnected) {
+        setConnected(false);
+      } else if (connected !== true) {
+        setConnected(true);
+      }
+      return result;
+    },
+    staleTime: 5 * 60 * 1000, // 5 分鐘
+    enabled: params.enabled !== false,
+  });
+
+  return {
+    ...query,
+    gcalConnected: query.data?.gcalConnected ?? connected ?? true,
+    degraded: query.data?.degraded ?? null,
+  };
+}

--- a/dev/frontend/lib/schemas/calendar.ts
+++ b/dev/frontend/lib/schemas/calendar.ts
@@ -1,0 +1,46 @@
+import { z } from "zod";
+
+/**
+ * Calendar API response 的 zod schema（可選使用；預設 hook 僅以 TypeScript 型別為準，
+ * 若需要嚴格驗證可在 queryFn 中 `calendarResponseSchema.parse(data)`）。
+ */
+export const calendarEntrySummarySchema = z.object({
+  id: z.string(),
+  title: z.string().nullable(),
+  summary: z.string().nullable(),
+  source_type: z.string().nullable(),
+  tags: z.array(z.string()),
+  created_at: z.string(),
+});
+
+export const calendarEventSummarySchema = z.object({
+  gcal_id: z.string(),
+  summary: z.string(),
+  start: z.string(),
+  end: z.string(),
+  all_day: z.boolean(),
+  linked_entry_id: z.string().nullable(),
+});
+
+export const calendarJournalSchema = z.object({
+  id: z.string(),
+  mood: z.string().nullable().optional(),
+});
+
+export const calendarDaySchema = z.object({
+  date: z.string(),
+  entry_count: z.number(),
+  event_count: z.number(),
+  has_journal: z.boolean(),
+  entries: z.array(calendarEntrySummarySchema),
+  events: z.array(calendarEventSummarySchema),
+  journal: calendarJournalSchema.nullable().optional(),
+});
+
+export const calendarResponseSchema = z.object({
+  since: z.string(),
+  until: z.string(),
+  days: z.array(calendarDaySchema),
+});
+
+export type CalendarResponseSchema = z.infer<typeof calendarResponseSchema>;

--- a/dev/frontend/package-lock.json
+++ b/dev/frontend/package-lock.json
@@ -25,6 +25,8 @@
         "@tanstack/react-query-devtools": "^5.62.7",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
+        "date-fns": "^3.6.0",
+        "date-fns-tz": "^3.2.0",
         "lucide-react": "^0.469.0",
         "next": "14.2.20",
         "next-themes": "^0.4.4",
@@ -4473,6 +4475,25 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/date-fns": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-3.6.0.tgz",
+      "integrity": "sha512-fRHTG8g/Gif+kSh50gaGEdToemgfj74aRX3swtiouboip5JDLAyDE9F11nHMIcvOaXeOC6D7SpNhi7uFyB7Uww==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/kossnocorp"
+      }
+    },
+    "node_modules/date-fns-tz": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/date-fns-tz/-/date-fns-tz-3.2.0.tgz",
+      "integrity": "sha512-sg8HqoTEulcbbbVXeg84u5UnlsQa8GS5QXMqjjYIhS4abEVVKIUwe0/l/UhrZdKaL/W5eWZNlbTeEIiOXTcsBQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "date-fns": "^3.0.0 || ^4.0.0"
       }
     },
     "node_modules/debug": {

--- a/dev/frontend/package.json
+++ b/dev/frontend/package.json
@@ -28,6 +28,8 @@
     "@tanstack/react-query-devtools": "^5.62.7",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
+    "date-fns": "^3.6.0",
+    "date-fns-tz": "^3.2.0",
     "lucide-react": "^0.469.0",
     "next": "14.2.20",
     "next-themes": "^0.4.4",


### PR DESCRIPTION
Closes #82

## 摘要
新增 /calendar 路由 + 月視圖 + sidebar 行事曆項目。週/日視圖與 DayDetailSheet 交給 F-027b / F-027c。

## 新增檔案
- `app/(dashboard)/calendar/page.tsx`
- `components/calendar/{calendar-toolbar,month-view,day-cell,gcal-banner}.tsx`
- `lib/api/calendar.ts`, `lib/hooks/use-calendar.ts`, `lib/schemas/calendar.ts`
- `lib/calendar/{date-utils,testids}.ts` + `__tests__/lib/calendar/date-utils.test.ts`
- `components/ui/tabs.tsx`（shadcn）

## 修改
- `components/app-sidebar.tsx`：加入「行事曆」導航項

## 對齊
- testid 對齊 `test/browser/fixtures/calendar.ts` 的 `CALENDAR_TESTIDS`
- 沿用 design spec（`design/components/calendar/*`）
- Bowser tz 經 `Intl.DateTimeFormat` 讀出，經 `X-Timezone` header 傳後端
- X-Degraded / gcal_connected=false → GcalBanner 呈現

## 未實作（留後續 PR）
- 週視圖 / 日視圖（F-027b）
- DayDetailSheet + 轉 entry 動作（F-027c）
- 鍵盤快捷鍵完整版（F-027b 接手）

## 測試
- `npx tsc --noEmit` 通過（2 個 pre-existing 無關錯誤忽略）
- Calendar date-utils unit test：22/22 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)