### PR TITLE
feat(backend): F-028c Journal LLM Draft

### DIFF
--- a/dev/src/handler/journal_draft.go
+++ b/dev/src/handler/journal_draft.go
@@ -1,0 +1,79 @@
+package handler
+
+import (
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+	"github.com/gpwork4u/aibo/dto"
+	"github.com/gpwork4u/aibo/model"
+	"github.com/gpwork4u/aibo/service"
+)
+
+// JournalDraftHandler F-028c：LLM 草稿 HTTP handler。
+//
+// 為避免與 F-028b 的 JournalHandler 互相干涉而拆獨立檔。
+type JournalDraftHandler struct {
+	svc *service.JournalDraftService
+}
+
+// NewJournalDraftHandler 建立 handler。
+func NewJournalDraftHandler(svc *service.JournalDraftService) *JournalDraftHandler {
+	return &JournalDraftHandler{svc: svc}
+}
+
+// JournalDraftResponse API 對外回應格式
+type JournalDraftResponse struct {
+	Date        string   `json:"date"`
+	Draft       string   `json:"draft"`
+	UsedRefs    []string `json:"used_refs,omitempty"`
+	Mood        string   `json:"mood,omitempty"`
+	GeneratedBy string   `json:"generated_by"`
+}
+
+// Draft POST /api/v1/journal/:date/draft
+//
+// Headers：X-Timezone（可選）
+// Query：calendar_id（可選，預設 primary）
+//
+// 回應：JournalDraftResponse
+//
+// 錯誤：
+//   - 400 INVALID_INPUT
+//   - 404 NOT_FOUND（當日無素材）
+//   - 424 LLM_NOT_CONFIGURED
+//   - 502 LLM_UPSTREAM_ERROR
+//
+// **Draft 不會寫進 DB**；前端拿 draft 後讓使用者編輯，再透過 PATCH /journal/:date 落地。
+func (h *JournalDraftHandler) Draft(c *gin.Context) {
+	date := c.Param("date")
+	if date == "" {
+		c.JSON(http.StatusBadRequest, dto.ErrorResponse{
+			Code:    model.ErrCodeInvalidInput,
+			Message: "date 為必填（YYYY-MM-DD）",
+		})
+		return
+	}
+	tz := c.GetHeader("X-Timezone")
+	calendarID := c.DefaultQuery("calendar_id", "primary")
+
+	result, err := h.svc.Draft(c.Request.Context(), date, tz, calendarID)
+	if err != nil {
+		if appErr, ok := err.(*model.AppError); ok {
+			c.JSON(appErr.Status, dto.ErrorResponse{Code: appErr.Code, Message: appErr.Message})
+			return
+		}
+		c.JSON(http.StatusInternalServerError, dto.ErrorResponse{
+			Code:    "INTERNAL_ERROR",
+			Message: "伺服器內部錯誤",
+		})
+		return
+	}
+
+	c.JSON(http.StatusOK, JournalDraftResponse{
+		Date:        date,
+		Draft:       result.Draft,
+		UsedRefs:    result.UsedRefs,
+		Mood:        result.Mood,
+		GeneratedBy: result.GeneratedBy,
+	})
+}

