### PR TITLE
feat(backend): F-028b Journal CRUD API

### DIFF
--- a/dev/src/handler/journal.go
+++ b/dev/src/handler/journal.go
@@ -1,0 +1,268 @@
+package handler
+
+import (
+	"net/http"
+	"strconv"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/gpwork4u/aibo/dto"
+	"github.com/gpwork4u/aibo/model"
+	"github.com/gpwork4u/aibo/repository"
+	"github.com/gpwork4u/aibo/service"
+)
+
+// JournalHandler 每日日記 HTTP handlers（F-028b）
+type JournalHandler struct {
+	svc *service.JournalService
+}
+
+// NewJournalHandler 建立 JournalHandler
+func NewJournalHandler(svc *service.JournalService) *JournalHandler {
+	return &JournalHandler{svc: svc}
+}
+
+// formatDate 將 model.Journal.Date 轉成 YYYY-MM-DD 字串
+func formatJournalDate(t time.Time) string {
+	return t.UTC().Format("2006-01-02")
+}
+
+// toJournalResponse 將 model + refs 組成 dto.JournalResponse
+func toJournalResponse(j *model.Journal, refs []model.JournalSourceRef) dto.JournalResponse {
+	highlights := j.Highlights
+	if highlights == nil {
+		highlights = []string{}
+	}
+	out := dto.JournalResponse{
+		ID:            j.ID,
+		Date:          formatJournalDate(j.Date),
+		Title:         j.Title,
+		Content:       j.Content,
+		Mood:          j.Mood,
+		Highlights:    highlights,
+		IsDraft:       j.IsDraft,
+		GeneratedBy:   j.GeneratedBy,
+		LlmProviderID: j.LlmProviderID,
+		SourceRefs:    make([]dto.SourceRefDTO, 0, len(refs)),
+		CreatedAt:     j.CreatedAt,
+		UpdatedAt:     j.UpdatedAt,
+	}
+	for _, r := range refs {
+		out.SourceRefs = append(out.SourceRefs, dto.SourceRefDTO{
+			SourceType: r.SourceType,
+			SourceID:   r.SourceID,
+		})
+	}
+	return out
+}
+
+// toJournalListItem 將 model 轉成列表項目
+func toJournalListItem(j *model.Journal) dto.JournalListItem {
+	return dto.JournalListItem{
+		ID:          j.ID,
+		Date:        formatJournalDate(j.Date),
+		Title:       j.Title,
+		Mood:        j.Mood,
+		IsDraft:     j.IsDraft,
+		GeneratedBy: j.GeneratedBy,
+		CreatedAt:   j.CreatedAt,
+		UpdatedAt:   j.UpdatedAt,
+	}
+}
+
+// writeJournalError 統一輸出 AppError
+func writeJournalError(c *gin.Context, err error) {
+	if appErr, ok := err.(*model.AppError); ok {
+		c.JSON(appErr.Status, dto.ErrorResponse{Code: appErr.Code, Message: appErr.Message})
+		return
+	}
+	c.JSON(http.StatusInternalServerError, dto.ErrorResponse{
+		Code:    "INTERNAL_ERROR",
+		Message: "伺服器內部錯誤",
+	})
+}
+
+// Create POST /api/v1/journal
+func (h *JournalHandler) Create(c *gin.Context) {
+	var req dto.CreateJournalRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, dto.ErrorResponse{
+			Code:    model.ErrCodeInvalidInput,
+			Message: err.Error(),
+		})
+		return
+	}
+
+	tz := c.GetHeader("X-Timezone")
+	j, refs, err := h.svc.Create(c.Request.Context(), &req, tz)
+	if err != nil {
+		writeJournalError(c, err)
+		return
+	}
+	c.JSON(http.StatusCreated, toJournalResponse(j, refs))
+}
+
+// GetByDate GET /api/v1/journal/:date
+func (h *JournalHandler) GetByDate(c *gin.Context) {
+	date := c.Param("date")
+	tz := c.GetHeader("X-Timezone")
+
+	j, refs, err := h.svc.GetByDate(c.Request.Context(), date, tz)
+	if err != nil {
+		writeJournalError(c, err)
+		return
+	}
+	c.JSON(http.StatusOK, toJournalResponse(j, refs))
+}
+
+// Update PATCH /api/v1/journal/:date
+func (h *JournalHandler) Update(c *gin.Context) {
+	date := c.Param("date")
+	tz := c.GetHeader("X-Timezone")
+
+	var req dto.UpdateJournalRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, dto.ErrorResponse{
+			Code:    model.ErrCodeInvalidInput,
+			Message: err.Error(),
+		})
+		return
+	}
+
+	j, refs, err := h.svc.Update(c.Request.Context(), date, tz, &req)
+	if err != nil {
+		writeJournalError(c, err)
+		return
+	}
+	c.JSON(http.StatusOK, toJournalResponse(j, refs))
+}
+
+// Delete DELETE /api/v1/journal/:date
+func (h *JournalHandler) Delete(c *gin.Context) {
+	date := c.Param("date")
+	tz := c.GetHeader("X-Timezone")
+
+	if err := h.svc.Delete(c.Request.Context(), date, tz); err != nil {
+		writeJournalError(c, err)
+		return
+	}
+	c.Status(http.StatusNoContent)
+}
+
+// List GET /api/v1/journal?page=&per_page=&since=&until=&mood=&is_draft=
+func (h *JournalHandler) List(c *gin.Context) {
+	tz := c.GetHeader("X-Timezone")
+	if tz == "" {
+		tz = "UTC"
+	}
+	loc, err := time.LoadLocation(tz)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, dto.ErrorResponse{
+			Code:    model.ErrCodeInvalidInput,
+			Message: "無效的時區",
+		})
+		return
+	}
+
+	opts := repository.JournalListOptions{
+		Page:    1,
+		PerPage: 20,
+	}
+
+	if v := c.Query("page"); v != "" {
+		n, err := strconv.Atoi(v)
+		if err != nil || n < 1 {
+			c.JSON(http.StatusBadRequest, dto.ErrorResponse{
+				Code:    model.ErrCodeInvalidInput,
+				Message: "page 必須為正整數",
+			})
+			return
+		}
+		opts.Page = n
+	}
+	if v := c.Query("per_page"); v != "" {
+		n, err := strconv.Atoi(v)
+		if err != nil || n < 1 || n > 200 {
+			c.JSON(http.StatusBadRequest, dto.ErrorResponse{
+				Code:    model.ErrCodeInvalidInput,
+				Message: "per_page 必須為 1~200 的整數",
+			})
+			return
+		}
+		opts.PerPage = n
+	}
+	if v := c.Query("since"); v != "" {
+		t, err := time.ParseInLocation("2006-01-02", v, loc)
+		if err != nil {
+			c.JSON(http.StatusBadRequest, dto.ErrorResponse{
+				Code:    model.ErrCodeInvalidInput,
+				Message: "無效的 since 日期格式，需 YYYY-MM-DD",
+			})
+			return
+		}
+		ut := time.Date(t.Year(), t.Month(), t.Day(), 0, 0, 0, 0, time.UTC)
+		opts.Since = &ut
+	}
+	if v := c.Query("until"); v != "" {
+		t, err := time.ParseInLocation("2006-01-02", v, loc)
+		if err != nil {
+			c.JSON(http.StatusBadRequest, dto.ErrorResponse{
+				Code:    model.ErrCodeInvalidInput,
+				Message: "無效的 until 日期格式，需 YYYY-MM-DD",
+			})
+			return
+		}
+		ut := time.Date(t.Year(), t.Month(), t.Day(), 0, 0, 0, 0, time.UTC)
+		opts.Until = &ut
+	}
+	if v := c.Query("mood"); v != "" {
+		switch v {
+		case model.MoodGreat, model.MoodOk, model.MoodDown:
+			m := v
+			opts.Mood = &m
+		default:
+			c.JSON(http.StatusBadRequest, dto.ErrorResponse{
+				Code:    model.ErrCodeInvalidInput,
+				Message: "mood 必須為 great / ok / down",
+			})
+			return
+		}
+	}
+	if v := c.Query("is_draft"); v != "" {
+		parsed, err := strconv.ParseBool(v)
+		if err != nil {
+			c.JSON(http.StatusBadRequest, dto.ErrorResponse{
+				Code:    model.ErrCodeInvalidInput,
+				Message: "is_draft 必須為 bool",
+			})
+			return
+		}
+		opts.IsDraft = &parsed
+	}
+
+	items, total, err := h.svc.List(c.Request.Context(), opts)
+	if err != nil {
+		writeJournalError(c, err)
+		return
+	}
+
+	data := make([]dto.JournalListItem, 0, len(items))
+	for _, j := range items {
+		data = append(data, toJournalListItem(j))
+	}
+
+	totalPages := 0
+	if opts.PerPage > 0 {
+		totalPages = int((total + int64(opts.PerPage) - 1) / int64(opts.PerPage))
+	}
+
+	c.JSON(http.StatusOK, dto.ListJournalResponse{
+		Data: data,
+		Pagination: dto.PaginationResponse{
+			Page:       opts.Page,
+			PerPage:    opts.PerPage,
+			Total:      int(total),
+			TotalPages: totalPages,
+		},
+	})
+}

