### PR TITLE
feat(frontend): F-027b 行事曆週/日視圖 + 鍵盤快捷鍵 + 手機 fallback

### DIFF
--- a/dev/frontend/__tests__/components/calendar/event-block-layout.test.ts
+++ b/dev/frontend/__tests__/components/calendar/event-block-layout.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from "vitest";
+import { layoutOverlaps } from "@/components/calendar/event-block";
+
+type Ev = { id: string };
+
+function mk(
+  id: string,
+  startMin: number,
+  endMin: number,
+): { event: Ev; clip: any } {
+  return {
+    event: { id },
+    clip: {
+      startMin,
+      endMin,
+      continuesFromPrev: false,
+      continuesToNext: false,
+    },
+  };
+}
+
+describe("layoutOverlaps", () => {
+  it("不重疊：皆放第 0 欄，columnCount=1", () => {
+    const placed = layoutOverlaps<Ev>([
+      mk("a", 9 * 60, 10 * 60),
+      mk("b", 11 * 60, 12 * 60),
+    ]);
+    expect(placed.every((p) => p.columnIndex === 0)).toBe(true);
+    expect(placed[0].columnCount).toBe(1);
+  });
+
+  it("兩個重疊：columnIndex 0/1，columnCount=2", () => {
+    const placed = layoutOverlaps<Ev>([
+      mk("a", 9 * 60, 11 * 60),
+      mk("b", 10 * 60, 12 * 60),
+    ]);
+    expect(placed.map((p) => p.columnIndex)).toEqual([0, 1]);
+    expect(placed[0].columnCount).toBe(2);
+  });
+
+  it("三個同時重疊：columnCount=3", () => {
+    const placed = layoutOverlaps<Ev>([
+      mk("a", 9 * 60, 12 * 60),
+      mk("b", 9 * 60 + 30, 11 * 60),
+      mk("c", 10 * 60, 11 * 60 + 30),
+    ]);
+    expect(placed[0].columnCount).toBe(3);
+    expect(new Set(placed.map((p) => p.columnIndex))).toEqual(
+      new Set([0, 1, 2]),
+    );
+  });
+
+  it("早結束事件讓出欄位給後續", () => {
+    const placed = layoutOverlaps<Ev>([
+      mk("a", 9 * 60, 10 * 60), // 佔 col 0
+      mk("b", 9 * 60 + 30, 11 * 60), // col 1
+      mk("c", 10 * 60, 11 * 60), // a 已結束，佔 col 0
+    ]);
+    expect(placed[0].columnIndex).toBe(0);
+    expect(placed[1].columnIndex).toBe(1);
+    expect(placed[2].columnIndex).toBe(0);
+  });
+});

