### PR TITLE
feat(frontend): F-029a Journal 列表頁 + heatmap + sidebar 日記項

### DIFF
--- a/dev/frontend/app/(dashboard)/journal/page.tsx
+++ b/dev/frontend/app/(dashboard)/journal/page.tsx
@@ -1,0 +1,122 @@
+"use client";
+
+import * as React from "react";
+import Link from "next/link";
+import { Plus } from "lucide-react";
+import { PageHeader } from "@/components/page-header";
+import { Button } from "@/components/ui/button";
+import { Skeleton } from "@/components/ui/skeleton";
+import { ErrorState } from "@/components/error-state";
+import { JournalListCard } from "@/components/journal/journal-list-card";
+import { JournalHeatmap } from "@/components/journal/journal-heatmap";
+import { JournalFilters } from "@/components/journal/journal-filters";
+import { JOURNAL_TESTIDS } from "@/lib/journal/testids";
+import { useJournals } from "@/lib/hooks/use-journals";
+import type { JournalEntry } from "@/lib/api/journal";
+
+function todayYmd(): string {
+  return new Date().toISOString().slice(0, 10);
+}
+
+export default function JournalListPage() {
+  const [mood, setMood] = React.useState<string>("all");
+
+  // 預設範圍：過去 90 天
+  const since = React.useMemo(() => {
+    const d = new Date();
+    d.setDate(d.getDate() - 89);
+    return d.toISOString().slice(0, 10);
+  }, []);
+  const until = todayYmd();
+
+  const { data, isLoading, isError, error } = useJournals({
+    since,
+    until,
+    mood: mood === "all" ? undefined : mood,
+  });
+
+  const journals: JournalEntry[] = data?.data ?? [];
+
+  // heatmap data：依字數產 intensity 1..4
+  const heatmapData = React.useMemo(
+    () =>
+      journals.map((j) => ({
+        date: j.date,
+        intensity: Math.min(4, Math.max(1, Math.ceil(j.content.length / 200))),
+      })),
+    [journals],
+  );
+
+  return (
+    <div
+      data-testid={JOURNAL_TESTIDS.listPage}
+      className="space-y-6"
+    >
+      <PageHeader
+        title="每日日記"
+        description="記錄今天，回看過去"
+        action={
+          <Button asChild>
+            <Link href={`/journal/${todayYmd()}`}>
+              <Plus className="mr-2 h-4 w-4" />
+              寫今天
+            </Link>
+          </Button>
+        }
+      />
+
+      <JournalHeatmap data={heatmapData} />
+
+      <div className="flex items-center justify-between">
+        <JournalFilters mood={mood} onMoodChange={setMood} />
+        <span className="text-sm text-muted-foreground">
+          共 {journals.length} 篇
+        </span>
+      </div>
+
+      {isLoading && (
+        <div className="space-y-3">
+          {Array.from({ length: 3 }).map((_, i) => (
+            <Skeleton key={i} className="h-24 w-full rounded-md" />
+          ))}
+        </div>
+      )}
+
+      {isError && (
+        <ErrorState
+          message={error instanceof Error ? error.message : "載入失敗"}
+        />
+      )}
+
+      {!isLoading && !isError && journals.length === 0 && (
+        <div
+          className="rounded-md border border-dashed py-12 text-center"
+          data-testid={JOURNAL_TESTIDS.listEmpty}
+        >
+          <p className="text-base font-semibold">還沒有日記</p>
+          <p className="mt-1 text-sm text-muted-foreground">
+            從今天開始，每日記錄一筆。
+          </p>
+          <Button
+            asChild
+            className="mt-4"
+            data-testid={JOURNAL_TESTIDS.listEmptyWriteFirst}
+          >
+            <Link href={`/journal/${todayYmd()}`}>
+              <Plus className="mr-2 h-4 w-4" />
+              寫第一篇
+            </Link>
+          </Button>
+        </div>
+      )}
+
+      {!isLoading && !isError && journals.length > 0 && (
+        <div className="space-y-3">
+          {journals.map((j) => (
+            <JournalListCard key={j.id} journal={j} />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/dev/frontend/components/app-sidebar.tsx
+++ b/dev/frontend/components/app-sidebar.tsx
@@ -3,6 +3,7 @@
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 import {
+  BookOpen,
   Bot,
   Calendar,
   FileText,
@@ -35,6 +36,7 @@ export function AppSidebar({ inboxCount = 0, open, onClose }: AppSidebarProps) {
   const main: NavItem[] = [
     { label: "Inbox", href: "/inbox", icon: Inbox, badge: inboxCount || undefined },
     { label: "行事曆", href: "/calendar", icon: Calendar },
+    { label: "日記", href: "/journal", icon: BookOpen },
     { label: "知識條目", href: "/entries", icon: FileText },
     { label: "分類管理", href: "/categories", icon: FolderTree },
     { label: "搜尋", href: "/search", icon: Search },

--- a/dev/frontend/components/journal/journal-filters.tsx
+++ b/dev/frontend/components/journal/journal-filters.tsx
@@ -1,0 +1,48 @@
+"use client";
+
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { JOURNAL_TESTIDS } from "@/lib/journal/testids";
+
+const MOODS = [
+  { value: "all", label: "全部心情" },
+  { value: "great", label: "😊 great" },
+  { value: "ok", label: "😐 ok" },
+  { value: "down", label: "😔 down" },
+];
+
+interface JournalFiltersProps {
+  mood: string; // "all" | "great" | "ok" | "down"
+  onMoodChange: (mood: string) => void;
+}
+
+export function JournalFilters({ mood, onMoodChange }: JournalFiltersProps) {
+  return (
+    <div className="flex items-center gap-2">
+      <Select value={mood} onValueChange={onMoodChange}>
+        <SelectTrigger
+          className="w-[150px]"
+          data-testid={JOURNAL_TESTIDS.listMoodFilter}
+        >
+          <SelectValue placeholder="心情" />
+        </SelectTrigger>
+        <SelectContent>
+          {MOODS.map((m) => (
+            <SelectItem
+              key={m.value}
+              value={m.value}
+              data-testid={JOURNAL_TESTIDS.listMoodOption(m.value)}
+            >
+              {m.label}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+    </div>
+  );
+}

--- a/dev/frontend/components/journal/journal-heatmap.tsx
+++ b/dev/frontend/components/journal/journal-heatmap.tsx
@@ -1,0 +1,104 @@
+"use client";
+
+import * as React from "react";
+import Link from "next/link";
+import { JOURNAL_TESTIDS } from "@/lib/journal/testids";
+import { cn } from "@/lib/utils";
+
+interface HeatmapDatum {
+  date: string; // YYYY-MM-DD
+  intensity: number; // 0..4
+}
+
+interface JournalHeatmapProps {
+  /** 起點日期（含），預設今天往前推 90 天 */
+  startDate?: Date;
+  /** 終點日期（含），預設今天 */
+  endDate?: Date;
+  /** 已存在日記的 dates（會分配 intensity = 1..4 依字數） */
+  data: HeatmapDatum[];
+}
+
+function ymd(d: Date): string {
+  return d.toISOString().slice(0, 10);
+}
+
+function eachDay(start: Date, end: Date): Date[] {
+  const days: Date[] = [];
+  const cur = new Date(start);
+  cur.setHours(0, 0, 0, 0);
+  const stop = new Date(end);
+  stop.setHours(0, 0, 0, 0);
+  while (cur <= stop) {
+    days.push(new Date(cur));
+    cur.setDate(cur.getDate() + 1);
+  }
+  return days;
+}
+
+const INTENSITY_CLASS = [
+  "bg-muted/30",
+  "bg-emerald-200 dark:bg-emerald-900/40",
+  "bg-emerald-300 dark:bg-emerald-700/60",
+  "bg-emerald-400 dark:bg-emerald-600/70",
+  "bg-emerald-500 dark:bg-emerald-500/80",
+];
+
+export function JournalHeatmap({
+  startDate,
+  endDate,
+  data,
+}: JournalHeatmapProps) {
+  const today = new Date();
+  const start = startDate ?? new Date(today.getTime() - 1000 * 60 * 60 * 24 * 89);
+  const end = endDate ?? today;
+  const intensityMap = React.useMemo(() => {
+    const m = new Map<string, number>();
+    for (const d of data) m.set(d.date, d.intensity);
+    return m;
+  }, [data]);
+
+  const days = eachDay(start, end);
+
+  return (
+    <div
+      data-testid={JOURNAL_TESTIDS.heatmap}
+      className="rounded-md border p-3"
+      role="grid"
+      aria-label="日記覆蓋熱力圖"
+    >
+      <div className="grid grid-cols-[repeat(auto-fill,minmax(14px,1fr))] gap-1">
+        {days.map((d) => {
+          const ds = ymd(d);
+          const intensity = intensityMap.get(ds) ?? 0;
+          return (
+            <Link
+              key={ds}
+              href={`/journal/${ds}`}
+              data-testid={JOURNAL_TESTIDS.heatmapCell(ds)}
+              data-intensity={intensity}
+              title={`${ds}${intensity > 0 ? " · 已寫" : ""}`}
+              className={cn(
+                "aspect-square rounded-sm transition-opacity hover:opacity-70",
+                INTENSITY_CLASS[Math.min(intensity, 4)],
+              )}
+            />
+          );
+        })}
+      </div>
+      <div
+        className="mt-3 flex items-center justify-end gap-2 text-xs text-muted-foreground"
+        data-testid={JOURNAL_TESTIDS.heatmapLegend}
+      >
+        <span>少</span>
+        {[0, 1, 2, 3, 4].map((i) => (
+          <span
+            key={i}
+            className={cn("h-3 w-3 rounded-sm", INTENSITY_CLASS[i])}
+          />
+        ))}
+        <span>多</span>
+      </div>
+    </div>
+  );
+}

--- a/dev/frontend/components/journal/journal-list-card.tsx
+++ b/dev/frontend/components/journal/journal-list-card.tsx
@@ -1,0 +1,77 @@
+"use client";
+
+import Link from "next/link";
+import { Card, CardContent } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { JOURNAL_TESTIDS } from "@/lib/journal/testids";
+import type { JournalEntry } from "@/lib/api/journal";
+
+interface JournalListCardProps {
+  journal: JournalEntry;
+}
+
+const MOOD_EMOJI: Record<string, string> = {
+  great: "😊",
+  ok: "😐",
+  down: "😔",
+};
+
+function snippet(s: string, max = 120): string {
+  const trimmed = s.trim().replace(/\s+/g, " ");
+  return trimmed.length > max ? trimmed.slice(0, max) + "…" : trimmed;
+}
+
+export function JournalListCard({ journal }: JournalListCardProps) {
+  const moodEmoji = journal.mood ? MOOD_EMOJI[journal.mood] ?? "🙂" : null;
+  const wordCount = journal.content.length;
+
+  return (
+    <Card
+      className="transition-colors hover:border-primary/50"
+      data-testid={JOURNAL_TESTIDS.listItem}
+      data-journal-date={journal.date}
+    >
+      <Link
+        href={`/journal/${journal.date}`}
+        className="block"
+        data-testid={JOURNAL_TESTIDS.listItemByDate(journal.date)}
+      >
+        <CardContent className="space-y-2 p-4">
+          <div className="flex items-center justify-between gap-2">
+            <div className="flex items-center gap-2">
+              <span className="text-sm font-medium">{journal.date}</span>
+              {moodEmoji && (
+                <span
+                  data-testid={JOURNAL_TESTIDS.listItemMoodEmoji}
+                  aria-label={`mood: ${journal.mood}`}
+                  className="text-lg"
+                >
+                  {moodEmoji}
+                </span>
+              )}
+            </div>
+            {journal.is_draft && (
+              <Badge
+                variant="warning"
+                className="text-[10px]"
+                data-testid={JOURNAL_TESTIDS.listItemDraftBadge}
+              >
+                草稿
+              </Badge>
+            )}
+          </div>
+          {journal.title && (
+            <h3 className="text-base font-semibold">{journal.title}</h3>
+          )}
+          <p
+            className="text-sm text-muted-foreground"
+            data-testid={JOURNAL_TESTIDS.listItemPreview}
+          >
+            {snippet(journal.content)}
+          </p>
+          <p className="text-xs text-muted-foreground">{wordCount} 字</p>
+        </CardContent>
+      </Link>
+    </Card>
+  );
+}

--- a/dev/frontend/lib/api/journal.ts
+++ b/dev/frontend/lib/api/journal.ts
@@ -1,0 +1,105 @@
+import { apiClient } from "./client";
+
+export type JournalMood = "great" | "ok" | "down" | string;
+
+export interface SourceRef {
+  source_type: "entry" | "gcal_event";
+  source_id: string;
+}
+
+export interface JournalEntry {
+  id: string;
+  date: string; // YYYY-MM-DD
+  title: string | null;
+  content: string;
+  mood: string | null;
+  highlights: string[];
+  is_draft: boolean;
+  generated_by: string | null;
+  llm_provider_id: string | null;
+  source_refs: SourceRef[];
+  created_at: string;
+  updated_at: string;
+}
+
+export interface ListJournalsParams {
+  since?: string; // YYYY-MM-DD
+  until?: string;
+  mood?: string;
+  q?: string;
+}
+
+export interface ListJournalsResponse {
+  data: JournalEntry[];
+}
+
+export interface CreateJournalInput {
+  date: string;
+  title?: string | null;
+  content: string;
+  mood?: string | null;
+  highlights?: string[];
+  is_draft?: boolean;
+  source_refs?: SourceRef[];
+}
+
+export type UpdateJournalInput = Partial<Omit<CreateJournalInput, "date">>;
+
+export interface JournalDraftResponse {
+  date: string;
+  draft: string;
+  used_refs?: string[];
+  mood?: string;
+  generated_by: string;
+}
+
+function buildQuery(params: ListJournalsParams): string {
+  const sp = new URLSearchParams();
+  if (params.since) sp.set("since", params.since);
+  if (params.until) sp.set("until", params.until);
+  if (params.mood) sp.set("mood", params.mood);
+  if (params.q) sp.set("q", params.q);
+  const q = sp.toString();
+  return q ? `?${q}` : "";
+}
+
+export async function listJournals(
+  params: ListJournalsParams = {},
+): Promise<ListJournalsResponse> {
+  return apiClient.get<ListJournalsResponse>(`/api/v1/journal${buildQuery(params)}`);
+}
+
+export async function getJournal(date: string): Promise<JournalEntry> {
+  return apiClient.get<JournalEntry>(`/api/v1/journal/${encodeURIComponent(date)}`);
+}
+
+export async function createJournal(input: CreateJournalInput): Promise<JournalEntry> {
+  return apiClient.post<JournalEntry>("/api/v1/journal", input);
+}
+
+export async function updateJournal(
+  date: string,
+  input: UpdateJournalInput,
+): Promise<JournalEntry> {
+  return apiClient.patch<JournalEntry>(
+    `/api/v1/journal/${encodeURIComponent(date)}`,
+    input,
+  );
+}
+
+export async function deleteJournal(date: string): Promise<void> {
+  await apiClient.delete(`/api/v1/journal/${encodeURIComponent(date)}`);
+}
+
+export async function draftJournal(
+  date: string,
+  opts: { tz?: string; calendarId?: string } = {},
+): Promise<JournalDraftResponse> {
+  const sp = new URLSearchParams();
+  if (opts.calendarId) sp.set("calendar_id", opts.calendarId);
+  const qs = sp.toString();
+  const url = `/api/v1/journal/${encodeURIComponent(date)}/draft${qs ? `?${qs}` : ""}`;
+  const headers: Record<string, string> = {};
+  if (opts.tz) headers["X-Timezone"] = opts.tz;
+  return apiClient.post<JournalDraftResponse>(url, undefined, { headers });
+}

--- a/dev/frontend/lib/hooks/use-journals.ts
+++ b/dev/frontend/lib/hooks/use-journals.ts
@@ -1,0 +1,84 @@
+"use client";
+
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import {
+  CreateJournalInput,
+  UpdateJournalInput,
+  createJournal,
+  deleteJournal,
+  draftJournal,
+  getJournal,
+  listJournals,
+  ListJournalsParams,
+  ListJournalsResponse,
+  JournalEntry,
+} from "@/lib/api/journal";
+
+export const JOURNALS_QUERY_KEY = ["journals"] as const;
+export const journalKey = (date: string) => ["journal", date] as const;
+
+export function useJournals(params: ListJournalsParams = {}) {
+  return useQuery<ListJournalsResponse>({
+    queryKey: [...JOURNALS_QUERY_KEY, params],
+    queryFn: () => listJournals(params),
+  });
+}
+
+export function useJournal(date: string | null | undefined) {
+  return useQuery<JournalEntry>({
+    queryKey: journalKey(date ?? ""),
+    queryFn: () => getJournal(date as string),
+    enabled: !!date,
+  });
+}
+
+export function useCreateJournal() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (input: CreateJournalInput) => createJournal(input),
+    onSuccess: (_data, vars) => {
+      qc.invalidateQueries({ queryKey: JOURNALS_QUERY_KEY });
+      qc.invalidateQueries({ queryKey: journalKey(vars.date) });
+    },
+  });
+}
+
+export function useUpdateJournal() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: ({ date, payload }: { date: string; payload: UpdateJournalInput }) =>
+      updateJournalApi(date, payload),
+    onSuccess: (_data, vars) => {
+      qc.invalidateQueries({ queryKey: JOURNALS_QUERY_KEY });
+      qc.invalidateQueries({ queryKey: journalKey(vars.date) });
+    },
+  });
+}
+
+// 重新匯出 update 以保留 hook 內 import 簡潔
+import { updateJournal as updateJournalApi } from "@/lib/api/journal";
+
+export function useDeleteJournal() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (date: string) => deleteJournal(date),
+    onSuccess: (_data, date) => {
+      qc.invalidateQueries({ queryKey: JOURNALS_QUERY_KEY });
+      qc.invalidateQueries({ queryKey: journalKey(date) });
+    },
+  });
+}
+
+export function useDraftJournal() {
+  return useMutation({
+    mutationFn: ({
+      date,
+      tz,
+      calendarId,
+    }: {
+      date: string;
+      tz?: string;
+      calendarId?: string;
+    }) => draftJournal(date, { tz, calendarId }),
+  });
+}

--- a/dev/frontend/lib/journal/testids.ts
+++ b/dev/frontend/lib/journal/testids.ts
@@ -1,0 +1,52 @@
+/**
+ * Journal 頁面 data-testid 常數。
+ *
+ * 必須與 `test/browser/fixtures/journal.ts` 的 `JOURNAL_TESTIDS` 保持一致，
+ * 修改時請同步更新兩邊。
+ */
+export const JOURNAL_TESTIDS = {
+  // 列表頁 /journal
+  listPage: "journal-list-page",
+  listEmpty: "journal-list-empty",
+  listEmptyWriteFirst: "journal-list-empty-write-first",
+  listMoodFilter: "journal-list-mood-filter",
+  listMoodOption: (mood: string) => `journal-list-mood-option-${mood}`,
+  listItem: "journal-list-item",
+  listItemByDate: (date: string) => `journal-list-item-${date}`,
+  listItemDraftBadge: "journal-list-item-draft-badge",
+  listItemMoodEmoji: "journal-list-item-mood-emoji",
+  listItemPreview: "journal-list-item-preview",
+
+  // Heatmap
+  heatmap: "journal-heatmap",
+  heatmapCell: (date: string) => `journal-heatmap-cell-${date}`,
+  heatmapLegend: "journal-heatmap-legend",
+
+  // 編輯頁 /journal/:date
+  editorPage: "journal-editor-page",
+  editorTitle: "journal-editor-title",
+  editorContent: "journal-editor-content",
+  editorPreviewTab: "journal-editor-preview-tab",
+  editorWriteTab: "journal-editor-write-tab",
+  editorSaveButton: "journal-editor-save-button",
+  editorDeleteButton: "journal-editor-delete-button",
+  editorEmptyState: "journal-editor-empty-state",
+
+  moodPicker: "journal-mood-picker",
+  moodOption: (mood: string) => `journal-mood-option-${mood}`,
+
+  llmDraftButton: "journal-llm-draft-button",
+  llmDraftLoading: "journal-llm-draft-loading",
+  draftBanner: "journal-draft-banner",
+  draftBannerConfirmButton: "journal-draft-banner-confirm-button",
+  draftBannerRegenerateButton: "journal-draft-banner-regenerate-button",
+
+  sourceRefsPanel: "journal-source-refs-panel",
+  sourceRefEntry: "journal-source-ref-entry",
+  sourceRefEvent: "journal-source-ref-event",
+
+  toastSaved: "journal-toast-saved",
+  toastLlmUnavailable: "journal-toast-llm-unavailable",
+  dialogConflict: "journal-dialog-conflict",
+  dialogConflictReload: "journal-dialog-conflict-reload",
+} as const;


### PR DESCRIPTION
Closes #99

新增 /journal 列表頁：90 天 heatmap、mood 過濾、列表卡片、空狀態、sidebar 「日記」項。

testid 全部對齊 test/browser/fixtures/journal.ts 的 JOURNAL_TESTIDS。

未實作（F-029b 處理）：/journal/:date 編輯頁。

tsc 僅剩 2 個 pre-existing 無關錯誤。

🤖 Generated with [Claude Code](https://claude.com/claude-code)