### PR TITLE
feat(gcal): F-030a migration 014 + repository 擴充

### DIFF
--- a/dev/src/migration/014_extend_gcal_integrations.down.sql
+++ b/dev/src/migration/014_extend_gcal_integrations.down.sql
@@ -1,0 +1,4 @@
+-- F-030a: 回滾 014_extend_gcal_integrations
+ALTER TABLE gcal_integrations
+  DROP COLUMN IF EXISTS access_token_expires_at,
+  DROP COLUMN IF EXISTS default_calendar_id;

--- a/dev/src/migration/014_extend_gcal_integrations.up.sql
+++ b/dev/src/migration/014_extend_gcal_integrations.up.sql
@@ -1,0 +1,11 @@
+-- F-030a: 擴充 gcal_integrations，加入 default_calendar_id 與 access_token_expires_at
+-- default_calendar_id: 使用者選定的預設日曆（events / calendar 強化用）
+-- access_token_expires_at: 新欄位，與既有 token_expiry 雙寫，供 token refresh 後的狀態查詢
+ALTER TABLE gcal_integrations
+  ADD COLUMN IF NOT EXISTS default_calendar_id TEXT NOT NULL DEFAULT 'primary',
+  ADD COLUMN IF NOT EXISTS access_token_expires_at TIMESTAMPTZ;
+
+-- backfill 既有資料：將 token_expiry 複製到 access_token_expires_at
+UPDATE gcal_integrations
+SET access_token_expires_at = token_expiry
+WHERE access_token_expires_at IS NULL;

--- a/dev/src/model/gcal_integration.go
+++ b/dev/src/model/gcal_integration.go
@@ -15,6 +15,11 @@ type GcalIntegration struct {
 	AccessToken  string    `json:"access_token"`  // AES-256 加密儲存
 	RefreshToken string    `json:"refresh_token"` // AES-256 加密儲存
 	TokenExpiry  time.Time `json:"token_expiry"`
-	CreatedAt    time.Time `json:"created_at"`
-	UpdatedAt    time.Time `json:"updated_at"`
+	// DefaultCalendarID 使用者選定的預設日曆（F-030 強化用）。Migration 014 起新增，預設 "primary"。
+	DefaultCalendarID string `json:"default_calendar_id"`
+	// AccessTokenExpiresAt 新版 access token 過期時間（F-030 強化用）。
+	// 與既有 TokenExpiry 欄位雙寫，便於後續逐步淘汰舊欄位；既有資料以 backfill 補齊。
+	AccessTokenExpiresAt *time.Time `json:"access_token_expires_at,omitempty"`
+	CreatedAt            time.Time  `json:"created_at"`
+	UpdatedAt            time.Time  `json:"updated_at"`
 }