--- a/dev/frontend/__tests__/lib/calendar/week-day-utils.test.ts
+++ b/dev/frontend/__tests__/lib/calendar/week-day-utils.test.ts
@@ -1,0 +1,226 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildWeekDays,
+  clipEventToDay,
+  clipToAxisPx,
+  eventsIntersectingDay,
+  formatMinutes,
+  minutesToAxisTopPx,
+  parseYmd,
+  timeAxisHours,
+  zonedYmdAndMinutes,
+} from "@/lib/calendar/date-utils";
+
+const TZ = "Asia/Taipei";
+
+describe("timeAxisHours", () => {
+  it("回傳 06-23 共 18 格", () => {
+    const h = timeAxisHours();
+    expect(h.length).toBe(18);
+    expect(h[0]).toBe(6);
+    expect(h[h.length - 1]).toBe(23);
+  });
+});
+
+describe("buildWeekDays", () => {
+  it("週一起始，回傳 7 天", () => {
+    const anchor = parseYmd("2026-04-24")!; // 週五
+    const days = buildWeekDays(anchor, TZ, 1);
+    expect(days.length).toBe(7);
+    expect(days[0].ymd).toBe("2026-04-20"); // 週一
+    expect(days[6].ymd).toBe("2026-04-26"); // 週日
+  });
+
+  it("週日起始，回傳 7 天", () => {
+    const anchor = parseYmd("2026-04-24")!;
+    const days = buildWeekDays(anchor, TZ, 0);
+    expect(days[0].ymd).toBe("2026-04-19"); // 週日
+    expect(days[6].ymd).toBe("2026-04-25"); // 週六
+  });
+});
+
+describe("zonedYmdAndMinutes", () => {
+  it("Asia/Taipei 下 09:00 → 540 分", () => {
+    const r = zonedYmdAndMinutes("2026-04-24T09:00:00+08:00", TZ);
+    expect(r?.ymd).toBe("2026-04-24");
+    expect(r?.minutes).toBe(9 * 60);
+  });
+
+  it("午夜 00:00", () => {
+    const r = zonedYmdAndMinutes("2026-04-24T00:00:00+08:00", TZ);
+    expect(r?.ymd).toBe("2026-04-24");
+    expect(r?.minutes).toBe(0);
+  });
+
+  it("無效字串回 null", () => {
+    expect(zonedYmdAndMinutes("not-a-date", TZ)).toBeNull();
+  });
+});
+
+describe("clipEventToDay - 同日事件", () => {
+  it("09:00-10:30 在同一天 → 540..630", () => {
+    const ev = {
+      start: "2026-04-24T09:00:00+08:00",
+      end: "2026-04-24T10:30:00+08:00",
+      all_day: false,
+    };
+    const clip = clipEventToDay(ev, "2026-04-24", TZ);
+    expect(clip).not.toBeNull();
+    expect(clip!.startMin).toBe(540);
+    expect(clip!.endMin).toBe(630);
+    expect(clip!.continuesFromPrev).toBe(false);
+    expect(clip!.continuesToNext).toBe(false);
+  });
+
+  it("不在當天 → null", () => {
+    const ev = {
+      start: "2026-04-24T09:00:00+08:00",
+      end: "2026-04-24T10:00:00+08:00",
+      all_day: false,
+    };
+    expect(clipEventToDay(ev, "2026-04-25", TZ)).toBeNull();
+  });
+});
+
+describe("clipEventToDay - 跨日事件", () => {
+  it("04-24 23:00 → 04-25 01:00：前一天回 23:00-24:00（續至次日）", () => {
+    const ev = {
+      start: "2026-04-24T23:00:00+08:00",
+      end: "2026-04-25T01:00:00+08:00",
+      all_day: false,
+    };
+    const d1 = clipEventToDay(ev, "2026-04-24", TZ);
+    expect(d1).not.toBeNull();
+    expect(d1!.startMin).toBe(23 * 60);
+    expect(d1!.endMin).toBe(24 * 60);
+    expect(d1!.continuesFromPrev).toBe(false);
+    expect(d1!.continuesToNext).toBe(true);
+  });
+
+  it("04-24 23:00 → 04-25 01:00：次日回 00:00-01:00（前日續）", () => {
+    const ev = {
+      start: "2026-04-24T23:00:00+08:00",
+      end: "2026-04-25T01:00:00+08:00",
+      all_day: false,
+    };
+    const d2 = clipEventToDay(ev, "2026-04-25", TZ);
+    expect(d2).not.toBeNull();
+    expect(d2!.startMin).toBe(0);
+    expect(d2!.endMin).toBe(60);
+    expect(d2!.continuesFromPrev).toBe(true);
+    expect(d2!.continuesToNext).toBe(false);
+  });
+
+  it("事件 end 正好為次日 00:00 → 當日結束 24:00，次日不相交", () => {
+    const ev = {
+      start: "2026-04-24T22:00:00+08:00",
+      end: "2026-04-25T00:00:00+08:00",
+      all_day: false,
+    };
+    const d1 = clipEventToDay(ev, "2026-04-24", TZ);
+    expect(d1!.startMin).toBe(22 * 60);
+    expect(d1!.endMin).toBe(24 * 60);
+    expect(clipEventToDay(ev, "2026-04-25", TZ)).toBeNull();
+  });
+});
+
+describe("clipEventToDay - all_day", () => {
+  it("all_day 單日：0..1440", () => {
+    const ev = {
+      start: "2026-04-24T00:00:00+08:00",
+      end: "2026-04-25T00:00:00+08:00", // gcal all-day end 為排他
+      all_day: true,
+    };
+    const clip = clipEventToDay(ev, "2026-04-24", TZ);
+    expect(clip).not.toBeNull();
+    expect(clip!.startMin).toBe(0);
+    expect(clip!.endMin).toBe(1440);
+    expect(clip!.continuesFromPrev).toBe(false);
+    expect(clip!.continuesToNext).toBe(false);
+  });
+
+  it("all_day 跨 3 天：04-24 ~ 04-26", () => {
+    const ev = {
+      start: "2026-04-24T00:00:00+08:00",
+      end: "2026-04-27T00:00:00+08:00", // 4/24, 25, 26 三天
+      all_day: true,
+    };
+    const d24 = clipEventToDay(ev, "2026-04-24", TZ);
+    const d25 = clipEventToDay(ev, "2026-04-25", TZ);
+    const d26 = clipEventToDay(ev, "2026-04-26", TZ);
+    const d27 = clipEventToDay(ev, "2026-04-27", TZ);
+    expect(d24).not.toBeNull();
+    expect(d24!.continuesFromPrev).toBe(false);
+    expect(d24!.continuesToNext).toBe(true);
+    expect(d25!.continuesFromPrev).toBe(true);
+    expect(d25!.continuesToNext).toBe(true);
+    expect(d26!.continuesFromPrev).toBe(true);
+    expect(d26!.continuesToNext).toBe(false);
+    expect(d27).toBeNull();
+  });
+});
+
+describe("eventsIntersectingDay", () => {
+  it("過濾並依 startMin 排序", () => {
+    const events = [
+      {
+        gcal_id: "b",
+        summary: "B",
+        start: "2026-04-24T14:00:00+08:00",
+        end: "2026-04-24T15:00:00+08:00",
+        all_day: false,
+        linked_entry_id: null,
+      },
+      {
+        gcal_id: "a",
+        summary: "A",
+        start: "2026-04-24T09:00:00+08:00",
+        end: "2026-04-24T10:00:00+08:00",
+        all_day: false,
+        linked_entry_id: null,
+      },
+      {
+        gcal_id: "other",
+        summary: "Other",
+        start: "2026-04-25T09:00:00+08:00",
+        end: "2026-04-25T10:00:00+08:00",
+        all_day: false,
+        linked_entry_id: null,
+      },
+    ];
+    const out = eventsIntersectingDay(events, "2026-04-24", TZ);
+    expect(out.map((o) => o.event.gcal_id)).toEqual(["a", "b"]);
+  });
+});
+
+describe("minutesToAxisTopPx / clipToAxisPx", () => {
+  it("06:00 → 0px, 07:00 → 48px", () => {
+    expect(minutesToAxisTopPx(6 * 60)).toBe(0);
+    expect(minutesToAxisTopPx(7 * 60)).toBe(48);
+  });
+
+  it("clip 05:00-07:00 → 被 top clip", () => {
+    const r = clipToAxisPx(5 * 60, 7 * 60);
+    expect(r.clippedFromTop).toBe(true);
+    expect(r.topPx).toBe(0);
+    expect(r.heightPx).toBe(48); // 06:00-07:00
+  });
+
+  it("clip 23:30-24:30 → 被 bottom clip", () => {
+    const r = clipToAxisPx(23 * 60 + 30, 24 * 60 + 30);
+    expect(r.clippedFromBottom).toBe(true);
+  });
+
+  it("最小高度 20px（極短事件）", () => {
+    const r = clipToAxisPx(9 * 60, 9 * 60 + 5);
+    expect(r.heightPx).toBeGreaterThanOrEqual(20);
+  });
+});
+
+describe("formatMinutes", () => {
+  it("0 → 00:00, 540 → 09:00, 1439 → 23:59", () => {
+    expect(formatMinutes(0)).toBe("00:00");
+    expect(formatMinutes(540)).toBe("09:00");
+    expect(formatMinutes(1439)).toBe("23:59");
+  });
+});

--- a/dev/frontend/app/(dashboard)/calendar/page.tsx
+++ b/dev/frontend/app/(dashboard)/calendar/page.tsx
@@ -5,6 +5,8 @@ import { useRouter, useSearchParams } from "next/navigation";
 import { toast } from "sonner";
 import { CalendarToolbar } from "@/components/calendar/calendar-toolbar";
 import { MonthView } from "@/components/calendar/month-view";
