### PR TITLE
feat(backend): F-028a Journal migration 013 + repository + DTO

### DIFF
--- a/dev/src/dto/journal.go
+++ b/dev/src/dto/journal.go
@@ -1,0 +1,81 @@
+package dto
+
+import (
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// SourceRefDTO 日記來源關聯（雙向使用：request 與 response）
+type SourceRefDTO struct {
+	SourceType string `json:"source_type" binding:"required,oneof=entry gcal_event"`
+	SourceID   string `json:"source_id" binding:"required"`
+}
+
+// CreateJournalRequest POST /api/v1/journal 的請求 body
+type CreateJournalRequest struct {
+	Date       string         `json:"date" binding:"required"`              // YYYY-MM-DD
+	Title      *string        `json:"title"`
+	Content    string         `json:"content" binding:"required,max=20000"` // 對齊 DB chk_journal_content_len
+	Mood       *string        `json:"mood" binding:"omitempty,oneof=great ok down"`
+	Highlights []string       `json:"highlights"`
+	SourceRefs []SourceRefDTO `json:"source_refs"`
+}
+
+// UpdateJournalRequest PATCH /api/v1/journal/:date 的 partial update body
+//
+// 所有欄位皆 optional：nil 代表不更動。
+//   - Title 用 **string 區分「不更動」(nil) 與「更新為 NULL」(*Title == nil)
+//   - SourceRefs 為 nil 代表不更動；非 nil（含長度 0）代表「整批覆寫」
+type UpdateJournalRequest struct {
+	Title      **string        `json:"title"`
+	Content    *string         `json:"content" binding:"omitempty,max=20000"`
+	Mood       **string        `json:"mood"`
+	Highlights *[]string       `json:"highlights"`
+	IsDraft    *bool           `json:"is_draft"`
+	SourceRefs *[]SourceRefDTO `json:"source_refs"`
+}
+
+// GenerateDraftRequest POST /api/v1/journal/:date/draft 的請求 body
+type GenerateDraftRequest struct {
+	LlmProviderID  *uuid.UUID `json:"llm_provider_id"`
+	Tone           string     `json:"tone" binding:"omitempty,oneof=reflective concise narrative"`
+	IncludeEntries *bool      `json:"include_entries"`
+	IncludeEvents  *bool      `json:"include_events"`
+}
+
+// JournalResponse Journal 的 API 回應
+//
+// Date 為 YYYY-MM-DD 字串（避免 timezone 誤解）。
+type JournalResponse struct {
+	ID            uuid.UUID      `json:"id"`
+	Date          string         `json:"date"`
+	Title         *string        `json:"title"`
+	Content       string         `json:"content"`
+	Mood          *string        `json:"mood"`
+	Highlights    []string       `json:"highlights"`
+	IsDraft       bool           `json:"is_draft"`
+	GeneratedBy   *string        `json:"generated_by"`
+	LlmProviderID *uuid.UUID     `json:"llm_provider_id"`
+	SourceRefs    []SourceRefDTO `json:"source_refs"`
+	CreatedAt     time.Time      `json:"created_at"`
+	UpdatedAt     time.Time      `json:"updated_at"`
+}
+
+// JournalListItem 日記列表精簡項目（不含完整 content / source_refs）
+type JournalListItem struct {
+	ID          uuid.UUID  `json:"id"`
+	Date        string     `json:"date"`
+	Title       *string    `json:"title"`
+	Mood        *string    `json:"mood"`
+	IsDraft     bool       `json:"is_draft"`
+	GeneratedBy *string    `json:"generated_by"`
+	CreatedAt   time.Time  `json:"created_at"`
+	UpdatedAt   time.Time  `json:"updated_at"`
+}
+
+// ListJournalResponse GET /api/v1/journal 的回應
+type ListJournalResponse struct {
+	Data       []JournalListItem  `json:"data"`
+	Pagination PaginationResponse `json:"pagination"`
+}

--- a/dev/src/migration/013_create_journal.down.sql
+++ b/dev/src/migration/013_create_journal.down.sql
@@ -1,0 +1,10 @@
+-- Rollback F-028 Journal 資料層
+-- DROP 順序：先 child（journal_source_refs，含 FK）再 parent（journal_entries）
+
+DROP INDEX IF EXISTS idx_journal_source_refs_lookup;
+DROP TABLE IF EXISTS journal_source_refs;
+
+DROP INDEX IF EXISTS idx_journal_entries_mood;
+DROP INDEX IF EXISTS idx_journal_entries_is_draft;
+DROP INDEX IF EXISTS idx_journal_entries_date;
+DROP TABLE IF EXISTS journal_entries;

--- a/dev/src/migration/013_create_journal.up.sql
+++ b/dev/src/migration/013_create_journal.up.sql
@@ -1,0 +1,48 @@
+-- F-028 每日日記資料層
+--
+-- 本 migration 建立以下資料表：
+--   1. journal_entries：每日日記主表（每日最多一篇，date 唯一）
+--   2. journal_source_refs：日記與來源（entry / gcal_event）的多對多關聯
+--
+-- 設計重點：
+--   * date 為 DATE 型別並 UNIQUE，確保「每日一篇」業務規則於 DB 層落實
+--   * mood / generated_by 用 CHECK constraint 限制 enum 值，避免額外查找表
+--   * content 長度 <= 20000，於 DB 層擋住超長內容（spec §Business Rules 3）
+--   * llm_provider_id ON DELETE SET NULL：刪 provider 不會牽連既有日記
+--   * highlights 用 TEXT[] 直接存 LLM 萃取的當日亮點（簡單即可，不需獨立表）
+--   * journal_source_refs 採聯合主鍵 (journal_id, source_type, source_id)
+--     - source_type CHECK 限制為 'entry' | 'gcal_event'
+--     - 不對 source_id 加 FK：gcal_event id 是字串、且 entry 可能在 journal 之後刪除，
+--       上層服務在組裝回應時自行 best-effort 解析
+--     - 索引 (source_type, source_id)：支援「某 entry 屬於哪些日記」的反查
+
+CREATE TABLE journal_entries (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  date DATE NOT NULL UNIQUE,
+  title TEXT,
+  content TEXT NOT NULL,
+  mood TEXT,
+  highlights TEXT[],
+  is_draft BOOLEAN NOT NULL DEFAULT false,
+  generated_by TEXT,
+  llm_provider_id UUID REFERENCES llm_providers(id) ON DELETE SET NULL,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  CONSTRAINT chk_journal_mood CHECK (mood IS NULL OR mood IN ('great','ok','down')),
+  CONSTRAINT chk_journal_generated_by CHECK (generated_by IS NULL OR generated_by IN ('user','llm')),
+  CONSTRAINT chk_journal_content_len CHECK (char_length(content) <= 20000)
+);
+
+CREATE INDEX idx_journal_entries_date ON journal_entries(date DESC);
+CREATE INDEX idx_journal_entries_is_draft ON journal_entries(is_draft);
+CREATE INDEX idx_journal_entries_mood ON journal_entries(mood);
+
+CREATE TABLE journal_source_refs (
+  journal_id UUID NOT NULL REFERENCES journal_entries(id) ON DELETE CASCADE,
+  source_type TEXT NOT NULL,
+  source_id TEXT NOT NULL,
+  PRIMARY KEY (journal_id, source_type, source_id),
+  CONSTRAINT chk_journal_source_type CHECK (source_type IN ('entry','gcal_event'))
+);
+
+CREATE INDEX idx_journal_source_refs_lookup ON journal_source_refs(source_type, source_id);

--- a/dev/src/model/journal.go
+++ b/dev/src/model/journal.go
@@ -1,0 +1,58 @@
+package model
+
+import (
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// Mood 日記情緒 enum 值（對應 migration 013 的 chk_journal_mood）
+const (
+	MoodGreat = "great"
+	MoodOk    = "ok"
+	MoodDown  = "down"
+)
+
+// GeneratedBy 日記生成來源 enum 值（對應 migration 013 的 chk_journal_generated_by）
+const (
+	GeneratedByUser = "user"
+	GeneratedByLlm  = "llm"
+)
+
+// JournalSourceType journal_source_refs.source_type 合法值
+const (
+	JournalSourceTypeEntry     = "entry"
+	JournalSourceTypeGcalEvent = "gcal_event"
+)
+
+// 額外錯誤碼（F-028）
+const (
+	ErrCodeJournalExists   = "JOURNAL_EXISTS"
+	ErrCodeJournalNotFound = "JOURNAL_NOT_FOUND"
+	ErrCodeLlmUnavailable  = "LLM_UNAVAILABLE"
+)
+
+// Journal 對應 journal_entries 資料表
+//
+// Date 採用 time.Time（DATE 型別 → UTC 00:00:00），在序列化時呼叫端應
+// 以 YYYY-MM-DD 格式輸出（見 dto.JournalResponse.DateString）。
+type Journal struct {
+	ID            uuid.UUID  `json:"id"`
+	Date          time.Time  `json:"-"` // 對外用 dto 的 string，避免 timezone 誤導
+	Title         *string    `json:"title"`
+	Content       string     `json:"content"`
+	Mood          *string    `json:"mood"`
+	Highlights    []string   `json:"highlights"`
+	IsDraft       bool       `json:"is_draft"`
+	GeneratedBy   *string    `json:"generated_by"`
+	LlmProviderID *uuid.UUID `json:"llm_provider_id"`
+	CreatedAt     time.Time  `json:"created_at"`
+	UpdatedAt     time.Time  `json:"updated_at"`
+}
+
+// JournalSourceRef 對應 journal_source_refs 資料表
+type JournalSourceRef struct {
+	JournalID  uuid.UUID `json:"-"`
+	SourceType string    `json:"source_type"`
+	SourceID   string    `json:"source_id"`
+}

--- a/dev/src/repository/journal.go
+++ b/dev/src/repository/journal.go
@@ -1,0 +1,424 @@
+package repository
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/gpwork4u/aibo/dto"
+	"github.com/gpwork4u/aibo/model"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+// JournalRepository 每日日記資料庫操作（F-028）
+type JournalRepository struct {
+	pool *pgxpool.Pool
+}
+
+// NewJournalRepository 建立新的 JournalRepository
+func NewJournalRepository(pool *pgxpool.Pool) *JournalRepository {
+	return &JournalRepository{pool: pool}
+}
+
+// JournalListOptions JournalRepository.List 的過濾條件
+type JournalListOptions struct {
+	Page    int
+	PerPage int
+	Since   *time.Time // inclusive
+	Until   *time.Time // inclusive
+	Mood    *string
+	IsDraft *bool
+}
+
+// JournalListResult List 的回傳結果
+type JournalListResult struct {
+	Items []*model.Journal
+	Total int64
+}
+
+const journalSelectCols = `id, date, title, content, mood, highlights, is_draft, generated_by,
+	llm_provider_id, created_at, updated_at`
+
+// scanJournal 將 row 掃進 *model.Journal
+func scanJournal(row pgx.Row) (*model.Journal, error) {
+	j := &model.Journal{}
+	err := row.Scan(
+		&j.ID, &j.Date, &j.Title, &j.Content, &j.Mood, &j.Highlights,
+		&j.IsDraft, &j.GeneratedBy, &j.LlmProviderID, &j.CreatedAt, &j.UpdatedAt,
+	)
+	if err != nil {
+		return nil, err
+	}
+	return j, nil
+}
+
+// mapPgErrToAppError 將常見的 PgError 轉成 model.AppError
+//
+// 特別處理：
+//   - journal_entries.date 唯一鍵衝突 → 409 JOURNAL_EXISTS
+//   - chk_journal_content_len → 400 INVALID_INPUT
+func mapJournalPgErr(err error) error {
+	if err == nil {
+		return nil
+	}
+	var pgErr *pgconn.PgError
+	if errors.As(err, &pgErr) {
+		// 23505 = unique_violation；ConstraintName 在 PG 通常是 journal_entries_date_key
+		if pgErr.Code == "23505" && (pgErr.ConstraintName == "journal_entries_date_key" ||
+			strings.Contains(pgErr.ConstraintName, "journal_entries") && strings.Contains(pgErr.ConstraintName, "date")) {
+			return model.NewAppError(409, model.ErrCodeJournalExists, "當日日記已存在")
+		}
+		// 23514 = check_violation
+		if pgErr.Code == "23514" {
+			switch pgErr.ConstraintName {
+			case "chk_journal_content_len":
+				return model.NewAppError(400, model.ErrCodeInvalidInput, "日記內容超過 20000 字上限")
+			case "chk_journal_mood":
+				return model.NewAppError(400, model.ErrCodeInvalidInput, "mood 必須為 great / ok / down")
+			case "chk_journal_generated_by":
+				return model.NewAppError(400, model.ErrCodeInvalidInput, "generated_by 必須為 user / llm")
+			case "chk_journal_source_type":
+				return model.NewAppError(400, model.ErrCodeInvalidInput, "source_type 必須為 entry / gcal_event")
+			}
+		}
+	}
+	return err
+}
+
+// Create 建立日記 + 批次插入 source_refs（同一個 transaction）
+//
+// 行為：
+//   - 若 j.ID 為零值，會由 DB 端 gen_random_uuid()
+//   - generated_by 預設由呼叫端決定（user 路徑下應填 'user'）
+//   - 若 date 已存在 → 回傳 409 JOURNAL_EXISTS
+func (r *JournalRepository) Create(ctx context.Context, j *model.Journal, refs []model.JournalSourceRef) error {
+	tx, err := r.pool.Begin(ctx)
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback(ctx)
+
+	// 若 ID 為零值，讓 DB 自動產生
+	var insertedID uuid.UUID
+	if j.ID == uuid.Nil {
+		err = tx.QueryRow(ctx,
+			`INSERT INTO journal_entries (date, title, content, mood, highlights, is_draft, generated_by, llm_provider_id)
+			 VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+			 RETURNING id, created_at, updated_at`,
+			j.Date, j.Title, j.Content, j.Mood, j.Highlights, j.IsDraft, j.GeneratedBy, j.LlmProviderID,
+		).Scan(&insertedID, &j.CreatedAt, &j.UpdatedAt)
+	} else {
+		err = tx.QueryRow(ctx,
+			`INSERT INTO journal_entries (id, date, title, content, mood, highlights, is_draft, generated_by, llm_provider_id)
+			 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
+			 RETURNING id, created_at, updated_at`,
+			j.ID, j.Date, j.Title, j.Content, j.Mood, j.Highlights, j.IsDraft, j.GeneratedBy, j.LlmProviderID,
+		).Scan(&insertedID, &j.CreatedAt, &j.UpdatedAt)
+	}
+	if err != nil {
+		return mapJournalPgErr(err)
+	}
+	j.ID = insertedID
+
+	// 批次插入 source_refs（若有）
+	if len(refs) > 0 {
+		if err := insertSourceRefsTx(ctx, tx, j.ID, refs); err != nil {
+			return mapJournalPgErr(err)
+		}
+	}
+
+	if err := tx.Commit(ctx); err != nil {
+		return err
+	}
+	return nil
+}
+
+// insertSourceRefsTx 在 tx 內批次插入 source_refs（不處理 commit / rollback）
+func insertSourceRefsTx(ctx context.Context, tx pgx.Tx, journalID uuid.UUID, refs []model.JournalSourceRef) error {
+	if len(refs) == 0 {
+		return nil
+	}
+	// 動態建構 VALUES 子句，一次 round-trip 完成
+	placeholders := make([]string, 0, len(refs))
+	args := make([]any, 0, len(refs)*3)
+	for i, ref := range refs {
+		base := i * 3
+		placeholders = append(placeholders, fmt.Sprintf("($%d, $%d, $%d)", base+1, base+2, base+3))
+		args = append(args, journalID, ref.SourceType, ref.SourceID)
+	}
+	q := fmt.Sprintf(
+		`INSERT INTO journal_source_refs (journal_id, source_type, source_id) VALUES %s
+		 ON CONFLICT DO NOTHING`,
+		strings.Join(placeholders, ", "),
+	)
+	_, err := tx.Exec(ctx, q, args...)
+	return err
+}
+
+// GetByDate 依日期載入日記與其 source_refs（一次回傳完整聚合）
+//
+// 不存在 → (nil, nil, nil)，呼叫端自行包成 404 JOURNAL_NOT_FOUND
+func (r *JournalRepository) GetByDate(ctx context.Context, date time.Time) (*model.Journal, []model.JournalSourceRef, error) {
+	row := r.pool.QueryRow(ctx,
+		`SELECT `+journalSelectCols+` FROM journal_entries WHERE date = $1`,
+		date,
+	)
+	j, err := scanJournal(row)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return nil, nil, nil
+	}
+	if err != nil {
+		return nil, nil, err
+	}
+
+	refs, err := r.listSourceRefs(ctx, j.ID)
+	if err != nil {
+		return nil, nil, err
+	}
+	return j, refs, nil
+}
+
+// listSourceRefs 取得指定 journal 的 source_refs
+func (r *JournalRepository) listSourceRefs(ctx context.Context, journalID uuid.UUID) ([]model.JournalSourceRef, error) {
+	rows, err := r.pool.Query(ctx,
+		`SELECT journal_id, source_type, source_id
+		 FROM journal_source_refs
+		 WHERE journal_id = $1
+		 ORDER BY source_type ASC, source_id ASC`,
+		journalID,
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	refs := make([]model.JournalSourceRef, 0)
+	for rows.Next() {
+		var ref model.JournalSourceRef
+		if err := rows.Scan(&ref.JournalID, &ref.SourceType, &ref.SourceID); err != nil {
+			return nil, err
+		}
+		refs = append(refs, ref)
+	}
+	return refs, rows.Err()
+}
+
+// Update 對指定日期的日記做 partial update。
+//
+// patch 內各欄位為 nil 代表「不更動」。
+// 若 patch.SourceRefs 非 nil（即使長度 0）→ 整批覆寫 source_refs。
+//
+// 不存在 → 404 JOURNAL_NOT_FOUND。
+func (r *JournalRepository) Update(
+	ctx context.Context,
+	date time.Time,
+	patch *dto.UpdateJournalRequest,
+) (*model.Journal, error) {
+	tx, err := r.pool.Begin(ctx)
+	if err != nil {
+		return nil, err
+	}
+	defer tx.Rollback(ctx)
+
+	// 先抓出當前 journal id（也用來確認存在性）
+	var journalID uuid.UUID
+	err = tx.QueryRow(ctx, `SELECT id FROM journal_entries WHERE date = $1 FOR UPDATE`, date).Scan(&journalID)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return nil, model.NewAppError(404, model.ErrCodeJournalNotFound, "當日尚無日記")
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	// 動態組 UPDATE 欄位
+	sets := []string{}
+	args := []any{}
+	idx := 1
+	if patch != nil {
+		if patch.Title != nil {
+			sets = append(sets, fmt.Sprintf("title = $%d", idx))
+			args = append(args, *patch.Title) // *string，可能為 nil
+			idx++
+		}
+		if patch.Content != nil {
+			sets = append(sets, fmt.Sprintf("content = $%d", idx))
+			args = append(args, *patch.Content)
+			idx++
+		}
+		if patch.Mood != nil {
+			sets = append(sets, fmt.Sprintf("mood = $%d", idx))
+			args = append(args, *patch.Mood)
+			idx++
+		}
+		if patch.Highlights != nil {
+			sets = append(sets, fmt.Sprintf("highlights = $%d", idx))
+			args = append(args, *patch.Highlights)
+			idx++
+		}
+		if patch.IsDraft != nil {
+			sets = append(sets, fmt.Sprintf("is_draft = $%d", idx))
+			args = append(args, *patch.IsDraft)
+			idx++
+		}
+	}
+	sets = append(sets, "updated_at = NOW()")
+
+	q := fmt.Sprintf(
+		`UPDATE journal_entries SET %s WHERE id = $%d
+		 RETURNING `+journalSelectCols,
+		strings.Join(sets, ", "), idx,
+	)
+	args = append(args, journalID)
+
+	updated, err := scanJournal(tx.QueryRow(ctx, q, args...))
+	if err != nil {
+		return nil, mapJournalPgErr(err)
+	}
+
+	// 若需覆寫 source_refs
+	if patch != nil && patch.SourceRefs != nil {
+		if _, err := tx.Exec(ctx,
+			`DELETE FROM journal_source_refs WHERE journal_id = $1`, journalID); err != nil {
+			return nil, err
+		}
+		// dto -> model
+		refs := make([]model.JournalSourceRef, 0, len(*patch.SourceRefs))
+		for _, r := range *patch.SourceRefs {
+			refs = append(refs, model.JournalSourceRef{
+				JournalID:  journalID,
+				SourceType: r.SourceType,
+				SourceID:   r.SourceID,
+			})
+		}
+		if err := insertSourceRefsTx(ctx, tx, journalID, refs); err != nil {
+			return nil, mapJournalPgErr(err)
+		}
+	}
+
+	if err := tx.Commit(ctx); err != nil {
+		return nil, err
+	}
+	return updated, nil
+}
+
+// Delete 依日期刪除日記（CASCADE 會連帶刪除 source_refs）
+//
+// 不存在 → 404 JOURNAL_NOT_FOUND。
+func (r *JournalRepository) Delete(ctx context.Context, date time.Time) error {
+	tag, err := r.pool.Exec(ctx, `DELETE FROM journal_entries WHERE date = $1`, date)
+	if err != nil {
+		return err
+	}
+	if tag.RowsAffected() == 0 {
+		return model.NewAppError(404, model.ErrCodeJournalNotFound, "當日尚無日記")
+	}
+	return nil
+}
+
+// List 分頁列表（支援 since/until/mood/is_draft 過濾），不載入 source_refs
+//
+// 排序：date DESC（最新優先）
+func (r *JournalRepository) List(ctx context.Context, opts JournalListOptions) ([]*model.Journal, int64, error) {
+	if opts.Page <= 0 {
+		opts.Page = 1
+	}
+	if opts.PerPage <= 0 {
+		opts.PerPage = 20
+	}
+
+	conds := []string{}
+	args := []any{}
+	idx := 1
+	if opts.Since != nil {
+		conds = append(conds, fmt.Sprintf("date >= $%d", idx))
+		args = append(args, *opts.Since)
+		idx++
+	}
+	if opts.Until != nil {
+		conds = append(conds, fmt.Sprintf("date <= $%d", idx))
+		args = append(args, *opts.Until)
+		idx++
+	}
+	if opts.Mood != nil {
+		conds = append(conds, fmt.Sprintf("mood = $%d", idx))
+		args = append(args, *opts.Mood)
+		idx++
+	}
+	if opts.IsDraft != nil {
+		conds = append(conds, fmt.Sprintf("is_draft = $%d", idx))
+		args = append(args, *opts.IsDraft)
+		idx++
+	}
+	where := ""
+	if len(conds) > 0 {
+		where = "WHERE " + strings.Join(conds, " AND ")
+	}
+
+	// 計 total
+	var total int64
+	if err := r.pool.QueryRow(ctx,
+		fmt.Sprintf(`SELECT COUNT(*) FROM journal_entries %s`, where), args...,
+	).Scan(&total); err != nil {
+		return nil, 0, err
+	}
+
+	offset := (opts.Page - 1) * opts.PerPage
+	q := fmt.Sprintf(
+		`SELECT `+journalSelectCols+` FROM journal_entries %s
+		 ORDER BY date DESC
+		 LIMIT $%d OFFSET $%d`,
+		where, idx, idx+1,
+	)
+	args = append(args, opts.PerPage, offset)
+
+	rows, err := r.pool.Query(ctx, q, args...)
+	if err != nil {
+		return nil, 0, err
+	}
+	defer rows.Close()
+
+	items := make([]*model.Journal, 0)
+	for rows.Next() {
+		j, err := scanJournal(rows)
+		if err != nil {
+			return nil, 0, err
+		}
+		items = append(items, j)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, 0, err
+	}
+	return items, total, nil
+}
+
+// ReplaceSourceRefs 清空後重插某 journal 的 source_refs（用於 LLM draft 重生）
+func (r *JournalRepository) ReplaceSourceRefs(
+	ctx context.Context,
+	journalID uuid.UUID,
+	refs []model.JournalSourceRef,
+) error {
+	tx, err := r.pool.Begin(ctx)
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback(ctx)
+
+	if _, err := tx.Exec(ctx,
+		`DELETE FROM journal_source_refs WHERE journal_id = $1`, journalID); err != nil {
+		return err
+	}
+	if err := insertSourceRefsTx(ctx, tx, journalID, refs); err != nil {
+		return mapJournalPgErr(err)
+	}
+	return tx.Commit(ctx)
+}
+
+// GetSourceRefs 對外暴露查詢 source_refs（避免外部直接寫 SQL）
+func (r *JournalRepository) GetSourceRefs(ctx context.Context, journalID uuid.UUID) ([]model.JournalSourceRef, error) {
+	return r.listSourceRefs(ctx, journalID)
+}

--- a/dev/src/repository/journal_test.go
+++ b/dev/src/repository/journal_test.go
@@ -1,0 +1,378 @@
+package repository
+
+import (
+	"context"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/gpwork4u/aibo/dto"
+	"github.com/gpwork4u/aibo/model"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+// withJournalTestDB 取得專供 journal 測試使用的 DB pool。
+//
+// 與 entry calendar 測試共用同一條 TEST_DATABASE_URL；本 helper 只清空
+// 與本檔測試相關的兩張表（journal_source_refs → journal_entries），
+// 並沿用既有的「dbname 必須含 'test' 字樣」防呆，避免誤連 dev/prod。
+func withJournalTestDB(t *testing.T) *pgxpool.Pool {
+	t.Helper()
+	dsn := os.Getenv("TEST_DATABASE_URL")
+	if dsn == "" {
+		t.Skip("TEST_DATABASE_URL 未設置，跳過 journal repo 整合測試")
+	}
+	if os.Getenv("ALLOW_NON_TEST_DB") != "1" && !strings.Contains(strings.ToLower(dsn), "test") {
+		t.Fatalf("TEST_DATABASE_URL 未包含 'test' 字樣，為安全起見拒絕對此 DB 執行破壞性測試")
+	}
+
+	pool, err := pgxpool.New(context.Background(), dsn)
+	if err != nil {
+		t.Fatalf("連接測試 DB 失敗: %v", err)
+	}
+
+	// 子表先清，主表後清（FK CASCADE 也行，但顯式清更安全）
+	for _, table := range []string{"journal_source_refs", "journal_entries"} {
+		if _, err := pool.Exec(context.Background(), "DELETE FROM "+table); err != nil {
+			pool.Close()
+			t.Fatalf("清空 %s 失敗: %v", table, err)
+		}
+	}
+	return pool
+}
+
+// makeJournal 建立一個測試用 Journal（呼叫端可只覆蓋需要的欄位）
+func makeJournal(date time.Time, content string) *model.Journal {
+	mood := model.MoodOk
+	gen := model.GeneratedByUser
+	return &model.Journal{
+		Date:        date,
+		Content:     content,
+		Mood:        &mood,
+		Highlights:  []string{"h1", "h2"},
+		IsDraft:     false,
+		GeneratedBy: &gen,
+	}
+}
+
+func date(y int, m time.Month, d int) time.Time {
+	return time.Date(y, m, d, 0, 0, 0, 0, time.UTC)
+}
+
+func ptrStr(s string) *string { return &s }
+func ptrBool(b bool) *bool    { return &b }
+
+func TestJournal_CreateAndGetByDate(t *testing.T) {
+	pool := withJournalTestDB(t)
+	defer pool.Close()
+	repo := NewJournalRepository(pool)
+
+	d := date(2026, 4, 24)
+	j := makeJournal(d, "Today was great.")
+	refs := []model.JournalSourceRef{
+		{SourceType: model.JournalSourceTypeEntry, SourceID: uuid.New().String()},
+		{SourceType: model.JournalSourceTypeGcalEvent, SourceID: "gcal-abc123"},
+	}
+
+	if err := repo.Create(context.Background(), j, refs); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if j.ID == uuid.Nil {
+		t.Fatalf("expected ID populated after Create")
+	}
+
+	got, gotRefs, err := repo.GetByDate(context.Background(), d)
+	if err != nil {
+		t.Fatalf("GetByDate: %v", err)
+	}
+	if got == nil {
+		t.Fatalf("expected journal, got nil")
+	}
+	if got.Content != "Today was great." {
+		t.Errorf("content mismatch: %q", got.Content)
+	}
+	if got.Mood == nil || *got.Mood != model.MoodOk {
+		t.Errorf("mood mismatch: %v", got.Mood)
+	}
+	if len(got.Highlights) != 2 {
+		t.Errorf("highlights len: %d", len(got.Highlights))
+	}
+	if len(gotRefs) != 2 {
+		t.Errorf("expected 2 source_refs, got %d", len(gotRefs))
+	}
+}
+
+func TestJournal_Create_DuplicateDate(t *testing.T) {
+	pool := withJournalTestDB(t)
+	defer pool.Close()
+	repo := NewJournalRepository(pool)
+
+	d := date(2026, 4, 24)
+	if err := repo.Create(context.Background(), makeJournal(d, "first"), nil); err != nil {
+		t.Fatalf("first Create: %v", err)
+	}
+
+	err := repo.Create(context.Background(), makeJournal(d, "second"), nil)
+	if err == nil {
+		t.Fatal("expected JOURNAL_EXISTS, got nil")
+	}
+	appErr, ok := err.(*model.AppError)
+	if !ok {
+		t.Fatalf("expected *AppError, got %T: %v", err, err)
+	}
+	if appErr.Status != 409 || appErr.Code != model.ErrCodeJournalExists {
+		t.Errorf("expected 409 JOURNAL_EXISTS, got %d %s", appErr.Status, appErr.Code)
+	}
+}
+
+func TestJournal_GetByDate_NotFound(t *testing.T) {
+	pool := withJournalTestDB(t)
+	defer pool.Close()
+	repo := NewJournalRepository(pool)
+
+	j, refs, err := repo.GetByDate(context.Background(), date(2026, 4, 24))
+	if err != nil {
+		t.Fatalf("GetByDate: %v", err)
+	}
+	if j != nil || refs != nil {
+		t.Errorf("expected nil result for missing date, got j=%v refs=%v", j, refs)
+	}
+}
+
+func TestJournal_Update_PartialAndSourceRefsReplace(t *testing.T) {
+	pool := withJournalTestDB(t)
+	defer pool.Close()
+	repo := NewJournalRepository(pool)
+
+	d := date(2026, 4, 24)
+	j := makeJournal(d, "draft content")
+	j.IsDraft = true
+	gen := model.GeneratedByLlm
+	j.GeneratedBy = &gen
+	if err := repo.Create(context.Background(), j, []model.JournalSourceRef{
+		{SourceType: "entry", SourceID: "old-1"},
+	}); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	// 部分更新：content + is_draft + source_refs 整批覆寫
+	newRefs := []dto.SourceRefDTO{
+		{SourceType: "entry", SourceID: "new-1"},
+		{SourceType: "entry", SourceID: "new-2"},
+	}
+	patch := &dto.UpdateJournalRequest{
+		Content:    ptrStr("edited"),
+		IsDraft:    ptrBool(false),
+		SourceRefs: &newRefs,
+	}
+	updated, err := repo.Update(context.Background(), d, patch)
+	if err != nil {
+		t.Fatalf("Update: %v", err)
+	}
+	if updated.Content != "edited" {
+		t.Errorf("content not updated: %q", updated.Content)
+	}
+	if updated.IsDraft {
+		t.Errorf("is_draft should be false")
+	}
+	// generated_by 應保持 'llm'（spec §Update 要求 confirm draft 不變 generated_by）
+	if updated.GeneratedBy == nil || *updated.GeneratedBy != model.GeneratedByLlm {
+		t.Errorf("generated_by should remain 'llm', got %v", updated.GeneratedBy)
+	}
+
+	// 驗證 source_refs 已被覆寫
+	_, gotRefs, err := repo.GetByDate(context.Background(), d)
+	if err != nil {
+		t.Fatalf("GetByDate: %v", err)
+	}
+	if len(gotRefs) != 2 {
+		t.Fatalf("expected 2 refs after replace, got %d", len(gotRefs))
+	}
+	for _, r := range gotRefs {
+		if r.SourceID == "old-1" {
+			t.Errorf("old ref should have been removed")
+		}
+	}
+}
+
+func TestJournal_Update_NotFound(t *testing.T) {
+	pool := withJournalTestDB(t)
+	defer pool.Close()
+	repo := NewJournalRepository(pool)
+
+	_, err := repo.Update(context.Background(), date(2026, 4, 24), &dto.UpdateJournalRequest{
+		Content: ptrStr("anything"),
+	})
+	if err == nil {
+		t.Fatal("expected error for missing journal")
+	}
+	appErr, ok := err.(*model.AppError)
+	if !ok || appErr.Status != 404 || appErr.Code != model.ErrCodeJournalNotFound {
+		t.Errorf("expected 404 JOURNAL_NOT_FOUND, got %v", err)
+	}
+}
+
+func TestJournal_Delete(t *testing.T) {
+	pool := withJournalTestDB(t)
+	defer pool.Close()
+	repo := NewJournalRepository(pool)
+
+	d := date(2026, 4, 24)
+	if err := repo.Create(context.Background(), makeJournal(d, "x"), []model.JournalSourceRef{
+		{SourceType: "entry", SourceID: "to-cascade"},
+	}); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	if err := repo.Delete(context.Background(), d); err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+
+	// 確認 cascade
+	got, refs, _ := repo.GetByDate(context.Background(), d)
+	if got != nil || len(refs) != 0 {
+		t.Errorf("expected journal & refs deleted")
+	}
+
+	// 重複刪 → 404
+	err := repo.Delete(context.Background(), d)
+	if err == nil {
+		t.Fatal("expected 404 on second delete")
+	}
+	appErr, _ := err.(*model.AppError)
+	if appErr == nil || appErr.Status != 404 {
+		t.Errorf("expected 404, got %v", err)
+	}
+}
+
+func TestJournal_List_Filters(t *testing.T) {
+	pool := withJournalTestDB(t)
+	defer pool.Close()
+	repo := NewJournalRepository(pool)
+
+	// 建立 5 筆，混合 mood + is_draft
+	specs := []struct {
+		date    time.Time
+		mood    string
+		isDraft bool
+	}{
+		{date(2026, 4, 20), model.MoodGreat, false},
+		{date(2026, 4, 21), model.MoodOk, true},
+		{date(2026, 4, 22), model.MoodOk, false},
+		{date(2026, 4, 23), model.MoodDown, false},
+		{date(2026, 4, 24), model.MoodGreat, true},
+	}
+	for _, s := range specs {
+		mood := s.mood
+		gen := model.GeneratedByUser
+		j := &model.Journal{
+			Date: s.date, Content: "x", Mood: &mood, IsDraft: s.isDraft,
+			GeneratedBy: &gen,
+		}
+		if err := repo.Create(context.Background(), j, nil); err != nil {
+			t.Fatalf("Create %v: %v", s.date, err)
+		}
+	}
+
+	// 過濾 mood=ok
+	mood := model.MoodOk
+	items, total, err := repo.List(context.Background(), JournalListOptions{
+		Page: 1, PerPage: 10, Mood: &mood,
+	})
+	if err != nil {
+		t.Fatalf("List mood=ok: %v", err)
+	}
+	if total != 2 || len(items) != 2 {
+		t.Errorf("mood=ok: expected 2, got total=%d len=%d", total, len(items))
+	}
+
+	// is_draft=true
+	isDraft := true
+	items, total, err = repo.List(context.Background(), JournalListOptions{
+		Page: 1, PerPage: 10, IsDraft: &isDraft,
+	})
+	if err != nil {
+		t.Fatalf("List is_draft=true: %v", err)
+	}
+	if total != 2 || len(items) != 2 {
+		t.Errorf("is_draft=true: expected 2, got total=%d len=%d", total, len(items))
+	}
+
+	// since/until
+	since := date(2026, 4, 22)
+	until := date(2026, 4, 23)
+	items, total, err = repo.List(context.Background(), JournalListOptions{
+		Page: 1, PerPage: 10, Since: &since, Until: &until,
+	})
+	if err != nil {
+		t.Fatalf("List since/until: %v", err)
+	}
+	if total != 2 || len(items) != 2 {
+		t.Errorf("since/until: expected 2, got total=%d len=%d", total, len(items))
+	}
+	// 排序：date DESC
+	if !items[0].Date.After(items[1].Date) {
+		t.Errorf("expected DESC by date")
+	}
+
+	// 分頁
+	items, total, err = repo.List(context.Background(), JournalListOptions{
+		Page: 2, PerPage: 2,
+	})
+	if err != nil {
+		t.Fatalf("List page=2: %v", err)
+	}
+	if total != 5 {
+		t.Errorf("expected total=5, got %d", total)
+	}
+	if len(items) != 2 {
+		t.Errorf("expected 2 items on page 2, got %d", len(items))
+	}
+}
+
+func TestJournal_ReplaceSourceRefs(t *testing.T) {
+	pool := withJournalTestDB(t)
+	defer pool.Close()
+	repo := NewJournalRepository(pool)
+
+	d := date(2026, 4, 24)
+	j := makeJournal(d, "x")
+	if err := repo.Create(context.Background(), j, []model.JournalSourceRef{
+		{SourceType: "entry", SourceID: "a"},
+		{SourceType: "entry", SourceID: "b"},
+	}); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	if err := repo.ReplaceSourceRefs(context.Background(), j.ID, []model.JournalSourceRef{
+		{SourceType: "gcal_event", SourceID: "evt-1"},
+	}); err != nil {
+		t.Fatalf("ReplaceSourceRefs: %v", err)
+	}
+
+	refs, err := repo.GetSourceRefs(context.Background(), j.ID)
+	if err != nil {
+		t.Fatalf("GetSourceRefs: %v", err)
+	}
+	if len(refs) != 1 || refs[0].SourceType != "gcal_event" || refs[0].SourceID != "evt-1" {
+		t.Errorf("unexpected refs after replace: %+v", refs)
+	}
+}
+
+func TestJournal_Create_ContentTooLong(t *testing.T) {
+	pool := withJournalTestDB(t)
+	defer pool.Close()
+	repo := NewJournalRepository(pool)
+
+	long := strings.Repeat("a", 20001)
+	err := repo.Create(context.Background(), makeJournal(date(2026, 4, 24), long), nil)
+	if err == nil {
+		t.Fatal("expected content length check violation")
+	}
+	appErr, _ := err.(*model.AppError)
+	if appErr == nil || appErr.Status != 400 || appErr.Code != model.ErrCodeInvalidInput {
+		t.Errorf("expected 400 INVALID_INPUT, got %v", err)
+	}
+}

--- a/dev/src/service/interfaces.go
+++ b/dev/src/service/interfaces.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"context"
+	"time"
 
 	"github.com/google/uuid"
 	"github.com/gpwork4u/aibo/dto"
@@ -106,6 +107,18 @@ type SystemRepository interface {
 	ExtensionInstalled(ctx context.Context, extName string) (bool, error)
 }
 
+// JournalRepository defines the interface for daily journal data access (F-028).
+// Used by: JournalService（將於 F-028b 引入）
+type JournalRepository interface {
+	Create(ctx context.Context, j *model.Journal, refs []model.JournalSourceRef) error
+	GetByDate(ctx context.Context, date time.Time) (*model.Journal, []model.JournalSourceRef, error)
+	Update(ctx context.Context, date time.Time, patch *dto.UpdateJournalRequest) (*model.Journal, error)
+	Delete(ctx context.Context, date time.Time) error
+	List(ctx context.Context, opts repository.JournalListOptions) ([]*model.Journal, int64, error)
+	ReplaceSourceRefs(ctx context.Context, journalID uuid.UUID, refs []model.JournalSourceRef) error
+	GetSourceRefs(ctx context.Context, journalID uuid.UUID) ([]model.JournalSourceRef, error)
+}
+
 // Compile-time interface satisfaction checks.
 // These ensure that the concrete repository structs implement the interfaces.
 var _ EntryRepository = (*repository.EntryRepository)(nil)
@@ -116,3 +129,4 @@ var _ GcalIntegrationRepository = (*repository.GcalIntegrationRepository)(nil)
 var _ ApiKeyRepository = (*repository.ApiKeyRepository)(nil)
 var _ StatsRepository = (*repository.StatsRepository)(nil)
 var _ SystemRepository = (*repository.SystemRepository)(nil)
+var _ JournalRepository = (*repository.JournalRepository)(nil)


### PR DESCRIPTION
Closes #96

## 摘要
為 F-028b/c 與 F-029 打底。新增 journal_entries 表（date 唯一）、JournalRepository CRUD、DTOs。

## 新增
- `dev/src/migration/013_create_journal.{up,down}.sql`
- `dev/src/model/journal.go`
- `dev/src/dto/journal.go`
- `dev/src/repository/journal.go`（pgconn.PgError 結構化錯誤）
- `dev/src/repository/journal_test.go`

## 修改
- `dev/src/service/interfaces.go`：加 JournalRepository 介面

## 測試
- `go build ./...` 通過
- `go vet ./...` 通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)