--- a/dev/src/handler/journal_test.go
+++ b/dev/src/handler/journal_test.go
@@ -1,0 +1,378 @@
+package handler
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+	"github.com/gpwork4u/aibo/dto"
+	"github.com/gpwork4u/aibo/model"
+	"github.com/gpwork4u/aibo/repository"
+	"github.com/gpwork4u/aibo/service"
+)
+
+// ─── 共用 fake repos（與 service test 同形狀，但獨立避免 cross-package 依賴） ──
+
+type fakeJournalRepo struct {
+	createErr error
+
+	getJournal *model.Journal
+	getRefs    []model.JournalSourceRef
+
+	updateRet *model.Journal
+	updateErr error
+
+	deleteErr error
+
+	listItems []*model.Journal
+	listTotal int64
+
+	getRefsRet []model.JournalSourceRef
+}
+
+func (r *fakeJournalRepo) Create(ctx context.Context, j *model.Journal, refs []model.JournalSourceRef) error {
+	if r.createErr != nil {
+		return r.createErr
+	}
+	if j.ID == uuid.Nil {
+		j.ID = uuid.New()
+	}
+	now := time.Now()
+	j.CreatedAt = now
+	j.UpdatedAt = now
+	r.getJournal = j
+	r.getRefs = refs
+	return nil
+}
+func (r *fakeJournalRepo) GetByDate(ctx context.Context, date time.Time) (*model.Journal, []model.JournalSourceRef, error) {
+	if r.getJournal == nil {
+		return nil, nil, nil
+	}
+	return r.getJournal, r.getRefs, nil
+}
+func (r *fakeJournalRepo) Update(ctx context.Context, date time.Time, patch *dto.UpdateJournalRequest) (*model.Journal, error) {
+	if r.updateErr != nil {
+		return nil, r.updateErr
+	}
+	return r.updateRet, nil
+}
+func (r *fakeJournalRepo) Delete(ctx context.Context, date time.Time) error { return r.deleteErr }
+func (r *fakeJournalRepo) List(ctx context.Context, opts repository.JournalListOptions) ([]*model.Journal, int64, error) {
+	return r.listItems, r.listTotal, nil
+}
+func (r *fakeJournalRepo) ReplaceSourceRefs(ctx context.Context, journalID uuid.UUID, refs []model.JournalSourceRef) error {
+	return nil
+}
+func (r *fakeJournalRepo) GetSourceRefs(ctx context.Context, journalID uuid.UUID) ([]model.JournalSourceRef, error) {
+	return r.getRefsRet, nil
+}
+
+// 最小 EntryRepository（FindByID 用 existing map）
+type fakeEntryRepo struct {
+	existing map[uuid.UUID]bool
+}
+
+func (r *fakeEntryRepo) Create(ctx context.Context, e *model.Entry) error { return nil }
+func (r *fakeEntryRepo) FindByID(ctx context.Context, id uuid.UUID) (*model.Entry, error) {
+	if r.existing[id] {
+		return &model.Entry{ID: id}, nil
+	}
+	return nil, nil
+}
+func (r *fakeEntryRepo) List(ctx context.Context, f model.EntryFilter) (*model.EntryListResult, error) {
+	return nil, nil
+}
+func (r *fakeEntryRepo) Update(ctx context.Context, e *model.Entry) error { return nil }
+func (r *fakeEntryRepo) Delete(ctx context.Context, id uuid.UUID) error   { return nil }
+func (r *fakeEntryRepo) ConfirmEntry(ctx context.Context, id uuid.UUID) (*model.Entry, error) {
+	return nil, nil
+}
+func (r *fakeEntryRepo) FlagEntry(ctx context.Context, id uuid.UUID, reason string, note *string) (*model.Entry, *model.EntryFlag, error) {
+	return nil, nil, nil
+}
+func (r *fakeEntryRepo) GetFlags(ctx context.Context, id uuid.UUID) ([]model.EntryFlag, error) {
+	return nil, nil
+}
+func (r *fakeEntryRepo) ExistsBySourceRef(ctx context.Context, st, sr string) (bool, error) {
+	return false, nil
+}
+func (r *fakeEntryRepo) CategoryExists(ctx context.Context, id uuid.UUID) (bool, error) {
+	return false, nil
+}
+func (r *fakeEntryRepo) ListByDateRange(ctx context.Context, s, u, tz string) ([]dto.CalendarEntrySummary, error) {
+	return nil, nil
+}
+func (r *fakeEntryRepo) SupersedeEntry(ctx context.Context, o, n uuid.UUID) (*model.Entry, error) {
+	return nil, nil
+}
+func (r *fakeEntryRepo) ClearSupersede(ctx context.Context, id uuid.UUID) (*model.Entry, error) {
+	return nil, nil
+}
+func (r *fakeEntryRepo) GetSupersedeChain(ctx context.Context, id uuid.UUID) ([]repository.HistoryItem, error) {
+	return nil, nil
+}
+func (r *fakeEntryRepo) CheckCircularSupersede(ctx context.Context, o, n uuid.UUID) (bool, error) {
+	return false, nil
+}
+
+// ─── helper ─────────────────────────────────────────────────────────────
+
+func newJournalTestRouter(t *testing.T) (*gin.Engine, *fakeJournalRepo, *fakeEntryRepo) {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+	jr := &fakeJournalRepo{}
+	er := &fakeEntryRepo{existing: map[uuid.UUID]bool{}}
+	svc := service.NewJournalService(jr, er)
+	h := NewJournalHandler(svc)
+
+	r := gin.New()
+	g := r.Group("/api/v1/journal")
+	g.GET("", h.List)
+	g.POST("", h.Create)
+	g.GET("/:date", h.GetByDate)
+	g.PATCH("/:date", h.Update)
+	g.DELETE("/:date", h.Delete)
+	return r, jr, er
+}
+
+func doReq(r *gin.Engine, method, path string, body any) *httptest.ResponseRecorder {
+	var buf *bytes.Buffer
+	if body != nil {
+		b, _ := json.Marshal(body)
+		buf = bytes.NewBuffer(b)
+	} else {
+		buf = bytes.NewBuffer(nil)
+	}
+	req := httptest.NewRequest(method, path, buf)
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	return w
+}
+
+// ─── Tests ──────────────────────────────────────────────────────────────
+
+func TestJournalHandler_Create_201(t *testing.T) {
+	r, _, _ := newJournalTestRouter(t)
+	mood := "great"
+	body := dto.CreateJournalRequest{
+		Date:    "2026-04-24",
+		Content: "Good day.",
+		Mood:    &mood,
+	}
+	w := doReq(r, http.MethodPost, "/api/v1/journal", body)
+	if w.Code != http.StatusCreated {
+		t.Fatalf("expected 201, got %d, body=%s", w.Code, w.Body.String())
+	}
+	var resp dto.JournalResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if resp.IsDraft {
+		t.Error("expected is_draft=false")
+	}
+	if resp.GeneratedBy == nil || *resp.GeneratedBy != "user" {
+		t.Errorf("expected generated_by=user, got %v", resp.GeneratedBy)
+	}
+	if resp.Date != "2026-04-24" {
+		t.Errorf("expected date 2026-04-24, got %s", resp.Date)
+	}
+}
+
+func TestJournalHandler_Create_InvalidJSON(t *testing.T) {
+	r, _, _ := newJournalTestRouter(t)
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/journal", strings.NewReader("not json"))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("expected 400, got %d", w.Code)
+	}
+}
+
+func TestJournalHandler_Create_ContentTooLong(t *testing.T) {
+	r, _, _ := newJournalTestRouter(t)
+	long := strings.Repeat("a", 20001)
+	body := dto.CreateJournalRequest{Date: "2026-04-24", Content: long}
+	w := doReq(r, http.MethodPost, "/api/v1/journal", body)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", w.Code)
+	}
+	var er dto.ErrorResponse
+	_ = json.Unmarshal(w.Body.Bytes(), &er)
+	if er.Code != model.ErrCodeInvalidInput {
+		t.Errorf("expected INVALID_INPUT, got %s", er.Code)
+	}
+}
+
+func TestJournalHandler_Create_409Duplicate(t *testing.T) {
+	r, jr, _ := newJournalTestRouter(t)
+	jr.createErr = model.NewAppError(409, model.ErrCodeJournalExists, "當日日記已存在")
+	body := dto.CreateJournalRequest{Date: "2026-04-24", Content: "x"}
+	w := doReq(r, http.MethodPost, "/api/v1/journal", body)
+	if w.Code != http.StatusConflict {
+		t.Fatalf("expected 409, got %d", w.Code)
+	}
+	var er dto.ErrorResponse
+	_ = json.Unmarshal(w.Body.Bytes(), &er)
+	if er.Code != model.ErrCodeJournalExists {
+		t.Errorf("expected JOURNAL_EXISTS, got %s", er.Code)
+	}
+}
+
+func TestJournalHandler_GetByDate_404(t *testing.T) {
+	r, _, _ := newJournalTestRouter(t)
+	w := doReq(r, http.MethodGet, "/api/v1/journal/2026-04-24", nil)
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("expected 404, got %d", w.Code)
+	}
+	var er dto.ErrorResponse
+	_ = json.Unmarshal(w.Body.Bytes(), &er)
+	if er.Code != model.ErrCodeJournalNotFound {
+		t.Errorf("expected JOURNAL_NOT_FOUND, got %s", er.Code)
+	}
+}
+
+func TestJournalHandler_GetByDate_200(t *testing.T) {
+	r, jr, _ := newJournalTestRouter(t)
+	id := uuid.New()
+	gen := "user"
+	jr.getJournal = &model.Journal{
+		ID:          id,
+		Date:        time.Date(2026, 4, 24, 0, 0, 0, 0, time.UTC),
+		Content:     "hello",
+		IsDraft:     false,
+		GeneratedBy: &gen,
+		Highlights:  []string{"a"},
+	}
+	jr.getRefs = []model.JournalSourceRef{
+		{JournalID: id, SourceType: "entry", SourceID: "e1"},
+	}
+	w := doReq(r, http.MethodGet, "/api/v1/journal/2026-04-24", nil)
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d, body=%s", w.Code, w.Body.String())
+	}
+	var resp dto.JournalResponse
+	_ = json.Unmarshal(w.Body.Bytes(), &resp)
+	if resp.Date != "2026-04-24" {
+		t.Errorf("expected date 2026-04-24, got %s", resp.Date)
+	}
+	if len(resp.SourceRefs) != 1 {
+		t.Errorf("expected 1 source_ref, got %d", len(resp.SourceRefs))
+	}
+}
+
+func TestJournalHandler_Update_200_PreservesGeneratedBy(t *testing.T) {
+	r, jr, _ := newJournalTestRouter(t)
+	gen := "llm"
+	jr.updateRet = &model.Journal{
+		ID:          uuid.New(),
+		Date:        time.Date(2026, 4, 24, 0, 0, 0, 0, time.UTC),
+		Content:     "edited",
+		IsDraft:     false,
+		GeneratedBy: &gen,
+	}
+	patch := dto.UpdateJournalRequest{}
+	c := "edited"
+	patch.Content = &c
+	f := false
+	patch.IsDraft = &f
+
+	w := doReq(r, http.MethodPatch, "/api/v1/journal/2026-04-24", patch)
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d, body=%s", w.Code, w.Body.String())
+	}
+	var resp dto.JournalResponse
+	_ = json.Unmarshal(w.Body.Bytes(), &resp)
+	if resp.IsDraft {
+		t.Error("expected is_draft=false")
+	}
+	if resp.GeneratedBy == nil || *resp.GeneratedBy != "llm" {
+		t.Errorf("expected generated_by=llm, got %v", resp.GeneratedBy)
+	}
+}
+
+func TestJournalHandler_Update_404(t *testing.T) {
+	r, jr, _ := newJournalTestRouter(t)
+	jr.updateErr = model.NewAppError(404, model.ErrCodeJournalNotFound, "當日尚無日記")
+	w := doReq(r, http.MethodPatch, "/api/v1/journal/2026-04-24", dto.UpdateJournalRequest{})
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("expected 404, got %d", w.Code)
+	}
+}
+
+func TestJournalHandler_Delete_204(t *testing.T) {
+	r, _, _ := newJournalTestRouter(t)
+	w := doReq(r, http.MethodDelete, "/api/v1/journal/2026-04-24", nil)
+	if w.Code != http.StatusNoContent {
+		t.Fatalf("expected 204, got %d", w.Code)
+	}
+}
+
+func TestJournalHandler_Delete_404(t *testing.T) {
+	r, jr, _ := newJournalTestRouter(t)
+	jr.deleteErr = model.NewAppError(404, model.ErrCodeJournalNotFound, "x")
+	w := doReq(r, http.MethodDelete, "/api/v1/journal/2026-04-24", nil)
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("expected 404, got %d", w.Code)
+	}
+}
+
+func TestJournalHandler_List_200(t *testing.T) {
+	r, jr, _ := newJournalTestRouter(t)
+	jr.listItems = []*model.Journal{
+		{ID: uuid.New(), Date: time.Date(2026, 4, 24, 0, 0, 0, 0, time.UTC)},
+		{ID: uuid.New(), Date: time.Date(2026, 4, 23, 0, 0, 0, 0, time.UTC)},
+	}
+	jr.listTotal = 2
+
+	w := doReq(r, http.MethodGet, "/api/v1/journal?since=2026-04-01&until=2026-04-30&mood=ok&is_draft=false&page=1&per_page=10", nil)
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d, body=%s", w.Code, w.Body.String())
+	}
+	var resp dto.ListJournalResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if len(resp.Data) != 2 {
+		t.Errorf("expected 2 items, got %d", len(resp.Data))
+	}
+	if resp.Pagination.Total != 2 {
+		t.Errorf("expected total=2, got %d", resp.Pagination.Total)
+	}
+	if resp.Pagination.TotalPages != 1 {
+		t.Errorf("expected total_pages=1, got %d", resp.Pagination.TotalPages)
+	}
+}
+
+func TestJournalHandler_List_InvalidQuery(t *testing.T) {
+	r, _, _ := newJournalTestRouter(t)
+	cases := []string{
+		"/api/v1/journal?page=abc",
+		"/api/v1/journal?per_page=-1",
+		"/api/v1/journal?since=bad-date",
+		"/api/v1/journal?until=bad-date",
+		"/api/v1/journal?mood=invalid",
+		"/api/v1/journal?is_draft=notbool",
+	}
+	for _, p := range cases {
+		w := doReq(r, http.MethodGet, p, nil)
+		if w.Code != http.StatusBadRequest {
+			t.Errorf("[%s] expected 400, got %d", p, w.Code)
+		}
+	}
+}
+
+func TestFormatJournalDate(t *testing.T) {
+	d := time.Date(2026, 4, 24, 0, 0, 0, 0, time.UTC)
+	if got := formatJournalDate(d); got != "2026-04-24" {
+		t.Errorf("expected 2026-04-24, got %s", got)
+	}
+}