--- a/dev/src/main.go
+++ b/dev/src/main.go
@@ -133,13 +133,15 @@ func main() {
 	calendarSvc := service.NewCalendarService(entryRepo, gcalSvc, true)
 	calendarHandler := handler.NewCalendarHandler(calendarSvc)
 
-	// 初始化日記服務（F-028b：CRUD）
+	// 初始化日記服務（F-028b：CRUD；F-028c：LLM draft）
 	journalRepo := repository.NewJournalRepository(pool)
 	journalSvc := service.NewJournalService(journalRepo, entryRepo)
 	journalHandler := handler.NewJournalHandler(journalSvc)
+	journalDraftSvc := service.NewJournalDraftService(llmSvc, entryRepo, gcalSvc)
+	journalDraftHandler := handler.NewJournalDraftHandler(journalDraftSvc)
 
 	// 設定路由
-	r := router.Setup(apiKeySvc, apiKeyHandler, categoryHandler, llmProviderHandler, entryHandler, classifyHandler, searchHandler, gitImportHandler, gcalHandler, confidenceHandler, statsHandler, systemHandler, lifecycleHandler, calendarConvertHandler, calendarHandler, journalHandler)
+	r := router.Setup(apiKeySvc, apiKeyHandler, categoryHandler, llmProviderHandler, entryHandler, classifyHandler, searchHandler, gitImportHandler, gcalHandler, confidenceHandler, statsHandler, systemHandler, lifecycleHandler, calendarConvertHandler, calendarHandler, journalHandler, journalDraftHandler)
 
 	// 啟動 HTTP server（graceful shutdown）
 	srv := &http.Server{

--- a/dev/src/router/router.go
+++ b/dev/src/router/router.go
@@ -10,7 +10,7 @@ import (
 )
 
 // Setup 設定路由
-func Setup(apiKeySvc *service.ApiKeyService, apiKeyHandler *handler.ApiKeyHandler, categoryHandler *handler.CategoryHandler, llmProviderHandler *handler.LlmProviderHandler, entryHandler *handler.EntryHandler, classifyHandler *handler.ClassifyHandler, searchHandler *handler.SearchHandler, gitImportHandler *handler.GitImportHandler, gcalHandler *handler.GcalHandler, confidenceHandler *handler.ConfidenceHandler, statsHandler *handler.StatsHandler, systemHandler *handler.SystemHandler, lifecycleHandler *handler.LifecycleHandler, calendarConvertHandler *handler.CalendarConvertHandler, calendarHandler *handler.CalendarHandler, journalHandler *handler.JournalHandler) *gin.Engine {
+func Setup(apiKeySvc *service.ApiKeyService, apiKeyHandler *handler.ApiKeyHandler, categoryHandler *handler.CategoryHandler, llmProviderHandler *handler.LlmProviderHandler, entryHandler *handler.EntryHandler, classifyHandler *handler.ClassifyHandler, searchHandler *handler.SearchHandler, gitImportHandler *handler.GitImportHandler, gcalHandler *handler.GcalHandler, confidenceHandler *handler.ConfidenceHandler, statsHandler *handler.StatsHandler, systemHandler *handler.SystemHandler, lifecycleHandler *handler.LifecycleHandler, calendarConvertHandler *handler.CalendarConvertHandler, calendarHandler *handler.CalendarHandler, journalHandler *handler.JournalHandler, journalDraftHandler *handler.JournalDraftHandler) *gin.Engine {
 	r := gin.Default()
 
 	// CORS middleware — 允許跨網域（前端 localhost:3000 呼叫 API localhost:8080）
@@ -130,7 +130,7 @@ func Setup(apiKeySvc *service.ApiKeyService, apiKeyHandler *handler.ApiKeyHandle
 			calendarGroup.GET("/days/:date", calendarHandler.GetDay)
 		}
 
-		// 每日日記（F-028b：CRUD；LLM draft 由 F-028c 補上）
+		// 每日日記（F-028b：CRUD；F-028c：LLM draft）
 		journal := v1.Group("/journal")
 		{
 			journal.GET("", journalHandler.List)
@@ -138,6 +138,8 @@ func Setup(apiKeySvc *service.ApiKeyService, apiKeyHandler *handler.ApiKeyHandle
 			journal.GET("/:date", journalHandler.GetByDate)
 			journal.PATCH("/:date", journalHandler.Update)
 			journal.DELETE("/:date", journalHandler.Delete)
+			// F-028c：LLM 草稿（不直接寫入 DB；前端拿 draft 編輯後再 PATCH）
+			journal.POST("/:date/draft", journalDraftHandler.Draft)
 		}
 	}
 

--- a/dev/src/service/journal_draft.go
+++ b/dev/src/service/journal_draft.go
@@ -1,0 +1,271 @@
+package service
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"strings"
+	"time"
+
+	"github.com/gpwork4u/aibo/dto"
+	"github.com/gpwork4u/aibo/model"
+	"github.com/sashabaranov/go-openai"
+)
+
+// JournalDraftService F-028c：依當日 entries + gcal events 由 LLM 生成日記草稿。
+//
+// 不直接寫入 DB；呼叫端拿到 draft 後讓使用者編輯，再透過 PATCH /journal/:date 落地。
+type JournalDraftService struct {
+	llmSvc      *LlmService
+	entryRepo   EntryRepository
+	gcalSvc     *GcalService // optional：gcal 未連時跳過
+	maxContent  int          // entries 內容 char 上限（避免 prompt 爆量）
+	timeoutSecs int          // 預設 60s
+}
+
+// NewJournalDraftService 建立 JournalDraftService。
+func NewJournalDraftService(llmSvc *LlmService, entryRepo EntryRepository, gcalSvc *GcalService) *JournalDraftService {
+	return &JournalDraftService{
+		llmSvc:      llmSvc,
+		entryRepo:   entryRepo,
+		gcalSvc:     gcalSvc,
+		maxContent:  4000,
+		timeoutSecs: 60,
+	}
+}
+
+// JournalDraftResult LLM 回傳結果（直接帶 markdown）。
+type JournalDraftResult struct {
+	Draft     string   `json:"draft"`
+	UsedRefs  []string `json:"used_refs,omitempty"` // 來源 entry IDs / event IDs（用於前端 source-refs panel）
+	Mood      string   `json:"mood,omitempty"`      // optional 推測情緒
+	GeneratedBy string `json:"generated_by"`
+}
+
+// Draft 為指定日期生成日記草稿。
+//
+// 流程：
+//  1. 依 tz 撈當日 entries（透過 EntryRepository.ListByDateRange）
+//  2. 嘗試讀 gcal events（未連 / 上游錯時跳過，不阻擋整體）
+//  3. 組 prompt 呼叫 LLM
+//  4. 解析回應 markdown → JournalDraftResult
+//
+// 錯誤：
+//   - 400 INVALID_INPUT：date / tz 格式錯
+//   - 404 NO_DATA：當日無 entries 也無 events，無法生成
+//   - 424 LLM_NOT_CONFIGURED：未設 default LLM provider
+//   - 502 LLM_UPSTREAM_ERROR：LLM 呼叫失敗
+func (s *JournalDraftService) Draft(ctx context.Context, dateStr, tz, calendarID string) (*JournalDraftResult, error) {
+	if _, err := parseJournalDate(dateStr, tz); err != nil {
+		return nil, err
+	}
+
+	entries, err := s.entryRepo.ListByDateRange(ctx, dateStr, dateStr, tz)
+	if err != nil {
+		return nil, fmt.Errorf("查詢當日 entries 失敗: %w", err)
+	}
+
+	// gcal events（best-effort）
+	var events []*gcalEventLike
+	if s.gcalSvc != nil {
+		evs, err := s.fetchGcalEventsForDate(ctx, dateStr, tz, calendarID)
+		if err != nil {
+			slog.Warn("draft: 取 gcal events 失敗，跳過", "error", err)
+		} else {
+			events = evs
+		}
+	}
+
+	if len(entries) == 0 && len(events) == 0 {
+		return nil, model.NewAppError(404, model.ErrCodeNotFound, "當日無可參考素材，無法生成日記草稿")
+	}
+
+	prompt := s.buildPrompt(dateStr, entries, events)
+
+	// 呼叫 LLM（使用 chat completion；非 streaming，依 spec/tech-survey 決策）
+	provider, err := s.llmSvc.providerSvc.GetActiveProvider(ctx)
+	if err != nil {
+		return nil, model.NewAppError(424, "LLM_NOT_CONFIGURED", "尚未設定可用的 LLM provider，無法生成日記草稿")
+	}
+	apiKey := ""
+	if provider.ApiKey != nil && *provider.ApiKey != "" {
+		decrypted, decErr := s.llmSvc.crypto.Decrypt(*provider.ApiKey)
+		if decErr != nil {
+			return nil, fmt.Errorf("解密 LLM API key 失敗: %w", decErr)
+		}
+		apiKey = decrypted
+	}
+	cached := s.llmSvc.getOrCreateClient(provider, apiKey)
+
+	timeout := time.Duration(s.timeoutSecs) * time.Second
+	if provider.Config != nil {
+		var cfg model.LlmProviderConfig
+		if err := json.Unmarshal(*provider.Config, &cfg); err == nil && cfg.TimeoutSeconds != nil {
+			timeout = time.Duration(*cfg.TimeoutSeconds) * time.Second
+		}
+	}
+	callCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	if err := cached.limiter.Wait(callCtx); err != nil {
+		return nil, fmt.Errorf("rate limit 等待取消: %w", err)
+	}
+
+	slog.Info("呼叫 LLM 生成日記草稿", "provider", provider.Name, "model", provider.ModelName, "date", dateStr)
+	resp, err := cached.client.CreateChatCompletion(callCtx, openai.ChatCompletionRequest{
+		Model: provider.ModelName,
+		Messages: []openai.ChatCompletionMessage{
+			{Role: openai.ChatMessageRoleSystem, Content: journalDraftSystemPrompt},
+			{Role: openai.ChatMessageRoleUser, Content: prompt},
+		},
+		ResponseFormat: &openai.ChatCompletionResponseFormat{
+			Type: openai.ChatCompletionResponseFormatTypeJSONObject,
+		},
+	})
+	if err != nil {
+		return nil, model.NewAppError(502, "LLM_UPSTREAM_ERROR", "LLM 服務暫時無法使用："+err.Error())
+	}
+	if len(resp.Choices) == 0 {
+		return nil, model.NewAppError(502, "LLM_UPSTREAM_ERROR", "LLM 回傳空結果")
+	}
+
+	raw := resp.Choices[0].Message.Content
+	var parsed JournalDraftResult
+	if err := json.Unmarshal([]byte(raw), &parsed); err != nil {
+		slog.Error("LLM 日記草稿格式解析失敗", "raw", raw, "error", err)
+		// fallback：把原 content 視為 draft（LLM 沒按 JSON）
+		parsed.Draft = strings.TrimSpace(raw)
+	}
+	parsed.GeneratedBy = provider.Name + "/" + provider.ModelName
+	return &parsed, nil
+}
+
+// gcalEventLike 內部表示，避免引入 calendar/v3 強耦合
+type gcalEventLike struct {
+	ID      string
+	Summary string
+	Start   string
+	End     string
+	AllDay  bool
+}
+
+func (s *JournalDraftService) fetchGcalEventsForDate(ctx context.Context, dateStr, tz, calendarID string) ([]*gcalEventLike, error) {
+	if s.gcalSvc == nil {
+		return nil, nil
+	}
+	if tz == "" {
+		tz = "UTC"
+	}
+	loc, err := time.LoadLocation(tz)
+	if err != nil {
+		return nil, err
+	}
+	d, err := time.ParseInLocation("2006-01-02", dateStr, loc)
+	if err != nil {
+		return nil, err
+	}
+	if calendarID == "" {
+		calendarID = "primary"
+	}
+	startUTC := d.UTC()
+	endUTC := d.AddDate(0, 0, 1).UTC()
+	connected, _ := s.gcalSvc.IsConnected(ctx)
+	if !connected {
+		return nil, nil
+	}
+	events, err := s.gcalSvc.ListEvents(ctx, calendarID, startUTC, endUTC, true)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]*gcalEventLike, 0, len(events))
+	for _, ev := range events {
+		if ev == nil {
+			continue
+		}
+		gel := &gcalEventLike{
+			ID:      ev.Id,
+			Summary: ev.Summary,
+		}
+		if ev.Start != nil {
+			if ev.Start.DateTime != "" {
+				gel.Start = ev.Start.DateTime
+			} else if ev.Start.Date != "" {
+				gel.Start = ev.Start.Date
+				gel.AllDay = true
+			}
+		}
+		if ev.End != nil {
+			if ev.End.DateTime != "" {
+				gel.End = ev.End.DateTime
+			} else if ev.End.Date != "" {
+				gel.End = ev.End.Date
+			}
+		}
+		out = append(out, gel)
+	}
+	return out, nil
+}
+
+// buildPrompt 將當日素材組成 prompt（截斷過長 entry 內容防止 prompt 爆量）。
+func (s *JournalDraftService) buildPrompt(date string, entries []dto.CalendarEntrySummary, events []*gcalEventLike) string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "請根據下列素材，為日期 %s 撰寫一篇日記草稿。\n\n", date)
+
+	if len(entries) > 0 {
+		b.WriteString("## 知識條目\n")
+		for _, e := range entries {
+			title := "(無標題)"
+			if e.Title != nil && *e.Title != "" {
+				title = *e.Title
+			}
+			summary := ""
+			if e.Summary != nil {
+				summary = *e.Summary
+			}
+			line := fmt.Sprintf("- [%s] %s — %s", e.ID, title, summary)
+			if len(line) > s.maxContent/4 {
+				line = line[:s.maxContent/4] + "…"
+			}
+			b.WriteString(line)
+			b.WriteString("\n")
+		}
+		b.WriteString("\n")
+	}
+
+	if len(events) > 0 {
+		b.WriteString("## Google Calendar 事件\n")
+		for _, ev := range events {
+			fmt.Fprintf(&b, "- [%s] %s（%s ~ %s）\n", ev.ID, ev.Summary, ev.Start, ev.End)
+		}
+		b.WriteString("\n")
+	}
+
+	full := b.String()
+	if len(full) > s.maxContent {
+		full = full[:s.maxContent] + "\n…(已截斷)"
+	}
+	return full
+}
+
+const journalDraftSystemPrompt = `你是一位日記寫作助手。
+
+我會給你某一天的「知識條目」和「Google Calendar 事件」清單，請以第一人稱、自然敘述風格寫一篇 markdown 日記草稿，內容包含：
+1. 簡短開場（描述今天整體的方向 / 主軸）
+2. 重點回顧（依素材順序 1-3 段，每段帶一個小標題）
+3. 反思 / 想法（1-2 句）
+
+額外要求：
+- 不要直接列點呈現 entries / events，要融入敘述
+- 避免捏造未提供的細節
+- 引用素材時用內嵌字句，不要寫 "根據 entry XX..."
+- 如果素材很少，就寫得短一點，不要硬湊長度
+
+請以嚴格的 JSON 格式回應：
+{
+  "draft": "## 標題\n\n第一段內容...\n\n## 小標題\n\n內容...",
+  "used_refs": ["<entry_id_1>", "<gcal_id_1>"],
+  "mood": "calm|energetic|focused|tired|reflective|（自由文字，可省略）"
+}
+
+只回傳 JSON，不要包含任何其他文字、說明或 markdown 程式碼框。`


### PR DESCRIPTION
Closes #98

POST /api/v1/journal/:date/draft 用 LLM 依當日 entries + gcal events 生成 markdown 草稿。Draft 不寫入 DB；使用者編輯後再 PATCH /journal/:date 落地。

go build / vet 通過。

🤖 Generated with [Claude Code](https://claude.com/claude-code)