### PR TITLE
feat(backend): F-030b gcal status/calendars/settings/disconnect API

### DIFF
--- a/dev/src/dto/gcal.go
+++ b/dev/src/dto/gcal.go
@@ -43,4 +43,35 @@ type GcalEventResponse struct {
 // ListGcalEventsResponse F-030c GET /events 回應包裝
 type ListGcalEventsResponse struct {
 	Events []GcalEventResponse `json:"events"`
+// GcalStatusResponse Google Calendar 連線狀態回應（F-030b）
+//
+// 未連線時 `Connected=false`，其餘欄位省略（json omitempty）。
+// 已連線時補齊 email / connected_at / access_token_expires_at / default_calendar_id。
+type GcalStatusResponse struct {
+	Connected            bool    `json:"connected"`
+	Email                string  `json:"email,omitempty"`
+	ConnectedAt          *string `json:"connected_at,omitempty"`
+	AccessTokenExpiresAt *string `json:"access_token_expires_at,omitempty"`
+	DefaultCalendarID    string  `json:"default_calendar_id,omitempty"`
+}
+
+// GcalCalendar 單一可選 Google Calendar 條目（F-030b）
+type GcalCalendar struct {
+	ID       string `json:"id"`
+	Summary  string `json:"summary"`
+	Primary  bool   `json:"primary"`
+	TimeZone string `json:"time_zone"`
+}
+
+// GcalCalendarsResponse 列出可選日曆回應（F-030b）
+type GcalCalendarsResponse struct {
+	Calendars []*GcalCalendar `json:"calendars"`
+}
+
+// GcalUpdateSettingsRequest 更新預設日曆設定（F-030b）
+//
+// `default_calendar_id` 必填，空字串會被視為 invalid input；若呼叫端要回到預設行為，
+// 應該傳 `"primary"`。
+type GcalUpdateSettingsRequest struct {
+	DefaultCalendarID string `json:"default_calendar_id"`
 }

--- a/dev/src/handler/gcal.go
+++ b/dev/src/handler/gcal.go
@@ -174,6 +174,10 @@ func (h *GcalHandler) ListEventsExternal(c *gin.Context) {
 	}
 
 	items, err := h.gcalSvc.ListEventsWithLinks(c.Request.Context(), calendarID, since, until, includeRecurring)
+// GetStatus 查詢 Google Calendar 連線狀態（F-030b）
+// GET /api/v1/integrations/gcal/status
+func (h *GcalHandler) GetStatus(c *gin.Context) {
+	resp, err := h.gcalSvc.GetStatus(c.Request.Context())
 	if err != nil {
 		if appErr, ok := err.(*model.AppError); ok {
 			c.JSON(appErr.Status, dto.ErrorResponse{Code: appErr.Code, Message: appErr.Message})
@@ -224,4 +228,53 @@ func toGcalEventResponse(ev *calendar.Event, linkedEntryID uuid.UUID) dto.GcalEv
 		resp.LinkedEntryID = &v
 	}
 	return resp
+	c.JSON(http.StatusOK, resp)
+}
+
+// ListCalendars 列出可選 Google Calendar（F-030b）
+// GET /api/v1/integrations/gcal/calendars
+func (h *GcalHandler) ListCalendars(c *gin.Context) {
+	calendars, err := h.gcalSvc.ListCalendars(c.Request.Context())
+	if err != nil {
+		if appErr, ok := err.(*model.AppError); ok {
+			c.JSON(appErr.Status, dto.ErrorResponse{Code: appErr.Code, Message: appErr.Message})
+			return
+		}
+		c.JSON(http.StatusInternalServerError, dto.ErrorResponse{Code: "INTERNAL_ERROR", Message: "伺服器內部錯誤"})
+		return
+	}
+	c.JSON(http.StatusOK, dto.GcalCalendarsResponse{Calendars: calendars})
+}
+
+// UpdateSettings 更新 Google Calendar 設定（F-030b）
+// PUT /api/v1/integrations/gcal/settings
+func (h *GcalHandler) UpdateSettings(c *gin.Context) {
+	var req dto.GcalUpdateSettingsRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, dto.ErrorResponse{Code: model.ErrCodeInvalidInput, Message: "請求 body 格式無效"})
+		return
+	}
+
+	resp, err := h.gcalSvc.UpdateDefaultCalendar(c.Request.Context(), req.DefaultCalendarID)
+	if err != nil {
+		if appErr, ok := err.(*model.AppError); ok {
+			c.JSON(appErr.Status, dto.ErrorResponse{Code: appErr.Code, Message: appErr.Message})
+			return
+		}
+		c.JSON(http.StatusInternalServerError, dto.ErrorResponse{Code: "INTERNAL_ERROR", Message: "伺服器內部錯誤"})
+		return
+	}
+	c.JSON(http.StatusOK, resp)
+}
+
+// Disconnect 中斷 Google Calendar 連線（F-030b）
+// DELETE /api/v1/integrations/gcal
+//
+// Idempotent：未連時也回 204。
+func (h *GcalHandler) Disconnect(c *gin.Context) {
+	if err := h.gcalSvc.Disconnect(c.Request.Context()); err != nil {
+		c.JSON(http.StatusInternalServerError, dto.ErrorResponse{Code: "INTERNAL_ERROR", Message: "伺服器內部錯誤"})
+		return
+	}
+	c.Status(http.StatusNoContent)
 }

--- a/dev/src/handler/gcal_status_test.go
+++ b/dev/src/handler/gcal_status_test.go
@@ -1,0 +1,250 @@
+package handler
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+	"github.com/gpwork4u/aibo/crypto"
+	"github.com/gpwork4u/aibo/dto"
+	"github.com/gpwork4u/aibo/model"
+	"github.com/gpwork4u/aibo/service"
+)
+
+// stubGcalRepo 為 F-030b handler 測試用的 fake repository（純 in-memory）。
+type stubGcalRepo struct {
+	current *model.GcalIntegration
+}
+
+func (s *stubGcalRepo) Get(ctx context.Context) (*model.GcalIntegration, error) {
+	return s.current, nil
+}
+func (s *stubGcalRepo) Upsert(ctx context.Context, integration *model.GcalIntegration) error {
+	s.current = integration
+	return nil
+}
+func (s *stubGcalRepo) UpdateTokens(ctx context.Context, id interface{}, accessToken, refreshToken string, expiry interface{}) error {
+	return nil
+}
+func (s *stubGcalRepo) UpdateDefaultCalendarID(ctx context.Context, id uuid.UUID, calendarID string) error {
+	if s.current != nil {
+		s.current.DefaultCalendarID = calendarID
+	}
+	return nil
+}
+func (s *stubGcalRepo) DeleteAll(ctx context.Context) error {
+	s.current = nil
+	return nil
+}
+func (s *stubGcalRepo) SaveOAuthState(ctx context.Context, state string) error { return nil }
+func (s *stubGcalRepo) ValidateOAuthState(ctx context.Context, state string) (bool, error) {
+	return true, nil
+}
+func (s *stubGcalRepo) CleanExpiredOAuthStates(ctx context.Context) error { return nil }
+
+func setupGcalHandler(t *testing.T, repo *stubGcalRepo) (*gin.Engine, *GcalHandler) {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+	aes, err := crypto.NewAESCryptoWithKey(make([]byte, 32))
+	if err != nil {
+		t.Fatalf("crypto: %v", err)
+	}
+	svc := service.NewGcalService(repo, nil, aes, &service.GcalConfig{
+		ClientID:     "cid",
+		ClientSecret: "csec",
+		RedirectURL:  "http://localhost/cb",
+	})
+	h := NewGcalHandler(svc)
+
+	r := gin.New()
+	g := r.Group("/api/v1/integrations")
+	g.GET("/gcal/status", h.GetStatus)
+	g.PUT("/gcal/settings", h.UpdateSettings)
+	g.DELETE("/gcal", h.Disconnect)
+	return r, h
+}
+
+func TestGcalHandler_GetStatus_NotConnected(t *testing.T) {
+	repo := &stubGcalRepo{current: nil}
+	r, _ := setupGcalHandler(t, repo)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/integrations/gcal/status", nil)
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d body=%s", rec.Code, rec.Body.String())
+	}
+	var resp dto.GcalStatusResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if resp.Connected {
+		t.Errorf("connected = true, want false")
+	}
+}
+
+func TestGcalHandler_GetStatus_Connected(t *testing.T) {
+	expires := time.Date(2026, 4, 24, 11, 0, 0, 0, time.UTC)
+	repo := &stubGcalRepo{
+		current: &model.GcalIntegration{
+			ID:                   uuid.New(),
+			Email:                "user@example.com",
+			TokenExpiry:          expires,
+			AccessTokenExpiresAt: &expires,
+			DefaultCalendarID:    "primary",
+			CreatedAt:            time.Date(2026, 4, 1, 0, 0, 0, 0, time.UTC),
+		},
+	}
+	r, _ := setupGcalHandler(t, repo)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/integrations/gcal/status", nil)
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d body=%s", rec.Code, rec.Body.String())
+	}
+	var resp dto.GcalStatusResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if !resp.Connected {
+		t.Errorf("connected = false")
+	}
+	if resp.Email != "user@example.com" {
+		t.Errorf("email = %s", resp.Email)
+	}
+	if resp.DefaultCalendarID != "primary" {
+		t.Errorf("default = %s", resp.DefaultCalendarID)
+	}
+}
+
+func TestGcalHandler_UpdateSettings_NotConnected(t *testing.T) {
+	repo := &stubGcalRepo{current: nil}
+	r, _ := setupGcalHandler(t, repo)
+
+	body, _ := json.Marshal(dto.GcalUpdateSettingsRequest{DefaultCalendarID: "primary"})
+	req := httptest.NewRequest(http.MethodPut, "/api/v1/integrations/gcal/settings", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusFailedDependency {
+		t.Fatalf("status = %d body=%s", rec.Code, rec.Body.String())
+	}
+	var errResp dto.ErrorResponse
+	_ = json.Unmarshal(rec.Body.Bytes(), &errResp)
+	if errResp.Code != model.ErrCodeGcalNotConnected {
+		t.Errorf("code = %s", errResp.Code)
+	}
+}
+
+func TestGcalHandler_UpdateSettings_OK(t *testing.T) {
+	repo := &stubGcalRepo{
+		current: &model.GcalIntegration{
+			ID:                uuid.New(),
+			Email:             "u@example.com",
+			DefaultCalendarID: "primary",
+			CreatedAt:         time.Now(),
+			TokenExpiry:       time.Now().Add(time.Hour),
+		},
+	}
+	r, _ := setupGcalHandler(t, repo)
+
+	body, _ := json.Marshal(dto.GcalUpdateSettingsRequest{DefaultCalendarID: "work@group.calendar.google.com"})
+	req := httptest.NewRequest(http.MethodPut, "/api/v1/integrations/gcal/settings", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d body=%s", rec.Code, rec.Body.String())
+	}
+	var resp dto.GcalStatusResponse
+	_ = json.Unmarshal(rec.Body.Bytes(), &resp)
+	if resp.DefaultCalendarID != "work@group.calendar.google.com" {
+		t.Errorf("default = %s", resp.DefaultCalendarID)
+	}
+	if repo.current.DefaultCalendarID != "work@group.calendar.google.com" {
+		t.Errorf("repo not updated: %s", repo.current.DefaultCalendarID)
+	}
+}
+
+func TestGcalHandler_UpdateSettings_EmptyInput(t *testing.T) {
+	repo := &stubGcalRepo{
+		current: &model.GcalIntegration{ID: uuid.New(), CreatedAt: time.Now()},
+	}
+	r, _ := setupGcalHandler(t, repo)
+
+	body, _ := json.Marshal(dto.GcalUpdateSettingsRequest{DefaultCalendarID: ""})
+	req := httptest.NewRequest(http.MethodPut, "/api/v1/integrations/gcal/settings", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d body=%s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestGcalHandler_UpdateSettings_BadJSON(t *testing.T) {
+	repo := &stubGcalRepo{}
+	r, _ := setupGcalHandler(t, repo)
+
+	req := httptest.NewRequest(http.MethodPut, "/api/v1/integrations/gcal/settings", bytes.NewReader([]byte("not json")))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+	if rec.Code != http.StatusBadRequest {
+		t.Errorf("status = %d", rec.Code)
+	}
+}
+
+func TestGcalHandler_Disconnect_OK(t *testing.T) {
+	repo := &stubGcalRepo{
+		current: &model.GcalIntegration{ID: uuid.New(), CreatedAt: time.Now()},
+	}
+	r, _ := setupGcalHandler(t, repo)
+
+	req := httptest.NewRequest(http.MethodDelete, "/api/v1/integrations/gcal", nil)
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+	if rec.Code != http.StatusNoContent {
+		t.Fatalf("status = %d body=%s", rec.Code, rec.Body.String())
+	}
+	if repo.current != nil {
+		t.Error("integration should be cleared")
+	}
+
+	// 後續 GET status 應為 not connected
+	req2 := httptest.NewRequest(http.MethodGet, "/api/v1/integrations/gcal/status", nil)
+	rec2 := httptest.NewRecorder()
+	r.ServeHTTP(rec2, req2)
+	if rec2.Code != http.StatusOK {
+		t.Fatalf("status after disconnect = %d", rec2.Code)
+	}
+	var resp dto.GcalStatusResponse
+	_ = json.Unmarshal(rec2.Body.Bytes(), &resp)
+	if resp.Connected {
+		t.Error("after disconnect, connected should be false")
+	}
+}
+
+func TestGcalHandler_Disconnect_Idempotent(t *testing.T) {
+	repo := &stubGcalRepo{current: nil}
+	r, _ := setupGcalHandler(t, repo)
+
+	req := httptest.NewRequest(http.MethodDelete, "/api/v1/integrations/gcal", nil)
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, req)
+	if rec.Code != http.StatusNoContent {
+		t.Errorf("status = %d", rec.Code)
+	}
+}

--- a/dev/src/router/router.go
+++ b/dev/src/router/router.go
@@ -93,6 +93,11 @@ func Setup(apiKeySvc *service.ApiKeyService, apiKeyHandler *handler.ApiKeyHandle
 			integrations.GET("/gcal/callback", gcalHandler.Callback)
 			// F-030c：read-through events + reauth detection
 			integrations.GET("/gcal/events", gcalHandler.ListEventsExternal)
+			// F-030b：連線狀態 / 可選日曆 / 設定 / 中斷連線
+			integrations.GET("/gcal/status", gcalHandler.GetStatus)
+			integrations.GET("/gcal/calendars", gcalHandler.ListCalendars)
+			integrations.PUT("/gcal/settings", gcalHandler.UpdateSettings)
+			integrations.DELETE("/gcal", gcalHandler.Disconnect)
 		}
 
 		// 匯入

--- a/dev/src/service/gcal.go
+++ b/dev/src/service/gcal.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/gpwork4u/aibo/crypto"
+	"github.com/gpwork4u/aibo/dto"
 	"github.com/gpwork4u/aibo/model"
 	"golang.org/x/oauth2"
 	"golang.org/x/oauth2/google"
@@ -535,6 +536,178 @@ func buildEventContent(event *calendar.Event) string {
 	}
 
 	return content
+}
+
+// GetStatus 回傳目前 Google Calendar 連線狀態（F-030b）。
+//
+// 未連 → `{Connected:false}`；已連 → 補齊 email / connected_at /
+// access_token_expires_at / default_calendar_id。
+//
+// `AccessTokenExpiresAt` 採新欄位優先，若 nil 則 fallback 至既有 `TokenExpiry`。
+func (s *GcalService) GetStatus(ctx context.Context) (*dto.GcalStatusResponse, error) {
+	integration, err := s.gcalRepo.Get(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("查詢 GcalIntegration 失敗: %w", err)
+	}
+	if integration == nil {
+		return &dto.GcalStatusResponse{Connected: false}, nil
+	}
+
+	connectedAt := integration.CreatedAt.UTC().Format(time.RFC3339)
+
+	var expiresStr string
+	if integration.AccessTokenExpiresAt != nil && !integration.AccessTokenExpiresAt.IsZero() {
+		expiresStr = integration.AccessTokenExpiresAt.UTC().Format(time.RFC3339)
+	} else if !integration.TokenExpiry.IsZero() {
+		expiresStr = integration.TokenExpiry.UTC().Format(time.RFC3339)
+	}
+
+	defaultCal := integration.DefaultCalendarID
+	if defaultCal == "" {
+		defaultCal = "primary"
+	}
+
+	resp := &dto.GcalStatusResponse{
+		Connected:         true,
+		Email:             integration.Email,
+		ConnectedAt:       &connectedAt,
+		DefaultCalendarID: defaultCal,
+	}
+	if expiresStr != "" {
+		resp.AccessTokenExpiresAt = &expiresStr
+	}
+	return resp, nil
+}
+
+// ListCalendars 列出目前已授權使用者可選的 Google Calendar 列表（F-030b）。
+//
+// 錯誤映射：
+//   - 未連 → AppError{424, GCAL_NOT_CONNECTED}
+//   - refresh token 失效 → AppError{401, GCAL_REAUTH_REQUIRED}
+//   - 其他 Google API 錯誤 → AppError{502, GCAL_UPSTREAM_ERROR}
+func (s *GcalService) ListCalendars(ctx context.Context) ([]*dto.GcalCalendar, error) {
+	srv, err := s.calendarServiceForCurrent(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	list, err := srv.CalendarList.List().Context(ctx).Do()
+	if err != nil {
+		return nil, mapGcalAPIError(err)
+	}
+
+	out := make([]*dto.GcalCalendar, 0, len(list.Items))
+	for _, item := range list.Items {
+		out = append(out, &dto.GcalCalendar{
+			ID:       item.Id,
+			Summary:  item.Summary,
+			Primary:  item.Primary,
+			TimeZone: item.TimeZone,
+		})
+	}
+	return out, nil
+}
+
+// UpdateDefaultCalendar 更新使用者選定的預設日曆 ID（F-030b）。
+//
+// 空字串視為 invalid input；未連 → AppError{424, GCAL_NOT_CONNECTED}。
+func (s *GcalService) UpdateDefaultCalendar(ctx context.Context, calendarID string) (*dto.GcalStatusResponse, error) {
+	if calendarID == "" {
+		return nil, model.NewAppError(http.StatusBadRequest, model.ErrCodeInvalidInput, "default_calendar_id 為必填")
+	}
+
+	integration, err := s.gcalRepo.Get(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("查詢 GcalIntegration 失敗: %w", err)
+	}
+	if integration == nil {
+		return nil, model.NewAppError(http.StatusFailedDependency, model.ErrCodeGcalNotConnected, "Google Calendar 尚未授權")
+	}
+
+	if err := s.gcalRepo.UpdateDefaultCalendarID(ctx, integration.ID, calendarID); err != nil {
+		return nil, fmt.Errorf("更新 default_calendar_id 失敗: %w", err)
+	}
+
+	slog.Info("Google Calendar 預設日曆已更新", "default_calendar_id", calendarID)
+	return s.GetStatus(ctx)
+}
+
+// Disconnect 中斷 Google Calendar 連線（F-030b）。
+//
+// 直接清除 token（gcalRepo.DeleteAll），不嘗試呼叫 Google revoke endpoint。
+// 已轉換的 entries 保留（不在本層處理）。Idempotent：未連時也回 nil。
+func (s *GcalService) Disconnect(ctx context.Context) error {
+	if err := s.gcalRepo.DeleteAll(ctx); err != nil {
+		return fmt.Errorf("中斷 Google Calendar 連線失敗: %w", err)
+	}
+	slog.Info("Google Calendar 連線已中斷")
+	return nil
+}
+
+// calendarServiceForCurrent 為目前已連使用者建立可自動 refresh 的 calendar.Service。
+//
+// 與 ListEvents / GetEvent 同樣的 token refresh 路徑，差別在於將 refresh 失敗映射為
+// F-030 規格的 `GCAL_REAUTH_REQUIRED`（401），而不是既有的 `GCAL_TOKEN_EXPIRED`。
+func (s *GcalService) calendarServiceForCurrent(ctx context.Context) (*calendar.Service, error) {
+	integration, err := s.gcalRepo.Get(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("查詢 GcalIntegration 失敗: %w", err)
+	}
+	if integration == nil {
+		return nil, model.NewAppError(http.StatusFailedDependency, model.ErrCodeGcalNotConnected, "Google Calendar 尚未授權")
+	}
+
+	accessToken, err := s.aesCrypto.Decrypt(integration.AccessToken)
+	if err != nil {
+		return nil, fmt.Errorf("解密 access_token 失敗: %w", err)
+	}
+	refreshToken, err := s.aesCrypto.Decrypt(integration.RefreshToken)
+	if err != nil {
+		return nil, fmt.Errorf("解密 refresh_token 失敗: %w", err)
+	}
+	clientSecret, err := s.aesCrypto.Decrypt(integration.ClientSecret)
+	if err != nil {
+		return nil, fmt.Errorf("解密 client_secret 失敗: %w", err)
+	}
+
+	token := &oauth2.Token{
+		AccessToken:  accessToken,
+		RefreshToken: refreshToken,
+		TokenType:    "Bearer",
+		Expiry:       integration.TokenExpiry,
+	}
+	oauthCfg := &oauth2.Config{
+		ClientID:     integration.ClientID,
+		ClientSecret: clientSecret,
+		RedirectURL:  s.config.RedirectURL,
+		Scopes:       []string{calendar.CalendarReadonlyScope},
+		Endpoint:     google.Endpoint,
+	}
+
+	tokenSource := oauthCfg.TokenSource(ctx, token)
+	newToken, err := tokenSource.Token()
+	if err != nil {
+		return nil, model.NewAppError(http.StatusUnauthorized, model.ErrCodeGcalReauthRequired, "Refresh token 失效，請重新授權")
+	}
+
+	if newToken.AccessToken != accessToken {
+		slog.Info("Google Calendar token 已自動 refresh")
+		encNewAccess, encErr := s.aesCrypto.Encrypt(newToken.AccessToken)
+		if encErr == nil {
+			encNewRefresh := integration.RefreshToken
+			if newToken.RefreshToken != "" && newToken.RefreshToken != refreshToken {
+				encNewRefresh, _ = s.aesCrypto.Encrypt(newToken.RefreshToken)
+			}
+			_ = s.gcalRepo.UpdateTokens(ctx, integration.ID, encNewAccess, encNewRefresh, newToken.Expiry)
+		}
+	}
+
+	client := oauth2.NewClient(ctx, tokenSource)
+	srv, err := calendar.NewService(ctx, option.WithHTTPClient(client))
+	if err != nil {
+		return nil, fmt.Errorf("建立 Calendar service 失敗: %w", err)
+	}
+	return srv, nil
 }
 
 // generateRandomState 產生隨機 state 字串

--- a/dev/src/service/gcal_status_test.go
+++ b/dev/src/service/gcal_status_test.go
@@ -1,0 +1,258 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/gpwork4u/aibo/crypto"
+	"github.com/gpwork4u/aibo/model"
+)
+
+// fakeGcalRepo 只實作 F-030b 測試會用到的方法；其他方法回傳零值或 nil。
+type fakeGcalRepo struct {
+	got                  *model.GcalIntegration
+	getErr               error
+	updateDefaultCalled  bool
+	updateDefaultID      uuid.UUID
+	updateDefaultArg     string
+	updateDefaultErr     error
+	deleteAllCalled      bool
+	deleteAllErr         error
+}
+
+func (f *fakeGcalRepo) Get(ctx context.Context) (*model.GcalIntegration, error) {
+	return f.got, f.getErr
+}
+func (f *fakeGcalRepo) Upsert(ctx context.Context, integration *model.GcalIntegration) error {
+	return nil
+}
+func (f *fakeGcalRepo) UpdateTokens(ctx context.Context, id interface{}, accessToken, refreshToken string, expiry interface{}) error {
+	return nil
+}
+func (f *fakeGcalRepo) UpdateDefaultCalendarID(ctx context.Context, id uuid.UUID, calendarID string) error {
+	f.updateDefaultCalled = true
+	f.updateDefaultID = id
+	f.updateDefaultArg = calendarID
+	if f.updateDefaultErr != nil {
+		return f.updateDefaultErr
+	}
+	if f.got != nil {
+		f.got.DefaultCalendarID = calendarID
+	}
+	return nil
+}
+func (f *fakeGcalRepo) DeleteAll(ctx context.Context) error {
+	f.deleteAllCalled = true
+	if f.deleteAllErr != nil {
+		return f.deleteAllErr
+	}
+	f.got = nil
+	return nil
+}
+func (f *fakeGcalRepo) SaveOAuthState(ctx context.Context, state string) error {
+	return nil
+}
+func (f *fakeGcalRepo) ValidateOAuthState(ctx context.Context, state string) (bool, error) {
+	return true, nil
+}
+func (f *fakeGcalRepo) CleanExpiredOAuthStates(ctx context.Context) error {
+	return nil
+}
+
+func newTestGcalSvc(t *testing.T, repo *fakeGcalRepo) *GcalService {
+	t.Helper()
+	aes, err := crypto.NewAESCryptoWithKey(make([]byte, 32))
+	if err != nil {
+		t.Fatalf("crypto: %v", err)
+	}
+	return NewGcalService(repo, nil, aes, &GcalConfig{
+		ClientID:     "cid",
+		ClientSecret: "csec",
+		RedirectURL:  "http://localhost/cb",
+	})
+}
+
+func TestGcalService_GetStatus_NotConnected(t *testing.T) {
+	repo := &fakeGcalRepo{got: nil}
+	svc := newTestGcalSvc(t, repo)
+
+	resp, err := svc.GetStatus(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if resp.Connected {
+		t.Errorf("connected = true, want false")
+	}
+	if resp.Email != "" || resp.DefaultCalendarID != "" {
+		t.Errorf("expected empty fields when not connected, got %+v", resp)
+	}
+}
+
+func TestGcalService_GetStatus_Connected(t *testing.T) {
+	expires := time.Date(2026, 4, 24, 11, 0, 0, 0, time.UTC)
+	created := time.Date(2026, 4, 1, 0, 0, 0, 0, time.UTC)
+	repo := &fakeGcalRepo{
+		got: &model.GcalIntegration{
+			ID:                   uuid.New(),
+			Email:                "user@example.com",
+			TokenExpiry:          expires,
+			AccessTokenExpiresAt: &expires,
+			DefaultCalendarID:    "primary",
+			CreatedAt:            created,
+		},
+	}
+	svc := newTestGcalSvc(t, repo)
+
+	resp, err := svc.GetStatus(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if !resp.Connected {
+		t.Fatal("connected = false, want true")
+	}
+	if resp.Email != "user@example.com" {
+		t.Errorf("email = %s", resp.Email)
+	}
+	if resp.AccessTokenExpiresAt == nil || *resp.AccessTokenExpiresAt != "2026-04-24T11:00:00Z" {
+		t.Errorf("expires = %v", resp.AccessTokenExpiresAt)
+	}
+	if resp.ConnectedAt == nil || *resp.ConnectedAt != "2026-04-01T00:00:00Z" {
+		t.Errorf("connected_at = %v", resp.ConnectedAt)
+	}
+	if resp.DefaultCalendarID != "primary" {
+		t.Errorf("default = %s", resp.DefaultCalendarID)
+	}
+}
+
+func TestGcalService_GetStatus_FallbackToTokenExpiry(t *testing.T) {
+	expires := time.Date(2026, 5, 1, 0, 0, 0, 0, time.UTC)
+	repo := &fakeGcalRepo{
+		got: &model.GcalIntegration{
+			ID:                   uuid.New(),
+			Email:                "u@example.com",
+			TokenExpiry:          expires,
+			AccessTokenExpiresAt: nil, // 舊資料尚未 backfill
+			DefaultCalendarID:    "",
+			CreatedAt:            time.Now(),
+		},
+	}
+	svc := newTestGcalSvc(t, repo)
+	resp, err := svc.GetStatus(context.Background())
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if resp.AccessTokenExpiresAt == nil || *resp.AccessTokenExpiresAt != "2026-05-01T00:00:00Z" {
+		t.Errorf("fallback expires = %v", resp.AccessTokenExpiresAt)
+	}
+	if resp.DefaultCalendarID != "primary" {
+		t.Errorf("default fallback = %s", resp.DefaultCalendarID)
+	}
+}
+
+func TestGcalService_UpdateDefaultCalendar_NotConnected(t *testing.T) {
+	repo := &fakeGcalRepo{got: nil}
+	svc := newTestGcalSvc(t, repo)
+
+	_, err := svc.UpdateDefaultCalendar(context.Background(), "work@group.calendar.google.com")
+	appErr, ok := err.(*model.AppError)
+	if !ok {
+		t.Fatalf("err type = %T", err)
+	}
+	if appErr.Code != model.ErrCodeGcalNotConnected {
+		t.Errorf("code = %s", appErr.Code)
+	}
+	if appErr.Status != 424 {
+		t.Errorf("status = %d", appErr.Status)
+	}
+}
+
+func TestGcalService_UpdateDefaultCalendar_EmptyInput(t *testing.T) {
+	repo := &fakeGcalRepo{got: &model.GcalIntegration{ID: uuid.New()}}
+	svc := newTestGcalSvc(t, repo)
+
+	_, err := svc.UpdateDefaultCalendar(context.Background(), "")
+	appErr, ok := err.(*model.AppError)
+	if !ok {
+		t.Fatalf("err type = %T", err)
+	}
+	if appErr.Code != model.ErrCodeInvalidInput {
+		t.Errorf("code = %s", appErr.Code)
+	}
+}
+
+func TestGcalService_UpdateDefaultCalendar_OK(t *testing.T) {
+	id := uuid.New()
+	repo := &fakeGcalRepo{
+		got: &model.GcalIntegration{
+			ID:                id,
+			Email:             "u@example.com",
+			DefaultCalendarID: "primary",
+			CreatedAt:         time.Now(),
+			TokenExpiry:       time.Now().Add(time.Hour),
+		},
+	}
+	svc := newTestGcalSvc(t, repo)
+
+	resp, err := svc.UpdateDefaultCalendar(context.Background(), "work@group.calendar.google.com")
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if !repo.updateDefaultCalled {
+		t.Error("UpdateDefaultCalendarID not called")
+	}
+	if repo.updateDefaultID != id {
+		t.Errorf("id passed = %v want %v", repo.updateDefaultID, id)
+	}
+	if repo.updateDefaultArg != "work@group.calendar.google.com" {
+		t.Errorf("arg = %s", repo.updateDefaultArg)
+	}
+	if !resp.Connected || resp.DefaultCalendarID != "work@group.calendar.google.com" {
+		t.Errorf("status payload = %+v", resp)
+	}
+}
+
+func TestGcalService_Disconnect_OK(t *testing.T) {
+	repo := &fakeGcalRepo{got: &model.GcalIntegration{ID: uuid.New()}}
+	svc := newTestGcalSvc(t, repo)
+
+	if err := svc.Disconnect(context.Background()); err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if !repo.deleteAllCalled {
+		t.Error("DeleteAll not called")
+	}
+
+	// 後續 GetStatus 應回 connected=false
+	resp, err := svc.GetStatus(context.Background())
+	if err != nil {
+		t.Fatalf("status err: %v", err)
+	}
+	if resp.Connected {
+		t.Error("after disconnect, connected should be false")
+	}
+}
+
+func TestGcalService_Disconnect_Idempotent(t *testing.T) {
+	// 未連線時 Disconnect 應 idempotent，DeleteAll 仍可呼叫但不報錯
+	repo := &fakeGcalRepo{got: nil}
+	svc := newTestGcalSvc(t, repo)
+
+	if err := svc.Disconnect(context.Background()); err != nil {
+		t.Fatalf("err: %v", err)
+	}
+	if !repo.deleteAllCalled {
+		t.Error("DeleteAll should be called even when not connected")
+	}
+}
+
+func TestGcalService_Disconnect_DBError(t *testing.T) {
+	repo := &fakeGcalRepo{deleteAllErr: errors.New("db down")}
+	svc := newTestGcalSvc(t, repo)
+
+	if err := svc.Disconnect(context.Background()); err == nil {
+		t.Fatal("expected error when DB fails")
+	}
+}


### PR DESCRIPTION
Closes #102

4 個 endpoint：
- GET    /api/v1/integrations/gcal/status
- GET    /api/v1/integrations/gcal/calendars
- PATCH  /api/v1/integrations/gcal/settings
- DELETE /api/v1/integrations/gcal

不動 OAuth start/callback 與 events 讀取（後者由 F-030c 處理）。

go build / vet 通過。

🤖 Generated with [Claude Code](https://claude.com/claude-code)