--- a/dev/src/main.go
+++ b/dev/src/main.go
@@ -133,8 +133,13 @@ func main() {
 	calendarSvc := service.NewCalendarService(entryRepo, gcalSvc, true)
 	calendarHandler := handler.NewCalendarHandler(calendarSvc)
 
+	// 初始化日記服務（F-028b：CRUD）
+	journalRepo := repository.NewJournalRepository(pool)
+	journalSvc := service.NewJournalService(journalRepo, entryRepo)
+	journalHandler := handler.NewJournalHandler(journalSvc)
+
 	// 設定路由
-	r := router.Setup(apiKeySvc, apiKeyHandler, categoryHandler, llmProviderHandler, entryHandler, classifyHandler, searchHandler, gitImportHandler, gcalHandler, confidenceHandler, statsHandler, systemHandler, lifecycleHandler, calendarConvertHandler, calendarHandler)
+	r := router.Setup(apiKeySvc, apiKeyHandler, categoryHandler, llmProviderHandler, entryHandler, classifyHandler, searchHandler, gitImportHandler, gcalHandler, confidenceHandler, statsHandler, systemHandler, lifecycleHandler, calendarConvertHandler, calendarHandler, journalHandler)
 
 	// 啟動 HTTP server（graceful shutdown）
 	srv := &http.Server{

--- a/dev/src/router/router.go
+++ b/dev/src/router/router.go
@@ -10,7 +10,7 @@ import (
 )
 
 // Setup 設定路由
-func Setup(apiKeySvc *service.ApiKeyService, apiKeyHandler *handler.ApiKeyHandler, categoryHandler *handler.CategoryHandler, llmProviderHandler *handler.LlmProviderHandler, entryHandler *handler.EntryHandler, classifyHandler *handler.ClassifyHandler, searchHandler *handler.SearchHandler, gitImportHandler *handler.GitImportHandler, gcalHandler *handler.GcalHandler, confidenceHandler *handler.ConfidenceHandler, statsHandler *handler.StatsHandler, systemHandler *handler.SystemHandler, lifecycleHandler *handler.LifecycleHandler, calendarConvertHandler *handler.CalendarConvertHandler, calendarHandler *handler.CalendarHandler) *gin.Engine {
+func Setup(apiKeySvc *service.ApiKeyService, apiKeyHandler *handler.ApiKeyHandler, categoryHandler *handler.CategoryHandler, llmProviderHandler *handler.LlmProviderHandler, entryHandler *handler.EntryHandler, classifyHandler *handler.ClassifyHandler, searchHandler *handler.SearchHandler, gitImportHandler *handler.GitImportHandler, gcalHandler *handler.GcalHandler, confidenceHandler *handler.ConfidenceHandler, statsHandler *handler.StatsHandler, systemHandler *handler.SystemHandler, lifecycleHandler *handler.LifecycleHandler, calendarConvertHandler *handler.CalendarConvertHandler, calendarHandler *handler.CalendarHandler, journalHandler *handler.JournalHandler) *gin.Engine {
 	r := gin.Default()
 
 	// CORS middleware — 允許跨網域（前端 localhost:3000 呼叫 API localhost:8080）
@@ -121,6 +121,16 @@ func Setup(apiKeySvc *service.ApiKeyService, apiKeyHandler *handler.ApiKeyHandle
 		{
 			calendarGroup.GET("", calendarHandler.Aggregate)
 			calendarGroup.GET("/days/:date", calendarHandler.GetDay)
+		}
+
+		// 每日日記（F-028b：CRUD；LLM draft 由 F-028c 補上）
+		journal := v1.Group("/journal")
+		{
+			journal.GET("", journalHandler.List)
+			journal.POST("", journalHandler.Create)
+			journal.GET("/:date", journalHandler.GetByDate)
+			journal.PATCH("/:date", journalHandler.Update)
+			journal.DELETE("/:date", journalHandler.Delete)
 		}
 	}
 

--- a/dev/src/service/journal.go
+++ b/dev/src/service/journal.go
@@ -1,0 +1,248 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/gpwork4u/aibo/dto"
+	"github.com/gpwork4u/aibo/model"
+	"github.com/gpwork4u/aibo/repository"
+	"github.com/jackc/pgx/v5"
+)
+
+// JournalService 每日日記 business logic（F-028b：CRUD，不含 LLM draft）
+//
+// 不含 LLM draft 路徑（POST /:date/draft），那由 F-028c 補上。
+type JournalService struct {
+	journalRepo JournalRepository
+	entryRepo   EntryRepository // 用於驗證 source_refs.entry 存在
+}
+
+// NewJournalService 建立 JournalService
+func NewJournalService(jr JournalRepository, er EntryRepository) *JournalService {
+	return &JournalService{journalRepo: jr, entryRepo: er}
+}
+
+// JournalListOptions service 層暴露給 handler 用，避免 handler import repository
+type JournalListOptions = repository.JournalListOptions
+
+// ParseDate 解析 YYYY-MM-DD（依 tz 轉成當天 00:00 UTC，再轉為 DATE）
+//
+// 因為 DB 用 DATE 型別（無時區），這裡僅取「該 tz 下指定那一天」的 UTC midnight 表示。
+// 與 calendar.go 的時區慣例一致：tz 為空字串時使用 UTC。
+func parseJournalDate(dateStr, tz string) (time.Time, error) {
+	if dateStr == "" {
+		return time.Time{}, model.NewAppError(400, model.ErrCodeInvalidInput, "date 為必填（格式 YYYY-MM-DD）")
+	}
+	if tz == "" {
+		tz = "UTC"
+	}
+	loc, err := time.LoadLocation(tz)
+	if err != nil {
+		return time.Time{}, model.NewAppError(400, model.ErrCodeInvalidInput, "無效的時區")
+	}
+	t, err := time.ParseInLocation("2006-01-02", dateStr, loc)
+	if err != nil {
+		return time.Time{}, model.NewAppError(400, model.ErrCodeInvalidInput, "無效的日期格式，需 YYYY-MM-DD")
+	}
+	// 轉成 UTC 的同一天 00:00（pgx DATE 編碼會以 UTC 解讀 time.Time 的年月日）
+	return time.Date(t.Year(), t.Month(), t.Day(), 0, 0, 0, 0, time.UTC), nil
+}
+
+// validateAndConvertSourceRefs 驗證 source_refs，並轉成 model 結構
+//
+// - source_type 必須為 entry / gcal_event（DTO binding 已先擋一道）
+// - 當 source_type=entry 時，service 用 EntryRepository.FindByID 驗證存在性
+//   不存在 → 400 INVALID_INPUT with message "source entry not found"
+func (s *JournalService) validateAndConvertSourceRefs(
+	ctx context.Context, refs []dto.SourceRefDTO,
+) ([]model.JournalSourceRef, error) {
+	out := make([]model.JournalSourceRef, 0, len(refs))
+	for _, r := range refs {
+		switch r.SourceType {
+		case model.JournalSourceTypeEntry:
+			id, err := uuid.Parse(r.SourceID)
+			if err != nil {
+				return nil, model.NewAppError(400, model.ErrCodeInvalidInput, "source entry id 格式錯誤")
+			}
+			entry, err := s.entryRepo.FindByID(ctx, id)
+			if err != nil {
+				return nil, err
+			}
+			if entry == nil {
+				return nil, model.NewAppError(400, model.ErrCodeInvalidInput, "source entry not found")
+			}
+		case model.JournalSourceTypeGcalEvent:
+			// gcal event id 為 string，不在 DB 中存對應表，跳過存在性檢查
+			if r.SourceID == "" {
+				return nil, model.NewAppError(400, model.ErrCodeInvalidInput, "source_id 為必填")
+			}
+		default:
+			return nil, model.NewAppError(400, model.ErrCodeInvalidInput, "source_type 必須為 entry / gcal_event")
+		}
+		out = append(out, model.JournalSourceRef{
+			SourceType: r.SourceType,
+			SourceID:   r.SourceID,
+		})
+	}
+	return out, nil
+}
+
+// Create 建立日記
+//
+// - generated_by 由 service 設為 'user'（不接受 client 傳入）
+// - is_draft 一律 false
+// - 若該日已存在 → 409 JOURNAL_EXISTS（由 repository 的 PgError mapping 處理）
+func (s *JournalService) Create(
+	ctx context.Context, req *dto.CreateJournalRequest, tz string,
+) (*model.Journal, []model.JournalSourceRef, error) {
+	if req == nil {
+		return nil, nil, model.NewAppError(400, model.ErrCodeInvalidInput, "request body 為必填")
+	}
+
+	date, err := parseJournalDate(req.Date, tz)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// service 層長度驗證（雙保險，DTO 已標 max=20000）
+	if l := len(req.Content); l > 20000 {
+		return nil, nil, model.NewAppError(400, model.ErrCodeInvalidInput, "日記內容超過 20000 字上限")
+	}
+
+	refs, err := s.validateAndConvertSourceRefs(ctx, req.SourceRefs)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	gen := model.GeneratedByUser
+	highlights := req.Highlights
+	if highlights == nil {
+		highlights = []string{}
+	}
+
+	j := &model.Journal{
+		Date:        date,
+		Title:       req.Title,
+		Content:     req.Content,
+		Mood:        req.Mood,
+		Highlights:  highlights,
+		IsDraft:     false,
+		GeneratedBy: &gen,
+	}
+
+	if err := s.journalRepo.Create(ctx, j, refs); err != nil {
+		return nil, nil, err
+	}
+
+	// 從 DB 重抓（拿到 source_refs 完整 journal_id 等）
+	created, gotRefs, err := s.journalRepo.GetByDate(ctx, date)
+	if err != nil {
+		return nil, nil, err
+	}
+	if created == nil {
+		// 理論上不會發生
+		return j, refs, nil
+	}
+	slog.InfoContext(ctx, "journal.create",
+		"id", created.ID,
+		"date", req.Date,
+		"source_refs", len(gotRefs),
+	)
+	return created, gotRefs, nil
+}
+
+// GetByDate 取得單日 journal
+//
+// 不存在 → 404 JOURNAL_NOT_FOUND
+func (s *JournalService) GetByDate(
+	ctx context.Context, dateStr, tz string,
+) (*model.Journal, []model.JournalSourceRef, error) {
+	date, err := parseJournalDate(dateStr, tz)
+	if err != nil {
+		return nil, nil, err
+	}
+	j, refs, err := s.journalRepo.GetByDate(ctx, date)
+	if err != nil {
+		return nil, nil, err
+	}
+	if j == nil {
+		return nil, nil, model.NewAppError(404, model.ErrCodeJournalNotFound, "當日尚無日記")
+	}
+	return j, refs, nil
+}
+
+// Update partial 更新；保留原 generated_by。
+//
+// - 若 patch 含 source_refs（非 nil）→ 整批覆寫，service 端先驗證 entry 存在性
+// - 不存在當日 journal → 404 JOURNAL_NOT_FOUND
+func (s *JournalService) Update(
+	ctx context.Context, dateStr, tz string, req *dto.UpdateJournalRequest,
+) (*model.Journal, []model.JournalSourceRef, error) {
+	if req == nil {
+		return nil, nil, model.NewAppError(400, model.ErrCodeInvalidInput, "request body 為必填")
+	}
+	date, err := parseJournalDate(dateStr, tz)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// service 層 content 長度雙保險
+	if req.Content != nil && len(*req.Content) > 20000 {
+		return nil, nil, model.NewAppError(400, model.ErrCodeInvalidInput, "日記內容超過 20000 字上限")
+	}
+
+	// 若帶 source_refs，先驗證
+	if req.SourceRefs != nil {
+		if _, err := s.validateAndConvertSourceRefs(ctx, *req.SourceRefs); err != nil {
+			return nil, nil, err
+		}
+	}
+
+	updated, err := s.journalRepo.Update(ctx, date, req)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	refs, err := s.journalRepo.GetSourceRefs(ctx, updated.ID)
+	if err != nil {
+		return nil, nil, err
+	}
+	slog.InfoContext(ctx, "journal.update", "id", updated.ID, "date", dateStr)
+	return updated, refs, nil
+}
+
+// Delete 刪除單日 journal（CASCADE 連帶刪除 source_refs）
+//
+// 不存在 → 404 JOURNAL_NOT_FOUND
+func (s *JournalService) Delete(ctx context.Context, dateStr, tz string) error {
+	date, err := parseJournalDate(dateStr, tz)
+	if err != nil {
+		return err
+	}
+	if err := s.journalRepo.Delete(ctx, date); err != nil {
+		return err
+	}
+	slog.InfoContext(ctx, "journal.delete", "date", dateStr)
+	return nil
+}
+
+// List 分頁列表（不含 source_refs / content）
+//
+// query：page, per_page, since, until, mood, is_draft
+func (s *JournalService) List(
+	ctx context.Context, opts JournalListOptions,
+) ([]*model.Journal, int64, error) {
+	items, total, err := s.journalRepo.List(ctx, opts)
+	if err != nil {
+		return nil, 0, err
+	}
+	return items, total, nil
+}
+
+// 確保 pgx.ErrNoRows 不會逃逸（防呆 — 目前路徑都已包成 AppError）
+var _ = errors.Is
+var _ = pgx.ErrNoRows

--- a/dev/src/service/journal_test.go
+++ b/dev/src/service/journal_test.go
@@ -1,0 +1,444 @@
+package service
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/gpwork4u/aibo/dto"
+	"github.com/gpwork4u/aibo/model"
+	"github.com/gpwork4u/aibo/repository"
+	"github.com/jackc/pgx/v5"
+)
+
+// ─── Fake JournalRepository ────────────────────────────────────────────
+
+type fakeJournalRepo struct {
+	createCalled bool
+	createErr    error
+	createArgs   *model.Journal
+	createRefs   []model.JournalSourceRef
+
+	getJournal *model.Journal
+	getRefs    []model.JournalSourceRef
+	getErr     error
+
+	updateCalled bool
+	updateRet    *model.Journal
+	updateErr    error
+	updatedPatch *dto.UpdateJournalRequest
+
+	deleteCalled bool
+	deleteErr    error
+
+	listItems []*model.Journal
+	listTotal int64
+	listErr   error
+	listOpts  repository.JournalListOptions
+
+	getRefsRet []model.JournalSourceRef
+	getRefsErr error
+}
+
+func (r *fakeJournalRepo) Create(ctx context.Context, j *model.Journal, refs []model.JournalSourceRef) error {
+	r.createCalled = true
+	r.createArgs = j
+	r.createRefs = refs
+	if r.createErr != nil {
+		return r.createErr
+	}
+	if j.ID == uuid.Nil {
+		j.ID = uuid.New()
+	}
+	now := time.Now()
+	j.CreatedAt = now
+	j.UpdatedAt = now
+	// 模擬：插入後 GetByDate 拿得到
+	r.getJournal = j
+	r.getRefs = refs
+	return nil
+}
+
+func (r *fakeJournalRepo) GetByDate(ctx context.Context, date time.Time) (*model.Journal, []model.JournalSourceRef, error) {
+	if r.getErr != nil {
+		return nil, nil, r.getErr
+	}
+	if r.getJournal == nil {
+		return nil, nil, nil
+	}
+	return r.getJournal, r.getRefs, nil
+}
+
+func (r *fakeJournalRepo) Update(ctx context.Context, date time.Time, patch *dto.UpdateJournalRequest) (*model.Journal, error) {
+	r.updateCalled = true
+	r.updatedPatch = patch
+	if r.updateErr != nil {
+		return nil, r.updateErr
+	}
+	return r.updateRet, nil
+}
+
+func (r *fakeJournalRepo) Delete(ctx context.Context, date time.Time) error {
+	r.deleteCalled = true
+	return r.deleteErr
+}
+
+func (r *fakeJournalRepo) List(ctx context.Context, opts repository.JournalListOptions) ([]*model.Journal, int64, error) {
+	r.listOpts = opts
+	if r.listErr != nil {
+		return nil, 0, r.listErr
+	}
+	return r.listItems, r.listTotal, nil
+}
+
+func (r *fakeJournalRepo) ReplaceSourceRefs(ctx context.Context, journalID uuid.UUID, refs []model.JournalSourceRef) error {
+	return nil
+}
+
+func (r *fakeJournalRepo) GetSourceRefs(ctx context.Context, journalID uuid.UUID) ([]model.JournalSourceRef, error) {
+	if r.getRefsErr != nil {
+		return nil, r.getRefsErr
+	}
+	return r.getRefsRet, nil
+}
+
+// ─── Fake EntryRepository（最小實作，僅 FindByID 有用） ──────────────────
+
+type fakeEntryRepoForJournal struct {
+	existing map[uuid.UUID]bool
+}
+
+func (r *fakeEntryRepoForJournal) Create(ctx context.Context, entry *model.Entry) error {
+	return nil
+}
+func (r *fakeEntryRepoForJournal) FindByID(ctx context.Context, id uuid.UUID) (*model.Entry, error) {
+	if r.existing[id] {
+		return &model.Entry{ID: id}, nil
+	}
+	return nil, nil
+}
+func (r *fakeEntryRepoForJournal) List(ctx context.Context, filter model.EntryFilter) (*model.EntryListResult, error) {
+	return nil, nil
+}
+func (r *fakeEntryRepoForJournal) Update(ctx context.Context, entry *model.Entry) error { return nil }
+func (r *fakeEntryRepoForJournal) Delete(ctx context.Context, id uuid.UUID) error       { return nil }
+func (r *fakeEntryRepoForJournal) ConfirmEntry(ctx context.Context, id uuid.UUID) (*model.Entry, error) {
+	return nil, nil
+}
+func (r *fakeEntryRepoForJournal) FlagEntry(ctx context.Context, id uuid.UUID, reason string, note *string) (*model.Entry, *model.EntryFlag, error) {
+	return nil, nil, nil
+}
+func (r *fakeEntryRepoForJournal) GetFlags(ctx context.Context, entryID uuid.UUID) ([]model.EntryFlag, error) {
+	return nil, nil
+}
+func (r *fakeEntryRepoForJournal) ExistsBySourceRef(ctx context.Context, sourceType, sourceRef string) (bool, error) {
+	return false, nil
+}
+func (r *fakeEntryRepoForJournal) CategoryExists(ctx context.Context, id uuid.UUID) (bool, error) {
+	return false, nil
+}
+func (r *fakeEntryRepoForJournal) ListByDateRange(ctx context.Context, sinceDate, untilDate string, tz string) ([]dto.CalendarEntrySummary, error) {
+	return nil, nil
+}
+func (r *fakeEntryRepoForJournal) SupersedeEntry(ctx context.Context, oldID, newID uuid.UUID) (*model.Entry, error) {
+	return nil, nil
+}
+func (r *fakeEntryRepoForJournal) ClearSupersede(ctx context.Context, id uuid.UUID) (*model.Entry, error) {
+	return nil, nil
+}
+func (r *fakeEntryRepoForJournal) GetSupersedeChain(ctx context.Context, id uuid.UUID) ([]repository.HistoryItem, error) {
+	return nil, nil
+}
+func (r *fakeEntryRepoForJournal) CheckCircularSupersede(ctx context.Context, oldID, newID uuid.UUID) (bool, error) {
+	return false, nil
+}
+
+// ─── Tests ─────────────────────────────────────────────────────────────
+
+func newJournalSvc(t *testing.T) (*JournalService, *fakeJournalRepo, *fakeEntryRepoForJournal) {
+	t.Helper()
+	jr := &fakeJournalRepo{}
+	er := &fakeEntryRepoForJournal{existing: map[uuid.UUID]bool{}}
+	return NewJournalService(jr, er), jr, er
+}
+
+func TestParseJournalDate(t *testing.T) {
+	d, err := parseJournalDate("2026-04-24", "")
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if d.Year() != 2026 || d.Month() != 4 || d.Day() != 24 {
+		t.Errorf("expected 2026-04-24, got %v", d)
+	}
+	if d.Location() != time.UTC {
+		t.Errorf("expected UTC, got %v", d.Location())
+	}
+
+	if _, err := parseJournalDate("", ""); err == nil {
+		t.Error("empty date should error")
+	}
+	if _, err := parseJournalDate("2026/04/24", ""); err == nil {
+		t.Error("invalid format should error")
+	}
+	if _, err := parseJournalDate("2026-04-24", "Not/A/Zone"); err == nil {
+		t.Error("invalid tz should error")
+	}
+	// 合法 tz
+	if _, err := parseJournalDate("2026-04-24", "Asia/Taipei"); err != nil {
+		t.Errorf("Asia/Taipei should be valid: %v", err)
+	}
+}
+
+func TestJournalSvc_Create_HappyPath(t *testing.T) {
+	svc, repo, _ := newJournalSvc(t)
+	mood := model.MoodGreat
+	req := &dto.CreateJournalRequest{
+		Date:    "2026-04-24",
+		Content: "Good day.",
+		Mood:    &mood,
+	}
+	j, refs, err := svc.Create(context.Background(), req, "")
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if !repo.createCalled {
+		t.Fatal("repo.Create not called")
+	}
+	if j.IsDraft {
+		t.Error("expected is_draft=false")
+	}
+	if j.GeneratedBy == nil || *j.GeneratedBy != model.GeneratedByUser {
+		t.Errorf("expected generated_by=user, got %v", j.GeneratedBy)
+	}
+	if len(refs) != 0 {
+		t.Errorf("expected 0 refs, got %d", len(refs))
+	}
+}
+
+func TestJournalSvc_Create_ContentTooLong(t *testing.T) {
+	svc, _, _ := newJournalSvc(t)
+	long := make([]byte, 20001)
+	for i := range long {
+		long[i] = 'a'
+	}
+	req := &dto.CreateJournalRequest{
+		Date:    "2026-04-24",
+		Content: string(long),
+	}
+	_, _, err := svc.Create(context.Background(), req, "")
+	appErr, ok := err.(*model.AppError)
+	if !ok {
+		t.Fatalf("expected AppError, got %T", err)
+	}
+	if appErr.Status != 400 || appErr.Code != model.ErrCodeInvalidInput {
+		t.Errorf("expected 400 INVALID_INPUT, got %+v", appErr)
+	}
+}
+
+func TestJournalSvc_Create_SourceEntryNotFound(t *testing.T) {
+	svc, _, _ := newJournalSvc(t)
+	req := &dto.CreateJournalRequest{
+		Date:    "2026-04-24",
+		Content: "x",
+		SourceRefs: []dto.SourceRefDTO{
+			{SourceType: model.JournalSourceTypeEntry, SourceID: uuid.New().String()},
+		},
+	}
+	_, _, err := svc.Create(context.Background(), req, "")
+	appErr, ok := err.(*model.AppError)
+	if !ok {
+		t.Fatalf("expected AppError, got %T (%v)", err, err)
+	}
+	if appErr.Code != model.ErrCodeInvalidInput {
+		t.Errorf("expected INVALID_INPUT, got %s", appErr.Code)
+	}
+	if appErr.Message != "source entry not found" {
+		t.Errorf("expected 'source entry not found', got %q", appErr.Message)
+	}
+}
+
+func TestJournalSvc_Create_SourceEntryFound(t *testing.T) {
+	svc, _, er := newJournalSvc(t)
+	id := uuid.New()
+	er.existing[id] = true
+	req := &dto.CreateJournalRequest{
+		Date:    "2026-04-24",
+		Content: "x",
+		SourceRefs: []dto.SourceRefDTO{
+			{SourceType: model.JournalSourceTypeEntry, SourceID: id.String()},
+			{SourceType: model.JournalSourceTypeGcalEvent, SourceID: "gcal-1"},
+		},
+	}
+	if _, _, err := svc.Create(context.Background(), req, ""); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+}
+
+func TestJournalSvc_Create_DuplicateDate(t *testing.T) {
+	svc, repo, _ := newJournalSvc(t)
+	repo.createErr = model.NewAppError(409, model.ErrCodeJournalExists, "當日日記已存在")
+	req := &dto.CreateJournalRequest{Date: "2026-04-24", Content: "x"}
+	_, _, err := svc.Create(context.Background(), req, "")
+	appErr, ok := err.(*model.AppError)
+	if !ok {
+		t.Fatalf("expected AppError, got %T", err)
+	}
+	if appErr.Status != 409 || appErr.Code != model.ErrCodeJournalExists {
+		t.Errorf("expected 409 JOURNAL_EXISTS, got %+v", appErr)
+	}
+}
+
+func TestJournalSvc_GetByDate_NotFound(t *testing.T) {
+	svc, _, _ := newJournalSvc(t)
+	_, _, err := svc.GetByDate(context.Background(), "2026-04-24", "")
+	appErr, ok := err.(*model.AppError)
+	if !ok {
+		t.Fatalf("expected AppError, got %T", err)
+	}
+	if appErr.Status != 404 || appErr.Code != model.ErrCodeJournalNotFound {
+		t.Errorf("expected 404 JOURNAL_NOT_FOUND, got %+v", appErr)
+	}
+}
+
+func TestJournalSvc_GetByDate_OK(t *testing.T) {
+	svc, repo, _ := newJournalSvc(t)
+	id := uuid.New()
+	repo.getJournal = &model.Journal{ID: id, Content: "hello"}
+	repo.getRefs = []model.JournalSourceRef{
+		{JournalID: id, SourceType: "entry", SourceID: "e1"},
+	}
+	j, refs, err := svc.GetByDate(context.Background(), "2026-04-24", "")
+	if err != nil {
+		t.Fatalf("GetByDate: %v", err)
+	}
+	if j.ID != id {
+		t.Error("wrong journal returned")
+	}
+	if len(refs) != 1 {
+		t.Errorf("expected 1 ref, got %d", len(refs))
+	}
+}
+
+func TestJournalSvc_Update_PreservesGeneratedBy(t *testing.T) {
+	svc, repo, _ := newJournalSvc(t)
+	gen := model.GeneratedByLlm
+	id := uuid.New()
+	// repo.Update returns updated journal as-is（不動 generated_by）
+	repo.updateRet = &model.Journal{
+		ID:          id,
+		Content:     "edited",
+		IsDraft:     false,
+		GeneratedBy: &gen, // 仍維持 llm
+	}
+	repo.getRefsRet = []model.JournalSourceRef{}
+
+	newContent := "edited"
+	isDraft := false
+	req := &dto.UpdateJournalRequest{
+		Content: &newContent,
+		IsDraft: &isDraft,
+	}
+	j, _, err := svc.Update(context.Background(), "2026-04-24", "", req)
+	if err != nil {
+		t.Fatalf("Update: %v", err)
+	}
+	if j.IsDraft {
+		t.Error("expected is_draft=false")
+	}
+	if j.GeneratedBy == nil || *j.GeneratedBy != model.GeneratedByLlm {
+		t.Errorf("generated_by should remain 'llm', got %v", j.GeneratedBy)
+	}
+}
+
+func TestJournalSvc_Update_NotFound(t *testing.T) {
+	svc, repo, _ := newJournalSvc(t)
+	repo.updateErr = model.NewAppError(404, model.ErrCodeJournalNotFound, "當日尚無日記")
+	_, _, err := svc.Update(context.Background(), "2026-04-24", "", &dto.UpdateJournalRequest{})
+	appErr, ok := err.(*model.AppError)
+	if !ok {
+		t.Fatalf("expected AppError, got %T", err)
+	}
+	if appErr.Status != 404 {
+		t.Errorf("expected 404, got %d", appErr.Status)
+	}
+}
+
+func TestJournalSvc_Update_ContentTooLong(t *testing.T) {
+	svc, _, _ := newJournalSvc(t)
+	long := make([]byte, 20001)
+	for i := range long {
+		long[i] = 'a'
+	}
+	s := string(long)
+	req := &dto.UpdateJournalRequest{Content: &s}
+	_, _, err := svc.Update(context.Background(), "2026-04-24", "", req)
+	appErr, ok := err.(*model.AppError)
+	if !ok {
+		t.Fatalf("expected AppError, got %T", err)
+	}
+	if appErr.Code != model.ErrCodeInvalidInput {
+		t.Errorf("expected INVALID_INPUT, got %s", appErr.Code)
+	}
+}
+
+func TestJournalSvc_Delete(t *testing.T) {
+	svc, repo, _ := newJournalSvc(t)
+	if err := svc.Delete(context.Background(), "2026-04-24", ""); err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+	if !repo.deleteCalled {
+		t.Error("repo.Delete not called")
+	}
+}
+
+func TestJournalSvc_Delete_NotFound(t *testing.T) {
+	svc, repo, _ := newJournalSvc(t)
+	repo.deleteErr = model.NewAppError(404, model.ErrCodeJournalNotFound, "當日尚無日記")
+	err := svc.Delete(context.Background(), "2026-04-24", "")
+	appErr, ok := err.(*model.AppError)
+	if !ok {
+		t.Fatalf("expected AppError, got %T", err)
+	}
+	if appErr.Status != 404 {
+		t.Errorf("expected 404, got %d", appErr.Status)
+	}
+}
+
+func TestJournalSvc_List_PassesOptions(t *testing.T) {
+	svc, repo, _ := newJournalSvc(t)
+	repo.listItems = []*model.Journal{{ID: uuid.New()}, {ID: uuid.New()}}
+	repo.listTotal = 2
+
+	mood := model.MoodOk
+	isDraft := true
+	since := time.Date(2026, 4, 1, 0, 0, 0, 0, time.UTC)
+	until := time.Date(2026, 4, 30, 0, 0, 0, 0, time.UTC)
+
+	items, total, err := svc.List(context.Background(), repository.JournalListOptions{
+		Page:    2,
+		PerPage: 10,
+		Since:   &since,
+		Until:   &until,
+		Mood:    &mood,
+		IsDraft: &isDraft,
+	})
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if total != 2 {
+		t.Errorf("expected total=2, got %d", total)
+	}
+	if len(items) != 2 {
+		t.Errorf("expected 2 items, got %d", len(items))
+	}
+	if repo.listOpts.Page != 2 || repo.listOpts.PerPage != 10 {
+		t.Errorf("opts not propagated: %+v", repo.listOpts)
+	}
+	if repo.listOpts.Mood == nil || *repo.listOpts.Mood != model.MoodOk {
+		t.Error("mood not propagated")
+	}
+}
+
+// 防止 import 被 vet 視為未使用
+var _ = pgx.ErrNoRows


### PR DESCRIPTION
Closes #97

5 個 endpoints：
- GET    /api/v1/journal/:date
- POST   /api/v1/journal/:date  （409 重複日期）
- PATCH  /api/v1/journal/:date
- DELETE /api/v1/journal/:date
- GET    /api/v1/journal?since=&until=

不含 LLM draft（F-028c 處理）。go build / vet 通過。

🤖 Generated with [Claude Code](https://claude.com/claude-code)