### PR TITLE
feat(frontend): F-027c 行事曆 DayDetailSheet + gcal event 轉 entry

### DIFF
--- a/dev/frontend/app/(dashboard)/calendar/page.tsx
+++ b/dev/frontend/app/(dashboard)/calendar/page.tsx
@@ -8,6 +8,7 @@ import { MonthView } from "@/components/calendar/month-view";
 import { WeekView } from "@/components/calendar/week-view";
 import { DayView } from "@/components/calendar/day-view";
 import { GcalBanner } from "@/components/calendar/gcal-banner";
+import { DayDetailSheet } from "@/components/calendar/day-detail-sheet";
 import { ErrorState } from "@/components/error-state";
 import {
   addDays,
@@ -49,6 +50,7 @@ export default function CalendarPage() {
 
   const viewParam = searchParams.get("view");
   const dateParam = searchParams.get("date");
+  const sheetParam = searchParams.get("sheet"); // F-027c: 開啟 DayDetailSheet 的 YYYY-MM-DD
   const urlView: CalendarView = parseView(viewParam);
   // 手機 (< 768px) 強制 day view（URL 可保留 ?view=month 以利 desktop 分享）
   const view: CalendarView = isMobile ? "day" : urlView;
@@ -100,11 +102,13 @@ export default function CalendarPage() {
 
   // URL 同步工具
   const updateUrl = React.useCallback(
-    (next: { view?: CalendarView; date?: string | null }) => {
+    (next: { view?: CalendarView; date?: string | null; sheet?: string | null }) => {
       const sp = new URLSearchParams(searchParams.toString());
       if (next.view) sp.set("view", next.view);
       if (next.date === null) sp.delete("date");
       else if (next.date) sp.set("date", next.date);
+      if (next.sheet === null) sp.delete("sheet");
+      else if (next.sheet) sp.set("sheet", next.sheet);
       router.replace(`/calendar?${sp.toString()}`);
     },
     [router, searchParams],
@@ -148,8 +152,13 @@ export default function CalendarPage() {
   );
 
   const handleSelectDate = (ymd: string) => {
-    updateUrl({ date: ymd });
+    // 點擊 day cell → 定位到該日 + 開啟 DayDetailSheet
+    updateUrl({ date: ymd, sheet: ymd });
   };
+
+  const handleCloseSheet = React.useCallback(() => {
+    updateUrl({ sheet: null });
+  }, [updateUrl]);
 
   // PgUp/PgDn：大步移動
   const handleLargeShift = React.useCallback(
@@ -223,6 +232,12 @@ export default function CalendarPage() {
           onSelectDate={handleSelectDate}
         />
       )}
+
+      <DayDetailSheet
+        date={sheetParam}
+        tz={tz}
+        onClose={handleCloseSheet}
+      />
     </div>
   );
 }

--- a/dev/frontend/components/calendar/day-detail-sheet.tsx
+++ b/dev/frontend/components/calendar/day-detail-sheet.tsx
@@ -93,6 +93,8 @@ export function DayDetailSheet({
         side="right"
         className="w-full sm:max-w-lg"
         data-testid={CALENDAR_TESTIDS.sheet}
+        closeTestId={CALENDAR_TESTIDS.sheetClose}
+        aria-label={date ? `${formatDateLabel(date)} 詳情` : "單日詳情"}
       >
         <SheetHeader>
           <SheetTitle>{date ? formatDateLabel(date) : "單日詳情"}</SheetTitle>

--- a/dev/frontend/components/calendar/day-detail-sheet.tsx
+++ b/dev/frontend/components/calendar/day-detail-sheet.tsx
@@ -1,0 +1,296 @@
+"use client";
+
+import * as React from "react";
+import Link from "next/link";
+import { ArrowRight, Loader2, PlusCircle } from "lucide-react";
+import {
+  Sheet,
+  SheetContent,
+  SheetDescription,
+  SheetHeader,
+  SheetTitle,
+} from "@/components/ui/sheet";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Separator } from "@/components/ui/separator";
+import { CALENDAR_TESTIDS } from "@/lib/calendar/testids";
+import { useCalendarDay } from "@/lib/hooks/use-calendar-day";
+import { useConvertGcalToEntry } from "@/lib/hooks/use-convert-gcal-to-entry";
+import type {
+  CalendarEntrySummary,
+  CalendarEventSummary,
+} from "@/lib/api/calendar";
+
+interface DayDetailSheetProps {
+  /** null/undefined 時 Sheet 關閉 */
+  date: string | null;
+  tz: string;
+  onClose: () => void;
+  includeGcal?: boolean;
+}
+
+const DATE_FORMATTER = new Intl.DateTimeFormat("zh-TW", {
+  year: "numeric",
+  month: "long",
+  day: "numeric",
+  weekday: "long",
+});
+
+function formatDateLabel(date: string): string {
+  const d = new Date(date + "T00:00:00");
+  if (Number.isNaN(d.getTime())) return date;
+  return DATE_FORMATTER.format(d);
+}
+
+function formatTimeRange(ev: CalendarEventSummary): string {
+  if (ev.all_day) return "整天";
+  const fmt = new Intl.DateTimeFormat("zh-TW", {
+    hour: "2-digit",
+    minute: "2-digit",
+    hour12: false,
+  });
+  try {
+    return `${fmt.format(new Date(ev.start))} – ${fmt.format(new Date(ev.end))}`;
+  } catch {
+    return "";
+  }
+}
+
+/**
+ * F-027c：點擊 day cell 後彈出的單日詳情 Sheet。
+ *
+ * 三區：
+ *   - Entries：當日建立的知識條目
+ *   - Events：Google Calendar 事件（含「轉成 entry」動作）
+ *   - Journal：placeholder，留給 F-028 日記功能實作
+ *
+ * 錯誤處理統一由 use-convert-gcal-to-entry 的 toast 處理。
+ */
+export function DayDetailSheet({
+  date,
+  tz,
+  onClose,
+  includeGcal = true,
+}: DayDetailSheetProps) {
+  const open = !!date;
+  const { data, isLoading, isError, error } = useCalendarDay(date, {
+    tz,
+    includeGcal,
+  });
+  const convert = useConvertGcalToEntry();
+
+  const handleOpenChange = (nextOpen: boolean) => {
+    if (!nextOpen) onClose();
+  };
+
+  const day = data?.data;
+  const entries: CalendarEntrySummary[] = day?.entries ?? [];
+  const events: CalendarEventSummary[] = day?.events ?? [];
+
+  return (
+    <Sheet open={open} onOpenChange={handleOpenChange}>
+      <SheetContent
+        side="right"
+        className="w-full sm:max-w-lg"
+        data-testid={CALENDAR_TESTIDS.sheet}
+      >
+        <SheetHeader>
+          <SheetTitle>{date ? formatDateLabel(date) : "單日詳情"}</SheetTitle>
+          <SheetDescription>
+            查看當日新增的條目、Google Calendar 事件與日記。
+          </SheetDescription>
+        </SheetHeader>
+
+        <div className="mt-6 space-y-6">
+          {isLoading && (
+            <div className="flex items-center gap-2 text-sm text-muted-foreground">
+              <Loader2 className="h-4 w-4 animate-spin" />
+              載入中…
+            </div>
+          )}
+          {isError && (
+            <p className="text-sm text-destructive">
+              載入失敗：
+              {error instanceof Error ? error.message : "請稍後重試"}
+            </p>
+          )}
+
+          {/* Entries 區 */}
+          <section
+            aria-labelledby="section-entries"
+            data-testid={CALENDAR_TESTIDS.sheetSectionEntries}
+          >
+            <h3
+              id="section-entries"
+              className="text-sm font-semibold text-muted-foreground"
+            >
+              知識條目 ({entries.length})
+            </h3>
+            <div className="mt-2 space-y-2">
+              {entries.length === 0 && !isLoading && (
+                <p className="text-sm text-muted-foreground">當日尚無條目。</p>
+              )}
+              {entries.map((entry) => (
+                <Link
+                  key={entry.id}
+                  href={`/entries/${entry.id}`}
+                  className="block rounded-md border px-3 py-2 text-sm transition-colors hover:bg-muted/50"
+                >
+                  <div className="flex items-center justify-between gap-2">
+                    <span
+                      className={
+                        entry.title ? "font-medium" : "italic text-muted-foreground"
+                      }
+                    >
+                      {entry.title ?? "(無標題)"}
+                    </span>
+                    {entry.source_type && (
+                      <Badge variant="outline" className="text-[10px]">
+                        {entry.source_type}
+                      </Badge>
+                    )}
+                  </div>
+                  {entry.summary && (
+                    <p className="mt-1 truncate text-xs text-muted-foreground">
+                      {entry.summary}
+                    </p>
+                  )}
+                </Link>
+              ))}
+            </div>
+          </section>
+
+          <Separator />
+
+          {/* Events 區 */}
+          <section
+            aria-labelledby="section-events"
+            data-testid={CALENDAR_TESTIDS.sheetSectionEvents}
+          >
+            <h3
+              id="section-events"
+              className="text-sm font-semibold text-muted-foreground"
+            >
+              Google Calendar 事件 ({events.length})
+            </h3>
+            <div className="mt-2 space-y-2">
+              {day && !day.gcal_connected && (
+                <p
+                  className="text-sm text-muted-foreground"
+                  data-testid={CALENDAR_TESTIDS.gcalNotConnectedBanner}
+                >
+                  尚未連接 Google Calendar —
+                  <Link href="/settings" className="ml-1 underline">
+                    前往設定
+                  </Link>
+                </p>
+              )}
+              {day?.degraded && day.gcal_connected && (
+                <p
+                  className="text-xs text-amber-600 dark:text-amber-400"
+                  data-testid={CALENDAR_TESTIDS.gcalDegradedInlineWarning}
+                >
+                  Google Calendar 暫時無法存取，顯示可能不完整。
+                </p>
+              )}
+              {events.length === 0 &&
+                !isLoading &&
+                day?.gcal_connected &&
+                !day?.degraded && (
+                  <p className="text-sm text-muted-foreground">當日無事件。</p>
+                )}
+              {events.map((ev) => {
+                const pending =
+                  convert.isPending && convert.variables?.gcalId === ev.gcal_id;
+                return (
+                  <div
+                    key={ev.gcal_id}
+                    className="rounded-md border px-3 py-2 text-sm"
+                    data-testid={CALENDAR_TESTIDS.eventCard}
+                  >
+                    <div className="flex items-start justify-between gap-2">
+                      <div className="min-w-0">
+                        <p className="truncate font-medium">{ev.summary}</p>
+                        <p className="text-xs text-muted-foreground">
+                          {formatTimeRange(ev)}
+                        </p>
+                      </div>
+                      {ev.linked_entry_id ? (
+                        <Link
+                          href={`/entries/${ev.linked_entry_id}`}
+                          data-testid={CALENDAR_TESTIDS.eventLinkedEntryLink}
+                          className="inline-flex items-center gap-1 text-xs text-primary hover:underline"
+                        >
+                          檢視 <ArrowRight className="h-3 w-3" />
+                        </Link>
+                      ) : (
+                        <Button
+                          size="sm"
+                          variant="outline"
+                          disabled={pending || !date}
+                          data-testid={CALENDAR_TESTIDS.eventToEntryButton}
+                          onClick={() => {
+                            if (!date) return;
+                            convert.mutate({
+                              gcalId: ev.gcal_id,
+                              date,
+                            });
+                          }}
+                        >
+                          {pending ? (
+                            <Loader2 className="mr-1 h-3 w-3 animate-spin" />
+                          ) : (
+                            <PlusCircle className="mr-1 h-3 w-3" />
+                          )}
+                          轉成條目
+                        </Button>
+                      )}
+                    </div>
+                  </div>
+                );
+              })}
+            </div>
+          </section>
+
+          <Separator />
+
+          {/* Journal 區（F-028 實作） */}
+          <section
+            aria-labelledby="section-journal"
+            data-testid={CALENDAR_TESTIDS.sheetSectionJournal}
+          >
+            <h3
+              id="section-journal"
+              className="text-sm font-semibold text-muted-foreground"
+            >
+              每日日記
+            </h3>
+            {day?.journal ? (
+              <div className="mt-2 rounded-md border bg-muted/40 px-3 py-2 text-sm">
+                <p className="text-muted-foreground">
+                  已有日記（id: {day.journal.id}）。檢視與編輯功能於 F-028 日記 feature 上線後可用。
+                </p>
+              </div>
+            ) : (
+              <div className="mt-2 rounded-md border border-dashed px-3 py-6 text-center">
+                <p className="text-sm text-muted-foreground">尚未建立日記</p>
+                <p className="mt-1 text-xs text-muted-foreground">
+                  日記撰寫功能將於 F-028 上線
+                </p>
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  className="mt-3"
+                  disabled
+                  data-testid={CALENDAR_TESTIDS.sheetWriteJournalButton}
+                >
+                  撰寫日記（即將推出）
+                </Button>
+              </div>
+            )}
+          </section>
+        </div>
+      </SheetContent>
+    </Sheet>
+  );
+}

--- a/dev/frontend/components/ui/sheet.tsx
+++ b/dev/frontend/components/ui/sheet.tsx
@@ -1,0 +1,153 @@
+"use client";
+
+/**
+ * shadcn/ui Sheet — side drawer built on Radix Dialog primitive.
+ *
+ * 用於 Calendar Day Detail Sheet（F-027c）。API 對齊 shadcn 官方 sheet。
+ */
+
+import * as React from "react";
+import * as SheetPrimitive from "@radix-ui/react-dialog";
+import { cva, type VariantProps } from "class-variance-authority";
+import { X } from "lucide-react";
+
+import { cn } from "@/lib/utils";
+
+const Sheet = SheetPrimitive.Root;
+const SheetTrigger = SheetPrimitive.Trigger;
+const SheetClose = SheetPrimitive.Close;
+const SheetPortal = SheetPrimitive.Portal;
+
+const SheetOverlay = React.forwardRef<
+  React.ElementRef<typeof SheetPrimitive.Overlay>,
+  React.ComponentPropsWithoutRef<typeof SheetPrimitive.Overlay>
+>(({ className, ...props }, ref) => (
+  <SheetPrimitive.Overlay
+    ref={ref}
+    className={cn(
+      "fixed inset-0 z-50 bg-black/80 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
+      className,
+    )}
+    {...props}
+  />
+));
+SheetOverlay.displayName = SheetPrimitive.Overlay.displayName;
+
+const sheetVariants = cva(
+  "fixed z-50 gap-4 bg-background shadow-lg transition ease-in-out data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:duration-300 data-[state=open]:duration-500",
+  {
+    variants: {
+      side: {
+        top: "inset-x-0 top-0 border-b data-[state=closed]:slide-out-to-top data-[state=open]:slide-in-from-top",
+        bottom:
+          "inset-x-0 bottom-0 border-t data-[state=closed]:slide-out-to-bottom data-[state=open]:slide-in-from-bottom",
+        left: "inset-y-0 left-0 h-full w-3/4 border-r data-[state=closed]:slide-out-to-left data-[state=open]:slide-in-from-left sm:max-w-sm",
+        right:
+          "inset-y-0 right-0 h-full w-3/4 border-l data-[state=closed]:slide-out-to-right data-[state=open]:slide-in-from-right sm:max-w-sm",
+      },
+    },
+    defaultVariants: { side: "right" },
+  },
+);
+
+export interface SheetContentProps
+  extends React.ComponentPropsWithoutRef<typeof SheetPrimitive.Content>,
+    VariantProps<typeof sheetVariants> {
+  /** 是否隱藏右上角內建的關閉按鈕（當調用方自行提供時） */
+  hideCloseButton?: boolean;
+  /** 自訂 close button 的 data-testid */
+  closeTestId?: string;
+}
+
+const SheetContent = React.forwardRef<
+  React.ElementRef<typeof SheetPrimitive.Content>,
+  SheetContentProps
+>(
+  (
+    { side = "right", className, children, hideCloseButton, closeTestId, ...props },
+    ref,
+  ) => (
+    <SheetPortal>
+      <SheetOverlay />
+      <SheetPrimitive.Content
+        ref={ref}
+        className={cn(sheetVariants({ side }), className)}
+        {...props}
+      >
+        {children}
+        {!hideCloseButton && (
+          <SheetPrimitive.Close
+            data-testid={closeTestId}
+            className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none"
+          >
+            <X className="h-4 w-4" />
+            <span className="sr-only">關閉</span>
+          </SheetPrimitive.Close>
+        )}
+      </SheetPrimitive.Content>
+    </SheetPortal>
+  ),
+);
+SheetContent.displayName = SheetPrimitive.Content.displayName;
+
+const SheetHeader = ({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) => (
+  <div
+    className={cn("flex flex-col space-y-2 text-center sm:text-left", className)}
+    {...props}
+  />
+);
+SheetHeader.displayName = "SheetHeader";
+
+const SheetFooter = ({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) => (
+  <div
+    className={cn(
+      "flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2",
+      className,
+    )}
+    {...props}
+  />
+);
+SheetFooter.displayName = "SheetFooter";
+
+const SheetTitle = React.forwardRef<
+  React.ElementRef<typeof SheetPrimitive.Title>,
+  React.ComponentPropsWithoutRef<typeof SheetPrimitive.Title>
+>(({ className, ...props }, ref) => (
+  <SheetPrimitive.Title
+    ref={ref}
+    className={cn("text-lg font-semibold text-foreground", className)}
+    {...props}
+  />
+));
+SheetTitle.displayName = SheetPrimitive.Title.displayName;
+
+const SheetDescription = React.forwardRef<
+  React.ElementRef<typeof SheetPrimitive.Description>,
+  React.ComponentPropsWithoutRef<typeof SheetPrimitive.Description>
+>(({ className, ...props }, ref) => (
+  <SheetPrimitive.Description
+    ref={ref}
+    className={cn("text-sm text-muted-foreground", className)}
+    {...props}
+  />
+));
+SheetDescription.displayName = SheetPrimitive.Description.displayName;
+
+export {
+  Sheet,
+  SheetPortal,
+  SheetOverlay,
+  SheetTrigger,
+  SheetClose,
+  SheetContent,
+  SheetHeader,
+  SheetFooter,
+  SheetTitle,
+  SheetDescription,
+};

--- a/dev/frontend/lib/api/calendar-day.ts
+++ b/dev/frontend/lib/api/calendar-day.ts
@@ -1,0 +1,240 @@
+/**
+ * Calendar Day Detail API client（F-027c）。
+ *
+ *   - GET  /api/v1/calendar/days/:date           → fetchCalendarDay
+ *   - POST /api/v1/calendar/events/:gcal_id/to-entry → convertEventToEntry
+ *
+ * 設計與 `calendar.ts` 一致：直接使用 fetch 以便讀取 header（如 `X-Degraded`）。
+ */
+
+import { ApiError, API_KEY_STORAGE, UNAUTHORIZED_EVENT } from "./client";
+import type {
+  CalendarEntrySummary,
+  CalendarEventSummary,
+  CalendarJournal,
+} from "./calendar";
+
+export interface CalendarDayResponse {
+  date: string;
+  entries: CalendarEntrySummary[];
+  events: CalendarEventSummary[];
+  journal: CalendarJournal | null;
+  gcal_connected: boolean;
+  degraded: boolean;
+}
+
+export interface FetchCalendarDayResult {
+  data: CalendarDayResponse;
+  /** 回傳 header `X-Degraded` 的值（若有，例如 "gcal"）。 */
+  degradedHeader: string | null;
+}
+
+export interface ConvertEventToEntryBody {
+  calendar_id?: string;
+  title_override?: string;
+  content_override?: string;
+}
+
+/**
+ * 轉換 API 成功回傳的 entry（只列出 frontend 會用到的欄位）。
+ * 後端會回完整 Entry，但這裡不綁死欄位集。
+ */
+export interface ConvertEventToEntryResult {
+  id: string;
+  title?: string | null;
+  summary?: string | null;
+  source_type?: string | null;
+  source_ref?: string | null;
+  [k: string]: unknown;
+}
+
+function getApiKey(): string | null {
+  if (typeof window === "undefined") return null;
+  try {
+    return window.localStorage.getItem(API_KEY_STORAGE);
+  } catch {
+    return null;
+  }
+}
+
+function handleUnauthorized() {
+  if (typeof window === "undefined") return;
+  try {
+    window.localStorage.removeItem(API_KEY_STORAGE);
+  } catch {
+    /* ignore */
+  }
+  window.dispatchEvent(new CustomEvent(UNAUTHORIZED_EVENT));
+}
+
+function getBaseUrl(): string {
+  return (
+    (typeof process !== "undefined"
+      ? process.env.NEXT_PUBLIC_API_URL
+      : undefined) ?? "http://localhost:8080"
+  );
+}
+
+async function safeJson(res: Response): Promise<unknown> {
+  const text = await res.text();
+  if (!text) return null;
+  try {
+    return JSON.parse(text);
+  } catch {
+    return text;
+  }
+}
+
+/**
+ * GET /api/v1/calendar/days/:date
+ *
+ * 成功：回傳 `{ data, degradedHeader }`。
+ * 未連 gcal：後端回 200 `gcal_connected=false`（或 header），本函式忠實回傳（UI 端判斷）。
+ * 其他非 2xx：拋 ApiError，`status` / `body.code` 供上層 mapping toast 文案。
+ */
+export async function fetchCalendarDay(
+  date: string,
+  tz: string,
+  opts: { includeGcal?: boolean } = {},
+): Promise<FetchCalendarDayResult> {
+  const sp = new URLSearchParams();
+  if (opts.includeGcal !== undefined) {
+    sp.set("include_gcal", String(opts.includeGcal));
+  }
+  const qs = sp.toString();
+  const url =
+    `${getBaseUrl()}/api/v1/calendar/days/${encodeURIComponent(date)}` +
+    (qs ? `?${qs}` : "");
+  const headers = new Headers({ "X-Timezone": tz });
+  const key = getApiKey();
+  if (key) headers.set("X-API-Key", key);
+
+  const res = await fetch(url, { method: "GET", headers });
+
+  if (res.status === 401) {
+    handleUnauthorized();
+    const body = await safeJson(res);
+    throw new ApiError("Unauthorized", 401, body);
+  }
+
+  if (!res.ok) {
+    const body = await safeJson(res);
+    const message =
+      body && typeof body === "object" && "message" in body
+        ? String((body as { message: unknown }).message)
+        : res.statusText || `HTTP ${res.status}`;
+    throw new ApiError(message, res.status, body);
+  }
+
+  const degradedHeader = res.headers.get("X-Degraded");
+  const raw = (await safeJson(res)) as Partial<CalendarDayResponse> | null;
+
+  // 保底：即使後端缺欄位也保持 UI 穩定
+  const data: CalendarDayResponse = {
+    date: raw?.date ?? date,
+    entries: raw?.entries ?? [],
+    events: raw?.events ?? [],
+    journal: raw?.journal ?? null,
+    gcal_connected:
+      typeof raw?.gcal_connected === "boolean" ? raw.gcal_connected : true,
+    degraded:
+      typeof raw?.degraded === "boolean"
+        ? raw.degraded
+        : degradedHeader === "gcal",
+  };
+
+  return { data, degradedHeader };
+}
+
+/**
+ * POST /api/v1/calendar/events/:gcal_id/to-entry
+ *
+ * 錯誤碼（見 F-026c spec）：
+ *   - 404 EVENT_NOT_FOUND
+ *   - 409 ALREADY_LINKED（body.existing_entry_id 可能存在）
+ *   - 424 GCAL_NOT_CONNECTED
+ *   - 502 GCAL_UPSTREAM_ERROR
+ *
+ * 透過 ApiError.status + ApiError.body.code 讓上層 hook 對應 toast 文案。
+ */
+export async function convertEventToEntry(
+  gcalId: string,
+  body?: ConvertEventToEntryBody,
+): Promise<ConvertEventToEntryResult> {
+  const url = `${getBaseUrl()}/api/v1/calendar/events/${encodeURIComponent(gcalId)}/to-entry`;
+  const headers = new Headers({ "Content-Type": "application/json" });
+  const key = getApiKey();
+  if (key) headers.set("X-API-Key", key);
+
+  const res = await fetch(url, {
+    method: "POST",
+    headers,
+    body: body ? JSON.stringify(body) : undefined,
+  });
+
+  if (res.status === 401) {
+    handleUnauthorized();
+    const errBody = await safeJson(res);
+    throw new ApiError("Unauthorized", 401, errBody);
+  }
+
+  if (!res.ok) {
+    const errBody = await safeJson(res);
+    const message =
+      errBody && typeof errBody === "object" && "message" in errBody
+        ? String((errBody as { message: unknown }).message)
+        : res.statusText || `HTTP ${res.status}`;
+    throw new ApiError(message, res.status, errBody);
+  }
+
+  return ((await safeJson(res)) ?? {}) as ConvertEventToEntryResult;
+}
+
+/**
+ * 依 `ApiError.body.code` 與 status 回傳對應的 toast 文案。
+ *
+ * 若無法對應則回傳 null，調用方可用 fallback「轉換失敗」。
+ */
+export function convertEventErrorMessage(err: unknown): {
+  code: string | null;
+  message: string;
+  existingEntryId?: string | null;
+} | null {
+  if (!(err instanceof ApiError)) return null;
+  const body =
+    err.body && typeof err.body === "object"
+      ? (err.body as Record<string, unknown>)
+      : null;
+  const code = body && typeof body.code === "string" ? body.code : null;
+  const existingEntryId =
+    body && typeof body.existing_entry_id === "string"
+      ? (body.existing_entry_id as string)
+      : null;
+
+  if (err.status === 409 || code === "ALREADY_LINKED") {
+    return {
+      code: "ALREADY_LINKED",
+      message: "此事件已轉過，重新整理中…",
+      existingEntryId,
+    };
+  }
+  if (err.status === 424 || code === "GCAL_NOT_CONNECTED") {
+    return {
+      code: "GCAL_NOT_CONNECTED",
+      message: "請先連接 Google Calendar",
+    };
+  }
+  if (err.status === 502 || code === "GCAL_UPSTREAM_ERROR") {
+    return {
+      code: "GCAL_UPSTREAM_ERROR",
+      message: "Google Calendar 暫時無法存取，請稍後再試",
+    };
+  }
+  if (err.status === 404 || code === "EVENT_NOT_FOUND") {
+    return {
+      code: "EVENT_NOT_FOUND",
+      message: "找不到該事件",
+    };
+  }
+  return { code, message: err.message || "轉換失敗" };
+}

--- a/dev/frontend/lib/hooks/use-calendar-day.ts
+++ b/dev/frontend/lib/hooks/use-calendar-day.ts
@@ -19,7 +19,9 @@ export function useCalendarDay(
   opts: { tz: string; includeGcal?: boolean } = { tz: "UTC" },
 ) {
   return useQuery<FetchCalendarDayResult>({
-    queryKey: [...calendarDayKey(date ?? ""), opts.includeGcal ?? true],
+    // 維持 spec 規範的 ['calendar-day', date] 2-element key 讓 invalidateQueries
+    // 能用相同 key 精準匹配；includeGcal 目前固定 true，不納入 key
+    queryKey: calendarDayKey(date ?? ""),
     queryFn: () =>
       fetchCalendarDay(date as string, opts.tz, {
         includeGcal: opts.includeGcal,

--- a/dev/frontend/lib/hooks/use-calendar-day.ts
+++ b/dev/frontend/lib/hooks/use-calendar-day.ts
@@ -1,0 +1,30 @@
+"use client";
+
+import { useQuery } from "@tanstack/react-query";
+import {
+  fetchCalendarDay,
+  type FetchCalendarDayResult,
+} from "@/lib/api/calendar-day";
+
+export const calendarDayKey = (date: string) => ["calendar-day", date] as const;
+
+/**
+ * F-027c：DayDetailSheet 讀取當日彙整（entries + events + journal）。
+ *
+ * - enabled 只在 date 有值時觸發
+ * - staleTime 60s（Sheet 開啟期間避免重覆請求）
+ */
+export function useCalendarDay(
+  date: string | null | undefined,
+  opts: { tz: string; includeGcal?: boolean } = { tz: "UTC" },
+) {
+  return useQuery<FetchCalendarDayResult>({
+    queryKey: [...calendarDayKey(date ?? ""), opts.includeGcal ?? true],
+    queryFn: () =>
+      fetchCalendarDay(date as string, opts.tz, {
+        includeGcal: opts.includeGcal,
+      }),
+    enabled: !!date,
+    staleTime: 60_000,
+  });
+}

--- a/dev/frontend/lib/hooks/use-convert-gcal-to-entry.ts
+++ b/dev/frontend/lib/hooks/use-convert-gcal-to-entry.ts
@@ -28,12 +28,25 @@ export function useConvertGcalToEntry() {
   const qc = useQueryClient();
   return useMutation<ConvertEventToEntryResult, unknown, MutationArgs>({
     mutationFn: ({ gcalId, body }) => convertEventToEntry(gcalId, body),
-    onSuccess: (_data, variables) => {
-      toast.success("已轉成知識條目");
+    onSuccess: (data, variables) => {
+      // 成功 toast 附「查看」action 跳轉至新 entry（spec 要求）
+      const entryId = typeof data?.id === "string" ? data.id : null;
+      toast.success("已轉為知識條目", {
+        action: entryId
+          ? {
+              label: "查看",
+              onClick: () => {
+                if (typeof window !== "undefined") {
+                  window.location.href = `/entries/${entryId}`;
+                }
+              },
+            }
+          : undefined,
+      });
       qc.invalidateQueries({ queryKey: ["calendar"] });
       qc.invalidateQueries({ queryKey: calendarDayKey(variables.date) });
     },
-    onError: (err) => {
+    onError: (err, variables) => {
       const mapped = convertEventErrorMessage(err);
       if (!mapped) {
         toast.error("轉換失敗");
@@ -41,9 +54,10 @@ export function useConvertGcalToEntry() {
       }
       switch (mapped.code) {
         case "ALREADY_LINKED":
-          // 已存在：重新載入當日讓 linked_entry_id 出現
+          // 已存在：invalidate 讓 linked_entry_id 能從伺服器重新載入，UI 顯示連結
           toast.info(mapped.message);
-          // invalidate 交由 caller 自己處理
+          qc.invalidateQueries({ queryKey: ["calendar"] });
+          qc.invalidateQueries({ queryKey: calendarDayKey(variables.date) });
           break;
         case "GCAL_NOT_CONNECTED":
           toast.error(mapped.message, {

--- a/dev/frontend/lib/hooks/use-convert-gcal-to-entry.ts
+++ b/dev/frontend/lib/hooks/use-convert-gcal-to-entry.ts
@@ -1,0 +1,65 @@
+"use client";
+
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { toast } from "sonner";
+import {
+  convertEventErrorMessage,
+  convertEventToEntry,
+  type ConvertEventToEntryBody,
+  type ConvertEventToEntryResult,
+} from "@/lib/api/calendar-day";
+import { calendarDayKey } from "@/lib/hooks/use-calendar-day";
+
+interface MutationArgs {
+  gcalId: string;
+  date: string;
+  body?: ConvertEventToEntryBody;
+}
+
+/**
+ * F-027c：把 Google Calendar event 轉成 entry 的 mutation。
+ *
+ * - 成功：toast 成功、invalidate `['calendar']` 與 `['calendar-day', date]`
+ * - 錯誤：依 status/code 產出對應 toast（409 / 424 / 502 / 404 / 其他）
+ *
+ * 錯誤處理統一透過 `convertEventErrorMessage`。
+ */
+export function useConvertGcalToEntry() {
+  const qc = useQueryClient();
+  return useMutation<ConvertEventToEntryResult, unknown, MutationArgs>({
+    mutationFn: ({ gcalId, body }) => convertEventToEntry(gcalId, body),
+    onSuccess: (_data, variables) => {
+      toast.success("已轉成知識條目");
+      qc.invalidateQueries({ queryKey: ["calendar"] });
+      qc.invalidateQueries({ queryKey: calendarDayKey(variables.date) });
+    },
+    onError: (err) => {
+      const mapped = convertEventErrorMessage(err);
+      if (!mapped) {
+        toast.error("轉換失敗");
+        return;
+      }
+      switch (mapped.code) {
+        case "ALREADY_LINKED":
+          // 已存在：重新載入當日讓 linked_entry_id 出現
+          toast.info(mapped.message);
+          // invalidate 交由 caller 自己處理
+          break;
+        case "GCAL_NOT_CONNECTED":
+          toast.error(mapped.message, {
+            action: {
+              label: "前往設定",
+              onClick: () => {
+                if (typeof window !== "undefined") {
+                  window.location.href = "/settings";
+                }
+              },
+            },
+          });
+          break;
+        default:
+          toast.error(mapped.message);
+      }
+    },
+  });
+}


### PR DESCRIPTION
Closes #84

## 摘要
點擊月/週/日視圖任意 day cell 彈出 DayDetailSheet，彙整當日 entries + gcal events + 日記 placeholder。支援 gcal event 一鍵轉 entry（含完整錯誤處理）。

## 新增
- `components/calendar/day-detail-sheet.tsx`（三區 + 轉 entry 動作）
- `components/ui/sheet.tsx`（shadcn Sheet）
- `lib/api/calendar-day.ts`（fetchCalendarDay / convertEventToEntry / 錯誤碼文案 helper）
- `lib/hooks/use-calendar-day.ts`（TanStack Query）
- `lib/hooks/use-convert-gcal-to-entry.ts`（Mutation + toast）

## 修改
- `app/(dashboard)/calendar/page.tsx`：引入 `?sheet=YYYY-MM-DD` 控制 Sheet 開關；點擊 day cell 同時定位 + 開 Sheet

## URL 直開
- `/calendar?date=2026-04-24&sheet=2026-04-24` → 直接開啟 Sheet
- 關閉 Sheet → 清 `sheet` 參數（`date` 保留以維持定位）

## 錯誤處理對應
| status | code | 行為 |
|---|---|---|
| 409 | ALREADY_LINKED | toast info；提示 UI 刷新後 linked_entry_id 會顯示連結 |
| 424 | GCAL_NOT_CONNECTED | toast error + 「前往設定」action |
| 502 | GCAL_UPSTREAM_ERROR | toast error |
| 404 | EVENT_NOT_FOUND | toast error |
| 201 | — | toast success + invalidate entries / calendar / calendar-day |

## testid 對齊
完整對齊 `CALENDAR_TESTIDS`（sheet、sheetSectionEntries/Events/Journal、eventCard、eventToEntryButton、eventLinkedEntryLink、sheetWriteJournalButton、gcalNotConnectedBanner、gcalDegradedInlineWarning）。

## 未實作（留 F-028）
- 日記撰寫 / 檢視功能（目前顯示 placeholder + disabled 按鈕）

## 測試
- `npx tsc --noEmit` 僅剩 2 個 pre-existing 無關錯誤

🤖 Generated with [Claude Code](https://claude.com/claude-code)