--- a/dev/src/repository/gcal_integration.go
+++ b/dev/src/repository/gcal_integration.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/gpwork4u/aibo/model"
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
@@ -24,14 +25,17 @@ func NewGcalIntegrationRepository(pool *pgxpool.Pool) *GcalIntegrationRepository
 func (r *GcalIntegrationRepository) Get(ctx context.Context) (*model.GcalIntegration, error) {
 	integration := &model.GcalIntegration{}
 	err := r.pool.QueryRow(ctx,
-		`SELECT id, email, client_id, client_secret, access_token, refresh_token, token_expiry, created_at, updated_at
+		`SELECT id, email, client_id, client_secret, access_token, refresh_token,
+		        token_expiry, default_calendar_id, access_token_expires_at,
+		        created_at, updated_at
 		 FROM gcal_integrations
 		 ORDER BY created_at DESC
 		 LIMIT 1`,
 	).Scan(
 		&integration.ID, &integration.Email, &integration.ClientID,
 		&integration.ClientSecret, &integration.AccessToken, &integration.RefreshToken,
-		&integration.TokenExpiry, &integration.CreatedAt, &integration.UpdatedAt,
+		&integration.TokenExpiry, &integration.DefaultCalendarID, &integration.AccessTokenExpiresAt,
+		&integration.CreatedAt, &integration.UpdatedAt,
 	)
 	if errors.Is(err, pgx.ErrNoRows) {
 		return nil, nil
@@ -42,7 +46,11 @@ func (r *GcalIntegrationRepository) Get(ctx context.Context) (*model.GcalIntegra
 	return integration, nil
 }
 
-// Upsert 建立或更新 GcalIntegration（刪除舊的，插入新的）
+// Upsert 建立或更新 GcalIntegration（刪除舊的，插入新的）。
+//
+// 為了讓使用者重新 OAuth 後不會遺失既有的 default_calendar_id 設定，
+// 在刪除既有紀錄前會先讀取舊的 default_calendar_id；若新進來的 integration
+// 仍是預設值 "primary" 而舊紀錄有自訂值，則繼承舊值。
 func (r *GcalIntegrationRepository) Upsert(ctx context.Context, integration *model.GcalIntegration) error {
 	tx, err := r.pool.Begin(ctx)
 	if err != nil {
@@ -50,19 +58,47 @@ func (r *GcalIntegrationRepository) Upsert(ctx context.Context, integration *mod
 	}
 	defer tx.Rollback(ctx)
 
-	// 刪除所有現有記錄（只支援一組）
-	_, err = tx.Exec(ctx, `DELETE FROM gcal_integrations`)
-	if err != nil {
+	// 讀舊紀錄的 default_calendar_id 以便繼承
+	var oldDefault string
+	err = tx.QueryRow(ctx,
+		`SELECT default_calendar_id FROM gcal_integrations ORDER BY created_at DESC LIMIT 1`,
+	).Scan(&oldDefault)
+	if err != nil && !errors.Is(err, pgx.ErrNoRows) {
 		return err
+	}
+
+	// 若呼叫端未指定 default_calendar_id，補上預設
+	if integration.DefaultCalendarID == "" {
+		integration.DefaultCalendarID = "primary"
+	}
+	// 若新值仍是預設 primary 但舊紀錄有自訂值，則繼承
+	if integration.DefaultCalendarID == "primary" && oldDefault != "" && oldDefault != "primary" {
+		integration.DefaultCalendarID = oldDefault
+	}
+
+	// 刪除所有現有記錄（只支援一組）
+	if _, err := tx.Exec(ctx, `DELETE FROM gcal_integrations`); err != nil {
+		return err
+	}
+
+	// access_token_expires_at 若呼叫端未提供，雙寫 token_expiry
+	expiresAt := integration.AccessTokenExpiresAt
+	if expiresAt == nil {
+		te := integration.TokenExpiry
+		expiresAt = &te
 	}
 
 	// 插入新記錄
 	_, err = tx.Exec(ctx,
-		`INSERT INTO gcal_integrations (id, email, client_id, client_secret, access_token, refresh_token, token_expiry, created_at, updated_at)
-		 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)`,
+		`INSERT INTO gcal_integrations
+		   (id, email, client_id, client_secret, access_token, refresh_token,
+		    token_expiry, default_calendar_id, access_token_expires_at,
+		    created_at, updated_at)
+		 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)`,
 		integration.ID, integration.Email, integration.ClientID,
 		integration.ClientSecret, integration.AccessToken, integration.RefreshToken,
-		integration.TokenExpiry, integration.CreatedAt, integration.UpdatedAt,
+		integration.TokenExpiry, integration.DefaultCalendarID, expiresAt,
+		integration.CreatedAt, integration.UpdatedAt,
 	)
 	if err != nil {
 		return err
@@ -71,14 +107,43 @@ func (r *GcalIntegrationRepository) Upsert(ctx context.Context, integration *mod
 	return tx.Commit(ctx)
 }
 
-// UpdateTokens 更新 access_token 和 refresh_token
+// UpdateTokens 更新 access_token / refresh_token / 過期時間。
+// 同時雙寫到 token_expiry（既有欄位）與 access_token_expires_at（F-030 新欄位）。
+//
+// 為向後相容既有呼叫，id 與 expiry 維持 interface{} 型別。
 func (r *GcalIntegrationRepository) UpdateTokens(ctx context.Context, id interface{}, accessToken, refreshToken string, expiry interface{}) error {
 	_, err := r.pool.Exec(ctx,
 		`UPDATE gcal_integrations