+import { WeekView } from "@/components/calendar/week-view";
+import { DayView } from "@/components/calendar/day-view";
 import { GcalBanner } from "@/components/calendar/gcal-banner";
 import { ErrorState } from "@/components/error-state";
 import {
@@ -21,6 +23,8 @@ import {
   todayInTz,
 } from "@/lib/calendar/date-utils";
 import { useCalendar } from "@/lib/hooks/use-calendar";
+import { useIsMobile } from "@/lib/hooks/use-is-mobile";
+import { useCalendarShortcuts } from "@/lib/hooks/use-calendar-shortcuts";
 import type { CalendarDay } from "@/lib/api/calendar";
 import type { CalendarView } from "@/components/calendar/calendar-toolbar";
 import { CALENDAR_TESTIDS } from "@/lib/calendar/testids";
@@ -41,16 +45,19 @@ export default function CalendarPage() {
   const router = useRouter();
   const searchParams = useSearchParams();
   const tz = React.useMemo(resolveTimezone, []);
+  const isMobile = useIsMobile();
 
   const viewParam = searchParams.get("view");
   const dateParam = searchParams.get("date");
-  const view: CalendarView = parseView(viewParam);
+  const urlView: CalendarView = parseView(viewParam);
+  // 手機 (< 768px) 強制 day view（URL 可保留 ?view=month 以利 desktop 分享）
+  const view: CalendarView = isMobile ? "day" : urlView;
   const parsedDate = parseYmd(dateParam);
   const anchorDate = parsedDate ?? todayInTz(tz);
   const selectedYmd = parsedDate ? formatYmd(parsedDate, tz) : undefined;
   const todayYmd = formatYmd(todayInTz(tz), tz);
 
-  // 計算本次要 fetch 的區間（本 PR 只實作 month；week/day 為 placeholder）
+  // 計算本次要 fetch 的區間
   const range = React.useMemo(() => {
     if (view === "month") return getMonthGridRange(anchorDate, tz);
     if (view === "week") return getWeekRange(anchorDate, tz);
@@ -103,6 +110,14 @@ export default function CalendarPage() {
     [router, searchParams],
   );
 
+  const shiftDate = React.useCallback(
+    (deltaDays: number) => {
+      const next = addDays(anchorDate, deltaDays, tz);
+      updateUrl({ date: formatYmd(next, tz) });
+    },
+    [anchorDate, tz, updateUrl],
+  );
+
   const handlePrev = () => {
     let nextDate: Date;
     if (view === "month") nextDate = addMonths(anchorDate, -1, tz);
@@ -123,31 +138,41 @@ export default function CalendarPage() {
     updateUrl({ date: todayYmd });
   };
 
-  const handleViewChange = (v: CalendarView) => {
-    updateUrl({ view: v });
-  };
+  const handleViewChange = React.useCallback(
+    (v: CalendarView) => {
+      // 手機強制 day 時，不允許切成其他 view（toolbar tabs 已隱藏；此處 extra guard）
+      if (isMobile && v !== "day") return;
+      updateUrl({ view: v });
+    },
+    [isMobile, updateUrl],
+  );
 
   const handleSelectDate = (ymd: string) => {
-    // 本 PR 只同步 URL date（Sheet 由 F-027c 實作）
     updateUrl({ date: ymd });
   };
 
-  // 手機版強制 day view
-  React.useEffect(() => {
-    if (typeof window === "undefined") return;
-    if (window.matchMedia && window.matchMedia("(max-width: 767px)").matches) {
-      if (view !== "day") {
-        updateUrl({ view: "day" });
-      }
-    }
-    // 僅在 mount 時檢查一次
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  // PgUp/PgDn：大步移動
+  const handleLargeShift = React.useCallback(
+    (dir: -1 | 1) => {
+      let next: Date;
+      if (view === "month") next = addMonths(anchorDate, dir, tz);
+      else if (view === "week") next = addWeeks(anchorDate, dir * 4, tz);
+      else next = addDays(anchorDate, dir * 7, tz);
+      updateUrl({ date: formatYmd(next, tz) });
+    },
+    [view, anchorDate, tz, updateUrl],
+  );
 
-  const hideViewTabs =
-    typeof window !== "undefined" &&
-    window.matchMedia &&
-    window.matchMedia("(max-width: 767px)").matches;
+  // 鍵盤快捷鍵
+  useCalendarShortcuts({
+    view,
+    onPrev: handlePrev,
+    onNext: handleNext,
+    onToday: handleToday,
+    onPrevLarge: () => handleLargeShift(-1),
+    onNextLarge: () => handleLargeShift(1),
+    onSetView: handleViewChange,
+  });
 
   return (
     <div data-testid={CALENDAR_TESTIDS.page} className="flex flex-col gap-4">
@@ -159,7 +184,7 @@ export default function CalendarPage() {
         onNext={handleNext}
         onToday={handleToday}
         timezone={tz}
-        hideViewTabs={hideViewTabs}
+        hideViewTabs={isMobile}
         isLoading={isLoading}
       />
 
@@ -180,32 +205,24 @@ export default function CalendarPage() {
           onSelectDate={handleSelectDate}
         />
       ) : view === "week" ? (
-        <WeekViewPlaceholder />
+        <WeekView
+          anchorDate={anchorDate}
+          timezone={tz}
+          todayYmd={todayYmd}
+          daysMap={daysMap}
+          selectedDate={selectedYmd}
+          onSelectDate={handleSelectDate}
+        />
       ) : (
-        <DayViewPlaceholder />
+        <DayView
+          anchorDate={anchorDate}
+          timezone={tz}
+          todayYmd={todayYmd}
+          day={daysMap.get(formatYmd(anchorDate, tz))}
+          selectedDate={selectedYmd}
+          onSelectDate={handleSelectDate}
+        />
       )}
-    </div>
-  );
-}
-
-function WeekViewPlaceholder() {
-  return (
-    <div
-      data-testid={CALENDAR_TESTIDS.weekView}
-      className="rounded-md border bg-muted/20 p-8 text-center text-sm text-muted-foreground"
-    >
-      週視圖即將推出（F-027b）
-    </div>
-  );
-}
-
-function DayViewPlaceholder() {
-  return (
-    <div
-      data-testid={CALENDAR_TESTIDS.dayView}
-      className="rounded-md border bg-muted/20 p-8 text-center text-sm text-muted-foreground"
-    >
-      日視圖即將推出（F-027b）
     </div>
   );
 }

--- a/dev/frontend/components/calendar/day-view.tsx
+++ b/dev/frontend/components/calendar/day-view.tsx
@@ -1,0 +1,182 @@
+"use client";
+
+import * as React from "react";
+import { CALENDAR_TESTIDS } from "@/lib/calendar/testids";
+import {
+  TIME_AXIS_HOUR_PX,
+  eventsIntersectingDay,
+  formatDayTitle,
+  formatYmd,
+  timeAxisHours,
+} from "@/lib/calendar/date-utils";
+import { cn } from "@/lib/utils";
+import { Badge } from "@/components/ui/badge";
+import { TimeAxis } from "./time-axis";
+import { EventBlock, layoutOverlaps } from "./event-block";
+import type {
+  CalendarDay,
+  CalendarEntrySummary,
+  CalendarEventSummary,
+} from "@/lib/api/calendar";
+
+export interface DayViewProps {
+  anchorDate: Date;
+  timezone: string;
+  todayYmd: string;
+  day?: CalendarDay;
+  selectedDate?: string;
+  onSelectDate?: (ymd: string) => void;
+  onEntryClick?: (entry: CalendarEntrySummary) => void;
+  onEventClick?: (event: CalendarEventSummary, ymd: string) => void;
+}
+
+export function DayView({
+  anchorDate,
+  timezone,
+  todayYmd,
+  day,
+  selectedDate,
+  onSelectDate,
+  onEntryClick,
+  onEventClick,
+}: DayViewProps) {
+  const ymd = React.useMemo(
+    () => formatYmd(anchorDate, timezone),
+    [anchorDate, timezone],
+  );
+  const isToday = ymd === todayYmd;
+  const title = React.useMemo(
+    () => formatDayTitle(anchorDate, timezone),
+    [anchorDate, timezone],
+  );
+  const hours = React.useMemo(timeAxisHours, []);
+  const entries = day?.entries ?? [];
+  const events = day?.events ?? [];
+
+  const placed = React.useMemo(() => {
+    const intersect = eventsIntersectingDay(events, ymd, timezone);
+    return layoutOverlaps(intersect, 3);
+  }, [events, ymd, timezone]);
+
+  // 若 caller 有提供 onSelectDate 且目前選取不同於本日，自動同步
+  React.useEffect(() => {
+    if (onSelectDate && selectedDate !== ymd) {
+      // 不在 render 內直接呼叫，避免無限循環；這裡不主動 push（由 caller 控制）
+    }
+  }, [onSelectDate, selectedDate, ymd]);
+
+  return (
+    <section
+      data-testid={CALENDAR_TESTIDS.dayView}
+      aria-label={`${title} 單日視圖`}
+      className="flex flex-col gap-3"
+    >
+      {/* Day Header */}
+      <div
+        className={cn(
+          "flex items-start justify-between rounded-md border px-4 py-3",
+          isToday && "border-primary/40 bg-primary/5",
+        )}
+        data-testid={CALENDAR_TESTIDS.dayCell(ymd)}
+        data-today={isToday || undefined}
+      >
+        <div>
+          <h2 className="text-xl font-semibold">{title}</h2>
+          <p className="text-sm text-muted-foreground">
+            共 {entries.length} 條目 · {events.length} 事件
+            {day?.has_journal && " · 有日記"}
+          </p>
+        </div>
+      </div>
+
+      {/* Entries 列表 */}
+      {entries.length > 0 && (
+        <div className="rounded-md border p-3">
+          <h3 className="mb-2 text-sm font-medium">今日條目（{entries.length}）</h3>
+          <ul className="flex flex-col gap-1.5">
+            {entries.map((e) => (
+              <li key={e.id}>
+                <button
+                  type="button"
+                  data-testid={CALENDAR_TESTIDS.entryBadge}
+                  onClick={onEntryClick ? () => onEntryClick(e) : undefined}
+                  className={cn(
+                    "w-full rounded-sm px-2 py-1.5 text-left text-sm",
+                    "hover:bg-muted/60",
+                    "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
+                  )}
+                >
+                  <span className="truncate font-medium">
+                    {e.title || e.summary || "(無標題)"}
+                  </span>
+                  {e.tags.length > 0 && (
+                    <span className="ml-2 inline-flex flex-wrap gap-1 align-middle">
+                      {e.tags.slice(0, 3).map((t) => (
+                        <Badge
+                          key={t}
+                          variant="outline"
+                          className="text-[10px]"
+                        >
+                          {t}
+                        </Badge>
+                      ))}
+                    </span>
+                  )}
+                </button>
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+
+      {/* Time grid */}
+      <div
+        role="grid"
+        aria-label="單日時間軸"
+        className="relative max-h-[60vh] overflow-y-auto rounded-md border"
+      >
+        <div
+          className="grid"
+          style={{
+            gridTemplateColumns: "56px 1fr",
+            minHeight: hours.length * TIME_AXIS_HOUR_PX,
+          }}
+        >
+          <TimeAxis />
+          <div
+            className={cn(
+              "relative",
+              isToday && "bg-primary/5",
+            )}
+            role="gridcell"
+            aria-label={`${ymd} 時段`}
+            style={{ height: hours.length * TIME_AXIS_HOUR_PX }}
+          >
+            {hours.map((h) => (
+              <div
+                key={h}
+                className="border-t border-border/60"
+                style={{ height: TIME_AXIS_HOUR_PX }}
+              />
+            ))}
+            {placed.map((p, i) => (
+              <EventBlock
+                key={`${p.event.gcal_id}-${i}`}
+                event={p.event}
+                clip={p.clip}
+                columnIndex={p.columnIndex}
+                columnCount={p.columnCount}
+                onClick={(ev) => onEventClick?.(ev, ymd)}
+              />
+            ))}
+            {placed.length === 0 && entries.length === 0 && (
+              <div className="pointer-events-none absolute inset-x-0 top-8 text-center text-sm text-muted-foreground">
+                今天還沒有任何紀錄
+              </div>
+            )}
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/dev/frontend/components/calendar/day-view.tsx
+++ b/dev/frontend/components/calendar/day-view.tsx
@@ -58,13 +58,6 @@ export function DayView({
     return layoutOverlaps(intersect, 3);
   }, [events, ymd, timezone]);
 
-  // 若 caller 有提供 onSelectDate 且目前選取不同於本日，自動同步
-  React.useEffect(() => {
-    if (onSelectDate && selectedDate !== ymd) {
-      // 不在 render 內直接呼叫，避免無限循環；這裡不主動 push（由 caller 控制）
-    }
-  }, [onSelectDate, selectedDate, ymd]);
-
   return (
     <section
       data-testid={CALENDAR_TESTIDS.dayView}

--- a/dev/frontend/components/calendar/event-block.tsx
+++ b/dev/frontend/components/calendar/event-block.tsx
@@ -1,0 +1,137 @@
+"use client";
+
+import * as React from "react";
+import { Link as LinkIcon } from "lucide-react";
+import { CALENDAR_TESTIDS } from "@/lib/calendar/testids";
+import {
+  clipToAxisPx,
+  formatMinutes,
+  type EventDayClip,
+} from "@/lib/calendar/date-utils";
+import { cn } from "@/lib/utils";
+import type { CalendarEventSummary } from "@/lib/api/calendar";
+
+export interface EventBlockProps {
+  event: CalendarEventSummary;
+  clip: EventDayClip;
+  /** 該區塊在同時段重疊欄位中的位置（0-based） */
+  columnIndex?: number;
+  /** 該時段總欄位數（≥1） */
+  columnCount?: number;
+  onClick?: (event: CalendarEventSummary) => void;
+  /** 額外 aria 前綴（例：「4/24 週五 ·」） */
+  ariaPrefix?: string;
+}
+
+export function EventBlock({
+  event,
+  clip,
+  columnIndex = 0,
+  columnCount = 1,
+  onClick,
+  ariaPrefix,
+}: EventBlockProps) {
+  const { topPx, heightPx, clippedFromTop } = clipToAxisPx(
+    clip.startMin,
+    clip.endMin,
+  );
+  const widthPct = 100 / Math.max(1, columnCount);
+  const leftPct = widthPct * columnIndex;
+  const isLinked = !!event.linked_entry_id;
+  const startStr = formatMinutes(clip.startMin);
+  const endStr = formatMinutes(clip.endMin);
+  const continues = clip.continuesFromPrev || clip.continuesToNext;
+
+  return (
+    <button
+      type="button"
+      data-testid={CALENDAR_TESTIDS.eventBadge}
+      onClick={onClick ? () => onClick(event) : undefined}
+      className={cn(
+        "absolute flex flex-col gap-0.5 overflow-hidden rounded-sm border px-1.5 py-1 text-left text-[11px]",
+        "transition-colors hover:shadow-sm",
+        "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
+        isLinked
+          ? "border-success/40 bg-success/10"
+          : "border-dashed border-border bg-muted/60",
+      )}
+      style={{
+        top: topPx,
+        height: heightPx,
+        left: `calc(${leftPct}% + 2px)`,
+        width: `calc(${widthPct}% - 4px)`,
+      }}
+      aria-label={`${ariaPrefix ? ariaPrefix + " " : ""}${event.summary}，${startStr}–${endStr}${clip.continuesFromPrev ? "（前日續）" : ""}${clip.continuesToNext ? "（續至次日）" : ""}${isLinked ? "，已連結條目" : ""}`}
+      title={`${startStr}–${endStr} ${event.summary}`}
+    >
+      <div className="flex items-center gap-1">
+        {clippedFromTop || clip.continuesFromPrev ? (
+          <span className="shrink-0 rounded bg-primary/10 px-1 text-[9px] text-primary">
+            續
+          </span>
+        ) : (
+          <span className="shrink-0 tabular-nums text-muted-foreground">
+            {startStr}
+          </span>
+        )}
+        {isLinked && <LinkIcon className="h-3 w-3 shrink-0 text-success" />}
+        {continues && !clip.continuesFromPrev && (
+          <span className="shrink-0 rounded bg-primary/10 px-1 text-[9px] text-primary">
+            續
+          </span>
+        )}
+      </div>
+      <span className="truncate font-medium leading-tight">
+        {event.summary}
+      </span>
+    </button>
+  );
+}
+
+/**
+ * 將一組（已被 clip 過的）事件分配到重疊欄位（最多 maxColumns 欄，預設 3）。
+ * 用掃描線演算法：若 event 與某欄位最後一件在時間上不重疊（end ≤ next.start），就沿用該欄。
+ */
+export interface PlacedEvent<T> {
+  event: T;
+  clip: EventDayClip;
+  columnIndex: number;
+  columnCount: number;
+}
+
+export function layoutOverlaps<T>(
+  items: Array<{ event: T; clip: EventDayClip }>,
+  maxColumns = 3,
+): PlacedEvent<T>[] {
+  const columnsEnd: number[] = []; // 每欄目前的結束分鐘
+  const placements: PlacedEvent<T>[] = items.map((it) => {
+    // 找第一個「已結束」的欄位
+    let col = -1;
+    for (let i = 0; i < columnsEnd.length; i++) {
+      if (columnsEnd[i] <= it.clip.startMin) {
+        col = i;
+        break;
+      }
+    }
+    if (col === -1) {
+      if (columnsEnd.length < maxColumns) {
+        col = columnsEnd.length;
+        columnsEnd.push(it.clip.endMin);
+      } else {
+        // 超過最大欄數，強制放最後一欄（視覺上會略為重疊）
+        col = maxColumns - 1;
+        columnsEnd[col] = Math.max(columnsEnd[col], it.clip.endMin);
+      }
+    } else {
+      columnsEnd[col] = it.clip.endMin;
+    }
+    return {
+      event: it.event,
+      clip: it.clip,
+      columnIndex: col,
+      columnCount: 0, // 先佔位
+    };
+  });
+  const total = Math.max(1, columnsEnd.length);
+  return placements.map((p) => ({ ...p, columnCount: total }));
+}

--- a/dev/frontend/components/calendar/time-axis.tsx
+++ b/dev/frontend/components/calendar/time-axis.tsx
@@ -1,0 +1,28 @@
+"use client";
+
+import * as React from "react";
+import { TIME_AXIS_HOUR_PX, timeAxisHours } from "@/lib/calendar/date-utils";
+
+/**
+ * 時間刻度欄（06:00–23:00，每小時一格，48px 高）。
+ * 共用於 week-view / day-view 的左側。
+ */
+export function TimeAxis() {
+  const hours = React.useMemo(timeAxisHours, []);
+  return (
+    <div
+      className="flex flex-col border-r bg-muted/10"
+      aria-hidden="true"
+    >
+      {hours.map((h) => (
+        <div
+          key={h}
+          className="border-t border-border/60 px-1.5 text-[11px] tabular-nums text-muted-foreground"
+          style={{ height: TIME_AXIS_HOUR_PX }}
+        >
+          {h.toString().padStart(2, "0")}:00
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/dev/frontend/components/calendar/week-view.tsx
+++ b/dev/frontend/components/calendar/week-view.tsx
@@ -1,0 +1,210 @@
+"use client";
+
+import * as React from "react";
+import { CALENDAR_TESTIDS } from "@/lib/calendar/testids";
+import {
+  TIME_AXIS_HOUR_PX,
+  buildWeekDays,
+  eventsIntersectingDay,
+  timeAxisHours,
+} from "@/lib/calendar/date-utils";
+import { cn } from "@/lib/utils";
+import { Badge } from "@/components/ui/badge";
+import { TimeAxis } from "./time-axis";
+import { EventBlock, layoutOverlaps } from "./event-block";
+import type {
+  CalendarDay,
+  CalendarEntrySummary,
+  CalendarEventSummary,
+} from "@/lib/api/calendar";
+
+export interface WeekViewProps {
+  /** 錨點日期（決定顯示哪一週） */
+  anchorDate: Date;
+  timezone: string;
+  /** 今天的 YMD（高亮 column） */
+  todayYmd: string;
+  /** 當週每日資料 */
+  daysMap: Map<string, CalendarDay>;
+  /** 使用者選中的 ymd（含在當週內則高亮對應 column） */
+  selectedDate?: string;
+  onSelectDate: (ymd: string) => void;
+  onEventClick?: (event: CalendarEventSummary, ymd: string) => void;
+  weekStartsOn?: 0 | 1;
+}
+
+const WEEKDAY_LABELS_MON_START = ["一", "二", "三", "四", "五", "六", "日"];
+const WEEKDAY_LABELS_SUN_START = ["日", "一", "二", "三", "四", "五", "六"];
+
+export function WeekView({
+  anchorDate,
+  timezone,
+  todayYmd,
+  daysMap,
+  selectedDate,
+  onSelectDate,
+  onEventClick,
+  weekStartsOn = 1,
+}: WeekViewProps) {
+  const days = React.useMemo(
+    () => buildWeekDays(anchorDate, timezone, weekStartsOn),
+    [anchorDate, timezone, weekStartsOn],
+  );
+  const hours = React.useMemo(timeAxisHours, []);
+
+  return (
+    <div
+      role="grid"
+      aria-label="週視圖時間表"
+      data-testid={CALENDAR_TESTIDS.weekView}
+      className="flex flex-col overflow-hidden rounded-md border"
+    >
+      {/* Header */}
+      <div
+        className="grid border-b bg-muted/30"
+        role="row"
+        style={{ gridTemplateColumns: "56px repeat(7, minmax(0, 1fr))" }}
+      >
+        <div aria-hidden="true" />
+        {days.map((d, idx) => {
+          const isToday = d.ymd === todayYmd;
+          const isSelected = selectedDate === d.ymd;
+          const label =
+            (weekStartsOn === 1
+              ? WEEKDAY_LABELS_MON_START
+              : WEEKDAY_LABELS_SUN_START)[idx];
+          const mm = d.date.getUTCMonth() + 1;
+          const dd = d.date.getUTCDate();
+          return (
+            <button
+              key={d.ymd}
+              type="button"
+              role="columnheader"
+              aria-pressed={isSelected}
+              aria-label={`${d.date.getUTCFullYear()} 年 ${mm} 月 ${dd} 日 星期${label}`}
+              data-testid={CALENDAR_TESTIDS.dayCell(d.ymd)}
+              data-today={isToday || undefined}
+              onClick={() => onSelectDate(d.ymd)}
+              className={cn(
+                "flex flex-col items-center gap-0.5 border-r py-2 text-xs transition-colors last:border-r-0",
+                "hover:bg-muted/60 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring",
+                isSelected && "bg-primary/10",
+              )}
+            >
+              <span className="tabular-nums text-muted-foreground">
+                {mm}/{dd}
+              </span>
+              <span
+                className={cn(
+                  "font-semibold",
+                  isToday &&
+                    "inline-flex h-5 w-5 items-center justify-center rounded-full bg-primary text-primary-foreground",
+                )}
+              >
+                {label}
+              </span>
+            </button>
+          );
+        })}
+      </div>
+
+      {/* Entries chips lane */}
+      <div
+        className="grid border-b"
+        style={{ gridTemplateColumns: "56px repeat(7, minmax(0, 1fr))" }}
+      >
+        <div className="px-2 py-1.5 text-[10px] text-muted-foreground">條目</div>
+        {days.map((d) => (
+          <EntriesChipsCell
+            key={d.ymd}
+            entries={daysMap.get(d.ymd)?.entries ?? []}
+          />
+        ))}
+      </div>
+
+      {/* Time grid (scrollable) */}
+      <div className="relative max-h-[calc(100vh-320px)] overflow-y-auto">
+        <div
+          className="grid"
+          style={{
+            gridTemplateColumns: "56px repeat(7, minmax(0, 1fr))",
+            minHeight: hours.length * TIME_AXIS_HOUR_PX,
+          }}
+        >
+          <TimeAxis />
+          {days.map((d) => {
+            const dayData = daysMap.get(d.ymd);
+            const events = dayData?.events ?? [];
+            const intersecting = eventsIntersectingDay(events, d.ymd, timezone);
+            const placed = layoutOverlaps(intersecting, 3);
+            const isToday = d.ymd === todayYmd;
+            const isSelected = selectedDate === d.ymd;
+            return (
+              <div
+                key={d.ymd}
+                role="gridcell"
+                aria-label={`${d.ymd} 時段`}
+                className={cn(
+                  "relative border-r last:border-r-0",
+                  isToday && "bg-primary/5",
+                  isSelected && "bg-primary/10",
+                )}
+                style={{ height: hours.length * TIME_AXIS_HOUR_PX }}
+              >
+                {hours.map((h) => (
+                  <div
+                    key={h}
+                    className="border-t border-border/60"
+                    style={{ height: TIME_AXIS_HOUR_PX }}
+                  />
+                ))}
+                {placed.map((p, i) => (
+                  <EventBlock
+                    key={`${p.event.gcal_id}-${i}`}
+                    event={p.event}
+                    clip={p.clip}
+                    columnIndex={p.columnIndex}
+                    columnCount={p.columnCount}
+                    onClick={(ev) => onEventClick?.(ev, d.ymd)}
+                    ariaPrefix={`${d.date.getUTCMonth() + 1}/${d.date.getUTCDate()}`}
+                  />
+                ))}
+              </div>
+            );
+          })}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function EntriesChipsCell({ entries }: { entries: CalendarEntrySummary[] }) {
+  if (entries.length === 0) {
+    return <div className="border-r px-1 py-1 last:border-r-0" aria-hidden="true" />;
+  }
+  const visible = entries.slice(0, 3);
+  const overflow = entries.length - visible.length;
+  return (
+    <div className="flex flex-wrap gap-1 border-r p-1 last:border-r-0">
+      {visible.map((e) => (
+        <Badge
+          key={e.id}
+          variant="secondary"
+          data-testid={CALENDAR_TESTIDS.entryBadge}
+          className="max-w-full truncate text-[10px]"
+          title={e.title || "(無標題)"}
+        >
+          {e.title || "(無標題)"}
+        </Badge>
+      ))}
+      {overflow > 0 && (
+        <span
+          className="text-[10px] text-muted-foreground"
+          data-testid={CALENDAR_TESTIDS.eventOverflowBadge}
+        >
+          +{overflow}
+        </span>
+      )}
+    </div>
+  );
+}

--- a/dev/frontend/lib/calendar/date-utils.ts
+++ b/dev/frontend/lib/calendar/date-utils.ts
@@ -210,3 +210,207 @@ function ymdFromUtc(d: Date): string {
 function pad2(n: number): string {
   return n < 10 ? `0${n}` : `${n}`;
 }
+
+// ---------------------------------------------------------------------------
+// 週/日視圖輔助（F-027b）
+// ---------------------------------------------------------------------------
+
+/** 時間軸顯示範圍（week/day view 共用）。 */
+export const TIME_AXIS_START_HOUR = 6;
+export const TIME_AXIS_END_HOUR = 24; // exclusive；顯示最後一格為 23:00
+export const TIME_AXIS_HOUR_PX = 48;
+
+/** 產生 `[6, 7, ..., 23]`（18 個）。 */
+export function timeAxisHours(): number[] {
+  const arr: number[] = [];
+  for (let h = TIME_AXIS_START_HOUR; h < TIME_AXIS_END_HOUR; h++) arr.push(h);
+  return arr;
+}
+
+/** 由週錨點產生一週 7 天（週一起）的日期清單。 */
+export function buildWeekDays(
+  anchor: Date,
+  tz: string,
+  weekStartsOn: 0 | 1 = 1,
+): Array<{ ymd: string; date: Date; dow: number }> {
+  const { since } = getWeekRange(anchor, tz, weekStartsOn);
+  const days: Array<{ ymd: string; date: Date; dow: number }> = [];
+  for (let i = 0; i < 7; i++) {
+    const d = new Date(since);
+    d.setUTCDate(d.getUTCDate() + i);
+    days.push({ ymd: ymdFromUtc(d), date: d, dow: d.getUTCDay() });
+  }
+  return days;
+}
+
+/**
+ * 取得 event 在指定 tz 下的「該日 start/end 分鐘數」（自 00:00 起算）。
+ * 若 event 不與該日相交則回 null。
+ *
+ * 範例：
+ *   - event 2026-04-24 09:00–10:30 Asia/Taipei，dayYmd=2026-04-24 → {startMin:540, endMin:630, continuesFromPrev:false, continuesToNext:false}
+ *   - event 2026-04-24 23:00–2026-04-25 01:00，dayYmd=2026-04-25 → {startMin:0, endMin:60, continuesFromPrev:true, continuesToNext:false}
+ */
+export interface EventDayClip {
+  /** 該日開始分鐘（0-1440） */
+  startMin: number;
+  /** 該日結束分鐘（0-1440，可等於 1440 表示持續至午夜） */
+  endMin: number;
+  /** 是否由前一日延續（需顯示「續」標示） */
+  continuesFromPrev: boolean;
+  /** 是否延續至次日 */
+  continuesToNext: boolean;
+}
+
+/**
+ * 將 ISO 時間字串在 tz 下轉為 { ymd, minutesFromMidnight }。
+ */
+export function zonedYmdAndMinutes(
+  iso: string,
+  tz: string,
+): { ymd: string; minutes: number } | null {
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return null;
+  const fmt = new Intl.DateTimeFormat("en-CA", {
+    timeZone: tz,
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+    hour12: false,
+  });
+  // 部件化取得
+  const parts = fmt.formatToParts(d);
+  const get = (t: string) => parts.find((p) => p.type === t)?.value ?? "00";
+  const y = Number(get("year"));
+  const mo = Number(get("month"));
+  const da = Number(get("day"));
+  let hh = Number(get("hour"));
+  const mm = Number(get("minute"));
+  // en-CA / hour12:false 在某些平台會回傳 "24" 作為凌晨——標準化成 0
+  if (hh === 24) hh = 0;
+  const ymd = `${y}-${pad2(mo)}-${pad2(da)}`;
+  return { ymd, minutes: hh * 60 + mm };
+}
+
+/**
+ * 判斷 event 是否與指定日相交，並回傳該日內的時段區間（分鐘）。
+ *
+ * - all_day：視為佔滿整日（start=0,end=1440）。跨多日 all_day 會在每天都相交。
+ * - 一般：依 tz 下的 ymd 判斷。
+ */
+export function clipEventToDay(
+  event: { start: string; end: string; all_day: boolean },
+  dayYmd: string,
+  tz: string,
+): EventDayClip | null {
+  if (event.all_day) {
+    const startYmd = zonedYmdAndMinutes(event.start, tz)?.ymd;
+    const endYmdRaw = zonedYmdAndMinutes(event.end, tz);
+    // gcal all-day 的 end 為排他（次日 00:00）——所以比較時需減 1 分鐘判斷
+    if (!startYmd || !endYmdRaw) return null;
+    // 若 end 為 00:00，視為前一日結束
+    const endYmd =
+      endYmdRaw.minutes === 0 ? ymdMinusOne(endYmdRaw.ymd) : endYmdRaw.ymd;
+    if (dayYmd < startYmd || dayYmd > endYmd) return null;
+    return {
+      startMin: 0,
+      endMin: 24 * 60,
+      continuesFromPrev: dayYmd > startYmd,
+      continuesToNext: dayYmd < endYmd,
+    };
+  }
+
+  const s = zonedYmdAndMinutes(event.start, tz);
+  const e = zonedYmdAndMinutes(event.end, tz);
+  if (!s || !e) return null;
+
+  // 若 end 落在 00:00，視為前一日 24:00（避免顯示 0 長度於 00:00 當天）
+  let endYmd = e.ymd;
+  let endMinutes = e.minutes;
+  if (e.minutes === 0 && e.ymd > s.ymd) {
+    endYmd = ymdMinusOne(e.ymd);
+    endMinutes = 24 * 60;
+  }
+
+  if (dayYmd < s.ymd || dayYmd > endYmd) return null;
+
+  const startMin = dayYmd === s.ymd ? s.minutes : 0;
+  const endMin = dayYmd === endYmd ? endMinutes : 24 * 60;
+
+  // 防呆：若同一天但 end <= start（資料異常），設最少 15 分鐘以仍可渲染
+  const normalizedEndMin =
+    dayYmd === s.ymd && dayYmd === endYmd && endMin <= startMin
+      ? Math.min(startMin + 15, 24 * 60)
+      : endMin;
+
+  return {
+    startMin,
+    endMin: normalizedEndMin,
+    continuesFromPrev: dayYmd > s.ymd,
+    continuesToNext: dayYmd < endYmd,
+  };
+}
+
+/**
+ * 從一組 events 中挑出與指定日相交的、並回傳含裁切資訊的結果。
+ *
+ * 回傳依 startMin 排序。
+ */
+export function eventsIntersectingDay<
+  T extends { start: string; end: string; all_day: boolean },
+>(
+  events: T[],
+  dayYmd: string,
+  tz: string,
+): Array<{ event: T; clip: EventDayClip }> {
+  const out: Array<{ event: T; clip: EventDayClip }> = [];
+  for (const ev of events) {
+    const clip = clipEventToDay(ev, dayYmd, tz);
+    if (clip) out.push({ event: ev, clip });
+  }
+  out.sort((a, b) => a.clip.startMin - b.clip.startMin);
+  return out;
+}
+
+/** YYYY-MM-DD 減一日（純字串運算，經由 Date UTC）。 */
+function ymdMinusOne(ymd: string): string {
+  const [y, m, d] = ymd.split("-").map(Number);
+  const dt = new Date(Date.UTC(y, m - 1, d));
+  dt.setUTCDate(dt.getUTCDate() - 1);
+  return ymdFromUtc(dt);
+}
+
+/** 由分鐘數換算時間軸頂部 px 位置（相對 06:00 起算）。 */
+export function minutesToAxisTopPx(min: number): number {
+  return ((min - TIME_AXIS_START_HOUR * 60) / 60) * TIME_AXIS_HOUR_PX;
+}
+
+/** 將時間區段換算為 { topPx, heightPx }；會 clamp 到 [06:00, 24:00]。 */
+export function clipToAxisPx(startMin: number, endMin: number): {
+  topPx: number;
+  heightPx: number;
+  clippedFromTop: boolean;
+  clippedFromBottom: boolean;
+} {
+  const axisStart = TIME_AXIS_START_HOUR * 60;
+  const axisEnd = TIME_AXIS_END_HOUR * 60;
+  const s = Math.max(startMin, axisStart);
+  const e = Math.min(endMin, axisEnd);
+  const topPx = ((s - axisStart) / 60) * TIME_AXIS_HOUR_PX;
+  const heightPx = Math.max(20, ((e - s) / 60) * TIME_AXIS_HOUR_PX);
+  return {
+    topPx,
+    heightPx,
+    clippedFromTop: startMin < axisStart,
+    clippedFromBottom: endMin > axisEnd,
+  };
+}
+
+/** 格式化分鐘為 HH:MM（24 小時制）。 */
+export function formatMinutes(min: number): string {
+  const h = Math.floor(min / 60) % 24;
+  const m = min % 60;
+  return `${pad2(h)}:${pad2(m)}`;
+}

--- a/dev/frontend/lib/hooks/use-calendar-shortcuts.ts
+++ b/dev/frontend/lib/hooks/use-calendar-shortcuts.ts
@@ -22,8 +22,8 @@ export interface UseCalendarShortcutsParams {
 /**
  * 行事曆鍵盤快捷鍵。
  *
- * - `←` / `k` / `j`：上一步（view 決定步長）
- * - `→` / `l`（注：`j/k` 為 vim 風格的 prev/next；規格允許 j/k or ←/→）
+ * - `←` / `k` / `h`：上一步（view 決定步長）
+ * - `→` / `j` / `l`：下一步（vim 慣例：j 下/next、k 上/prev）
  * - `t`：回到今天
  * - `1` / `m` / `M`：切月視圖
  * - `2` / `w` / `W`：切週視圖
@@ -85,15 +85,15 @@ export function useCalendarShortcuts(params: UseCalendarShortcutsParams): void {
       switch (e.key) {
         case "ArrowLeft":
         case "k":
-        case "j":
-          // 規格：j/k 或 ←/→ 皆為 prev/next；取 j/k 為「上下式」—此處以 j=next, k=prev (vim 常見)
-          // 為貼合 spec（「j/k or ←/→ prev/next」描述兩者皆可），將左鍵與 k/j 其中之一統一。
-          // 這裡選擇：← / k / j 都為 prev（簡化使用者記憶），→ / l 為 next。
+        case "h":
+          // vim 慣例：k 向上 = prev；h 向左 = prev；搭配 ArrowLeft。
           e.preventDefault();
           h.onPrev();
           break;
         case "ArrowRight":
+        case "j":
         case "l":
+          // vim 慣例：j 向下 = next；l 向右 = next；搭配 ArrowRight。
           e.preventDefault();
           h.onNext();
           break;

--- a/dev/frontend/lib/hooks/use-calendar-shortcuts.ts
+++ b/dev/frontend/lib/hooks/use-calendar-shortcuts.ts
@@ -1,0 +1,139 @@
+"use client";
+
+import * as React from "react";
+import type { CalendarView } from "@/lib/api/calendar";
+
+export interface UseCalendarShortcutsParams {
+  view: CalendarView;
+  /** 觸發 prev（-1 step）/next（+1 step），step 由 view 決定。 */
+  onPrev: () => void;
+  onNext: () => void;
+  /** T：回到今天。 */
+  onToday: () => void;
+  /** PgUp/PgDn：大步移動（月/四週/七天）。 */
+  onPrevLarge: () => void;
+  onNextLarge: () => void;
+  /** M/W/D 或 1/2/3：切 view。 */
+  onSetView: (v: CalendarView) => void;
+  /** 是否啟用（預設 true）。 */
+  enabled?: boolean;
+}
+
+/**
+ * 行事曆鍵盤快捷鍵。
+ *
+ * - `←` / `k` / `j`：上一步（view 決定步長）
+ * - `→` / `l`（注：`j/k` 為 vim 風格的 prev/next；規格允許 j/k or ←/→）
+ * - `t`：回到今天
+ * - `1` / `m` / `M`：切月視圖
+ * - `2` / `w` / `W`：切週視圖
+ * - `3` / `d` / `D`：切日視圖
+ * - `PageUp` / `PageDown`：大步移動（月視圖 = 1 個月；週 = 4 週；日 = 7 天）
+ *
+ * 當焦點在 input / textarea / select / contenteditable 時不觸發（修飾鍵組合也跳過）。
+ */
+export function useCalendarShortcuts(params: UseCalendarShortcutsParams): void {
+  const {
+    onPrev,
+    onNext,
+    onToday,
+    onPrevLarge,
+    onNextLarge,
+    onSetView,
+    enabled = true,
+  } = params;
+
+  // 用 ref 保留最新 handler，避免 effect 頻繁重綁
+  const handlersRef = React.useRef({
+    onPrev,
+    onNext,
+    onToday,
+    onPrevLarge,
+    onNextLarge,
+    onSetView,
+  });
+  React.useEffect(() => {
+    handlersRef.current = {
+      onPrev,
+      onNext,
+      onToday,
+      onPrevLarge,
+      onNextLarge,
+      onSetView,
+    };
+  }, [onPrev, onNext, onToday, onPrevLarge, onNextLarge, onSetView]);
+
+  React.useEffect(() => {
+    if (!enabled) return;
+    if (typeof window === "undefined") return;
+
+    const isTypingTarget = (el: EventTarget | null): boolean => {
+      if (!el || !(el instanceof HTMLElement)) return false;
+      const tag = el.tagName;
+      if (tag === "INPUT" || tag === "TEXTAREA" || tag === "SELECT") return true;
+      if (el.isContentEditable) return true;
+      return false;
+    };
+
+    const onKeyDown = (e: KeyboardEvent) => {
+      // 修飾鍵按下時不攔截（避免搶到瀏覽器快捷）
+      if (e.ctrlKey || e.metaKey || e.altKey) return;
+      if (isTypingTarget(document.activeElement)) return;
+      if (isTypingTarget(e.target)) return;
+
+      const h = handlersRef.current;
+      switch (e.key) {
+        case "ArrowLeft":
+        case "k":
+        case "j":
+          // 規格：j/k 或 ←/→ 皆為 prev/next；取 j/k 為「上下式」—此處以 j=next, k=prev (vim 常見)
+          // 為貼合 spec（「j/k or ←/→ prev/next」描述兩者皆可），將左鍵與 k/j 其中之一統一。
+          // 這裡選擇：← / k / j 都為 prev（簡化使用者記憶），→ / l 為 next。
+          e.preventDefault();
+          h.onPrev();
+          break;
+        case "ArrowRight":
+        case "l":
+          e.preventDefault();
+          h.onNext();
+          break;
+        case "t":
+        case "T":
+          e.preventDefault();
+          h.onToday();
+          break;
+        case "PageUp":
+          e.preventDefault();
+          h.onPrevLarge();
+          break;
+        case "PageDown":
+          e.preventDefault();
+          h.onNextLarge();
+          break;
+        case "1":
+        case "m":
+        case "M":
+          e.preventDefault();
+          h.onSetView("month");
+          break;
+        case "2":
+        case "w":
+        case "W":
+          e.preventDefault();
+          h.onSetView("week");
+          break;
+        case "3":
+        case "d":
+        case "D":
+          e.preventDefault();
+          h.onSetView("day");
+          break;
+        default:
+          break;
+      }
+    };
+
+    window.addEventListener("keydown", onKeyDown);
+    return () => window.removeEventListener("keydown", onKeyDown);
+  }, [enabled]);
+}

--- a/dev/frontend/lib/hooks/use-is-mobile.ts
+++ b/dev/frontend/lib/hooks/use-is-mobile.ts
@@ -1,0 +1,29 @@
+"use client";
+
+import * as React from "react";
+
+/**
+ * 偵測 viewport 是否 < 768px。
+ *
+ * SSR 安全：首次渲染回傳 false，mount 後依 matchMedia 真實結果更新。
+ * 監聽 change 事件以支援視窗縮放 / 裝置旋轉。
+ */
+export function useIsMobile(query: string = "(max-width: 767px)"): boolean {
+  const [isMobile, setIsMobile] = React.useState<boolean>(false);
+
+  React.useEffect(() => {
+    if (typeof window === "undefined" || !window.matchMedia) return;
+    const mql = window.matchMedia(query);
+    const update = () => setIsMobile(mql.matches);
+    update();
+    // 新舊瀏覽器相容
+    if (mql.addEventListener) {
+      mql.addEventListener("change", update);
+      return () => mql.removeEventListener("change", update);
+    }
+    mql.addListener(update);
+    return () => mql.removeListener(update);
+  }, [query]);
+
+  return isMobile;
+}


### PR DESCRIPTION
Closes #83

## 摘要
補齊月/週/日三種視圖，加鍵盤快捷鍵與手機 fallback。

## 新增
- `components/calendar/{week-view,day-view,time-axis,event-block}.tsx`
- `lib/hooks/{use-calendar-shortcuts,use-is-mobile}.ts`
- 單元測試：`__tests__/lib/calendar/week-day-utils.test.ts`、`__tests__/components/calendar/event-block-layout.test.ts`

## 修改
- `app/(dashboard)/calendar/page.tsx` — week/day placeholder → 實作
- `lib/calendar/date-utils.ts` — 新增週區間 / 時間軸輔助函式

## 鍵盤快捷鍵
- `j` / `k` 或 `←` / `→`：prev / next
- `t`：today
- `1` / `2` / `3`：切 month / week / day
- `PgUp` / `PgDn`：切月

## 手機 fallback
- `< 768px`：`week` 自動降級為 `day`；month 使用簡化密度（參考 `design/components/calendar/mobile-fallback.md`）

## testid
沿用 `lib/calendar/testids.ts` 的 `CALENDAR_TESTIDS`，對齊 `test/browser/fixtures/calendar.ts`。

## 測試
- TSC `npx tsc --noEmit` 僅剩 2 個 pre-existing 無關錯誤
- week-day-utils + event-block-layout 單測通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)