-		 SET access_token = $1, refresh_token = $2, token_expiry = $3, updated_at = NOW()
+		 SET access_token = $1,
+		     refresh_token = $2,
+		     token_expiry = $3,
+		     access_token_expires_at = $3,
+		     updated_at = NOW()
 		 WHERE id = $4`,
 		accessToken, refreshToken, expiry, id,
 	)
+	return err
+}
+
+// UpdateDefaultCalendarID 更新預設日曆 ID（PUT /api/v1/integrations/gcal/settings 使用）
+func (r *GcalIntegrationRepository) UpdateDefaultCalendarID(ctx context.Context, id uuid.UUID, calendarID string) error {
+	if calendarID == "" {
+		calendarID = "primary"
+	}
+	_, err := r.pool.Exec(ctx,
+		`UPDATE gcal_integrations
+		 SET default_calendar_id = $1,
+		     updated_at = NOW()
+		 WHERE id = $2`,
+		calendarID, id,
+	)
+	return err
+}
+
+// DeleteAll 清空所有 GcalIntegration 紀錄（DELETE /api/v1/integrations/gcal 使用）。
+// 因為系統只允許單一組整合，這等同於「中斷連線」。
+func (r *GcalIntegrationRepository) DeleteAll(ctx context.Context) error {
+	_, err := r.pool.Exec(ctx, `DELETE FROM gcal_integrations`)
 	return err
 }
 

--- a/dev/src/repository/gcal_integration_test.go
+++ b/dev/src/repository/gcal_integration_test.go
@@ -1,0 +1,221 @@
+package repository
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/gpwork4u/aibo/model"
+)
+
+// withGcalTestDB 取得測試 DB pool 並清空 gcal_integrations 表。
+// 使用與 entry_calendar_test.go 同樣的 TEST_DATABASE_URL 安全防護機制。
+func withGcalTestDB(t *testing.T) (*GcalIntegrationRepository, func()) {
+	t.Helper()
+	pool := withTestDB(t)
+	if _, err := pool.Exec(context.Background(), "DELETE FROM gcal_integrations"); err != nil {
+		pool.Close()
+		t.Fatalf("清空 gcal_integrations 失敗: %v", err)
+	}
+	repo := NewGcalIntegrationRepository(pool)
+	return repo, func() { pool.Close() }
+}
+
+func newTestIntegration() *model.GcalIntegration {
+	now := time.Now().UTC().Truncate(time.Second)
+	expiry := now.Add(1 * time.Hour)
+	return &model.GcalIntegration{
+		ID:           uuid.New(),
+		Email:        "user@example.com",
+		ClientID:     "test-client-id",
+		ClientSecret: "enc-secret",
+		AccessToken:  "enc-access",
+		RefreshToken: "enc-refresh",
+		TokenExpiry:  expiry,
+		CreatedAt:    now,
+		UpdatedAt:    now,
+	}
+}
+
+// TestUpsert_DefaultsCalendarIDToPrimary 驗證 Upsert 時若未指定 default_calendar_id，使用預設 "primary"。
+func TestUpsert_DefaultsCalendarIDToPrimary(t *testing.T) {
+	repo, cleanup := withGcalTestDB(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	integ := newTestIntegration()
+	// 故意不設 DefaultCalendarID
+	if err := repo.Upsert(ctx, integ); err != nil {
+		t.Fatalf("Upsert: %v", err)
+	}
+
+	got, err := repo.Get(ctx)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if got == nil {
+		t.Fatal("expected integration, got nil")
+	}
+	if got.DefaultCalendarID != "primary" {
+		t.Errorf("DefaultCalendarID: expected 'primary', got %q", got.DefaultCalendarID)
+	}
+}
+
+// TestUpsert_DoubleWriteAccessTokenExpiresAt 驗證 Upsert 時 access_token_expires_at 雙寫。
+func TestUpsert_DoubleWriteAccessTokenExpiresAt(t *testing.T) {
+	repo, cleanup := withGcalTestDB(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	integ := newTestIntegration()
+	if err := repo.Upsert(ctx, integ); err != nil {
+		t.Fatalf("Upsert: %v", err)
+	}
+
+	got, err := repo.Get(ctx)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if got.AccessTokenExpiresAt == nil {
+		t.Fatal("AccessTokenExpiresAt should be backfilled from TokenExpiry")
+	}
+	if !got.AccessTokenExpiresAt.Equal(integ.TokenExpiry) {
+		t.Errorf("AccessTokenExpiresAt: expected %v, got %v", integ.TokenExpiry, *got.AccessTokenExpiresAt)
+	}
+}
+
+// TestUpsert_InheritsCustomCalendarID 驗證重新 OAuth 後，default_calendar_id 不會被重置。
+func TestUpsert_InheritsCustomCalendarID(t *testing.T) {
+	repo, cleanup := withGcalTestDB(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	first := newTestIntegration()
+	first.DefaultCalendarID = "work@group.calendar.google.com"
+	if err := repo.Upsert(ctx, first); err != nil {
+		t.Fatalf("first Upsert: %v", err)
+	}
+
+	// 模擬重新 OAuth：新 ID、未指定 default
+	second := newTestIntegration()
+	if err := repo.Upsert(ctx, second); err != nil {
+		t.Fatalf("second Upsert: %v", err)
+	}
+
+	got, err := repo.Get(ctx)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if got.DefaultCalendarID != "work@group.calendar.google.com" {
+		t.Errorf("DefaultCalendarID 應繼承舊值, got %q", got.DefaultCalendarID)
+	}
+}
+
+// TestUpdateDefaultCalendarID 驗證更新 default_calendar_id。
+func TestUpdateDefaultCalendarID(t *testing.T) {
+	repo, cleanup := withGcalTestDB(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	integ := newTestIntegration()
+	if err := repo.Upsert(ctx, integ); err != nil {
+		t.Fatalf("Upsert: %v", err)
+	}
+
+	newCal := "team@group.calendar.google.com"
+	if err := repo.UpdateDefaultCalendarID(ctx, integ.ID, newCal); err != nil {
+		t.Fatalf("UpdateDefaultCalendarID: %v", err)
+	}
+
+	got, err := repo.Get(ctx)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if got.DefaultCalendarID != newCal {
+		t.Errorf("DefaultCalendarID: expected %q, got %q", newCal, got.DefaultCalendarID)
+	}
+}
+
+// TestUpdateDefaultCalendarID_EmptyResetsToPrimary 驗證傳入空字串時重置為 "primary"。
+func TestUpdateDefaultCalendarID_EmptyResetsToPrimary(t *testing.T) {
+	repo, cleanup := withGcalTestDB(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	integ := newTestIntegration()
+	integ.DefaultCalendarID = "x@group.calendar.google.com"
+	if err := repo.Upsert(ctx, integ); err != nil {
+		t.Fatalf("Upsert: %v", err)
+	}
+
+	if err := repo.UpdateDefaultCalendarID(ctx, integ.ID, ""); err != nil {
+		t.Fatalf("UpdateDefaultCalendarID empty: %v", err)
+	}
+
+	got, err := repo.Get(ctx)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if got.DefaultCalendarID != "primary" {
+		t.Errorf("空字串應重置為 'primary'，got %q", got.DefaultCalendarID)
+	}
+}
+
+// TestDeleteAll 驗證 DeleteAll 清空所有紀錄。
+func TestDeleteAll(t *testing.T) {
+	repo, cleanup := withGcalTestDB(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	integ := newTestIntegration()
+	if err := repo.Upsert(ctx, integ); err != nil {
+		t.Fatalf("Upsert: %v", err)
+	}
+
+	if err := repo.DeleteAll(ctx); err != nil {
+		t.Fatalf("DeleteAll: %v", err)
+	}
+
+	got, err := repo.Get(ctx)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if got != nil {
+		t.Errorf("expected no integration after DeleteAll, got %+v", got)
+	}
+}
+
+// TestUpdateTokens_DoubleWrite 驗證 UpdateTokens 同時更新 token_expiry 與 access_token_expires_at。
+func TestUpdateTokens_DoubleWrite(t *testing.T) {
+	repo, cleanup := withGcalTestDB(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	integ := newTestIntegration()
+	if err := repo.Upsert(ctx, integ); err != nil {
+		t.Fatalf("Upsert: %v", err)
+	}
+
+	newExpiry := time.Now().UTC().Add(2 * time.Hour).Truncate(time.Second)
+	if err := repo.UpdateTokens(ctx, integ.ID, "new-access", "new-refresh", newExpiry); err != nil {
+		t.Fatalf("UpdateTokens: %v", err)
+	}
+
+	got, err := repo.Get(ctx)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if got.AccessToken != "new-access" {
+		t.Errorf("AccessToken: expected 'new-access', got %q", got.AccessToken)
+	}
+	if got.RefreshToken != "new-refresh" {
+		t.Errorf("RefreshToken: expected 'new-refresh', got %q", got.RefreshToken)
+	}
+	if !got.TokenExpiry.Equal(newExpiry) {
+		t.Errorf("TokenExpiry: expected %v, got %v", newExpiry, got.TokenExpiry)
+	}
+	if got.AccessTokenExpiresAt == nil || !got.AccessTokenExpiresAt.Equal(newExpiry) {
+		t.Errorf("AccessTokenExpiresAt 應同步更新為 %v，got %v", newExpiry, got.AccessTokenExpiresAt)
+	}
+}

--- a/dev/src/service/interfaces.go
+++ b/dev/src/service/interfaces.go
@@ -72,6 +72,8 @@ type GcalIntegrationRepository interface {
 	Get(ctx context.Context) (*model.GcalIntegration, error)
 	Upsert(ctx context.Context, integration *model.GcalIntegration) error
 	UpdateTokens(ctx context.Context, id interface{}, accessToken, refreshToken string, expiry interface{}) error
+	UpdateDefaultCalendarID(ctx context.Context, id uuid.UUID, calendarID string) error
+	DeleteAll(ctx context.Context) error
 	SaveOAuthState(ctx context.Context, state string) error
 	ValidateOAuthState(ctx context.Context, state string) (bool, error)
 	CleanExpiredOAuthStates(ctx context.Context) error


### PR DESCRIPTION
## Summary
F-030a Wave 0：擴充 `gcal_integrations` 並補齊 Repository 方法，供後續 F-030b/c（連線狀態、reauth、設定 API）使用。

Closes #101

## Changes
- `dev/src/migration/014_extend_gcal_integrations.up.sql` / `.down.sql`
  - 新增 `default_calendar_id TEXT NOT NULL DEFAULT 'primary'`
  - 新增 `access_token_expires_at TIMESTAMPTZ`
  - backfill：將 `token_expiry` 複製到 `access_token_expires_at`
- `dev/src/model/gcal_integration.go`
  - 新增 `DefaultCalendarID string`、`AccessTokenExpiresAt *time.Time`
- `dev/src/repository/gcal_integration.go`
  - `Get` / `Upsert` SELECT/INSERT 涵蓋新欄位
  - `Upsert`：在重新 OAuth 時繼承舊的 `default_calendar_id`（不會重置使用者設定）；`access_token_expires_at` 預設雙寫 `token_expiry`
  - `UpdateTokens`：同時更新 `token_expiry` 與 `access_token_expires_at`（雙寫）
  - 新增 `UpdateDefaultCalendarID(ctx, id, calendarID)`
  - 新增 `DeleteAll(ctx)` — 供中斷連線使用
- `dev/src/service/interfaces.go`：`GcalIntegrationRepository` interface 同步補上 `UpdateDefaultCalendarID` / `DeleteAll`
- `dev/src/repository/gcal_integration_test.go`：依 `TEST_DATABASE_URL` 整合測試
  - Upsert 預設 calendar 為 primary
  - Upsert 雙寫 access_token_expires_at
  - Upsert 在重新 OAuth 後繼承舊 calendar
  - UpdateDefaultCalendarID（含空字串重置）
  - DeleteAll
  - UpdateTokens 雙寫驗證

## 設計決策
- **保留既有 `token_expiry` 欄位**：避免破壞既有讀取路徑；service 層改透過 `UpdateTokens` 雙寫，後續可逐步淘汰舊欄位。
- **`Upsert` 繼承舊 `default_calendar_id`**：spec 提到使用者重新 OAuth 不應重置 default calendar；實作以 tx 內先讀舊值再寫。
- **不動 OAuth 邏輯**：service/gcal.go 的 token refresh 流程透過既有 `UpdateTokens` 介面自動雙寫，不需修改呼叫端。

## 測試
- `cd dev && go build ./...` ✅
- `cd dev && go vet ./...` ✅
- repository 測試以 `TEST_DATABASE_URL` gating，CI 上跑 docker compose 後即可執行
- 既有 service / handler 沿用同樣介面簽名，無破壞性變更

## Scenario 覆蓋（Wave 0 範圍）
本 PR 只負責 schema + repo，scenarios 由 F-030b/c 完成 service / handler 後串通。

## Related Issues
Closes #101