### PR TITLE
feat(frontend): F-030d 設定頁 Google Calendar 區塊

### DIFF
--- a/dev/frontend/app/(dashboard)/settings/gcal/page.tsx
+++ b/dev/frontend/app/(dashboard)/settings/gcal/page.tsx
@@ -1,0 +1,16 @@
+"use client";
+
+import { PageHeader } from "@/components/page-header";
+import { GcalStatusCard } from "@/components/gcal-settings/gcal-status-card";
+
+export default function GcalSettingsPage() {
+  return (
+    <div className="space-y-6">
+      <PageHeader
+        title="Google Calendar"
+        description="連結 Google 帳號以整合日曆事件"
+      />
+      <GcalStatusCard />
+    </div>
+  );
+}

--- a/dev/frontend/components/app-sidebar.tsx
+++ b/dev/frontend/components/app-sidebar.tsx
@@ -44,6 +44,7 @@ export function AppSidebar({ inboxCount = 0, open, onClose }: AppSidebarProps) {
   const settings: NavItem[] = [
     { label: "API Key", href: "/settings/api-keys", icon: Key },
     { label: "LLM Provider", href: "/settings/llm-providers", icon: Bot },
+    { label: "Google Calendar", href: "/settings/gcal", icon: Calendar },
   ];
 
   return (

--- a/dev/frontend/components/gcal-settings/gcal-status-card.tsx
+++ b/dev/frontend/components/gcal-settings/gcal-status-card.tsx
@@ -1,0 +1,257 @@
+"use client";
+
+import * as React from "react";
+import { toast } from "sonner";
+import { CheckCircle2, ExternalLink, Loader2, Plug } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader } from "@/components/ui/card";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Skeleton } from "@/components/ui/skeleton";
+import { GCAL_SETTINGS_TESTIDS } from "@/lib/gcal-settings/testids";
+import {
+  useDisconnectGcal,
+  useGcalCalendars,
+  useGcalStatus,
+  useStartGcalAuth,
+  useUpdateGcalSettings,
+} from "@/lib/hooks/use-gcal-settings";
+
+export function GcalStatusCard() {
+  const { data: status, isLoading } = useGcalStatus();
+  const isConnected = !!status?.connected;
+  const { data: calendarsResp, isLoading: loadingCalendars } = useGcalCalendars({
+    enabled: isConnected,
+  });
+  const updateMut = useUpdateGcalSettings();
+  const disconnectMut = useDisconnectGcal();
+  const startAuth = useStartGcalAuth();
+
+  const [selectedCalendarId, setSelectedCalendarId] = React.useState<string>("");
+  const [confirmOpen, setConfirmOpen] = React.useState(false);
+
+  React.useEffect(() => {
+    if (status?.default_calendar_id) {
+      setSelectedCalendarId(status.default_calendar_id);
+    }
+  }, [status?.default_calendar_id]);
+
+  const handleConnect = async () => {
+    try {
+      const res = await startAuth.mutateAsync();
+      window.location.href = res.auth_url;
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : "啟動授權失敗");
+    }
+  };
+
+  const handleSave = async () => {
+    if (!selectedCalendarId) return;
+    try {
+      await updateMut.mutateAsync({ default_calendar_id: selectedCalendarId });
+      toast.success("已儲存設定", { id: GCAL_SETTINGS_TESTIDS.toastSaved });
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : "儲存失敗");
+    }
+  };
+
+  const handleDisconnect = async () => {
+    try {
+      await disconnectMut.mutateAsync();
+      toast.success("已中斷 Google Calendar 連線", {
+        id: GCAL_SETTINGS_TESTIDS.toastDisconnected,
+      });
+      setConfirmOpen(false);
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : "中斷連線失敗");
+    }
+  };
+
+  if (isLoading) {
+    return (
+      <Card data-testid={GCAL_SETTINGS_TESTIDS.section}>
+        <CardHeader>
+          <h2 className="text-lg font-semibold">Google Calendar</h2>
+        </CardHeader>
+        <CardContent>
+          <Skeleton className="h-20 w-full" />
+        </CardContent>
+      </Card>
+    );
+  }
+
+  return (
+    <Card data-testid={GCAL_SETTINGS_TESTIDS.section}>
+      <CardHeader>
+        <h2 className="text-lg font-semibold">Google Calendar</h2>
+        <p className="text-sm text-muted-foreground">
+          整合行事曆事件到 aibo 的彙整視圖。
+        </p>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        {!isConnected ? (
+          <div
+            className="flex flex-col items-start gap-3 rounded-md border border-dashed p-4"
+            data-testid={GCAL_SETTINGS_TESTIDS.notConnectedState}
+          >
+            <p className="text-sm text-muted-foreground">尚未連接 Google Calendar</p>
+            <Button
+              onClick={handleConnect}
+              disabled={startAuth.isPending}
+              data-testid={GCAL_SETTINGS_TESTIDS.connectButton}
+            >
+              {startAuth.isPending ? (
+                <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+              ) : (
+                <Plug className="mr-2 h-4 w-4" />
+              )}
+              連接 Google Calendar
+            </Button>
+          </div>
+        ) : (
+          <div
+            className="space-y-4"
+            data-testid={GCAL_SETTINGS_TESTIDS.connectedState}
+          >
+            {status?.needs_reauth && (
+              <div
+                className="flex items-start justify-between gap-3 rounded-md border border-amber-500/50 bg-amber-500/10 p-3 text-sm"
+                data-testid={GCAL_SETTINGS_TESTIDS.reauthBanner}
+                role="status"
+              >
+                <div>
+                  <p className="font-medium">需要重新授權</p>
+                  <p className="text-xs text-muted-foreground">
+                    Google Calendar token 已失效，請重新授權以恢復使用。
+                  </p>
+                </div>
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={handleConnect}
+                  data-testid={GCAL_SETTINGS_TESTIDS.reauthBannerReconnect}
+                >
+                  <ExternalLink className="mr-1 h-3 w-3" />
+                  重新授權
+                </Button>
+              </div>
+            )}
+
+            <div className="flex items-center gap-2 text-sm">
+              <CheckCircle2 className="h-4 w-4 text-emerald-500" />
+              <span data-testid={GCAL_SETTINGS_TESTIDS.emailLabel}>
+                {status?.email ?? "已連線"}
+              </span>
+              {status?.access_token_expires_at && (
+                <span
+                  className="text-xs text-muted-foreground"
+                  data-testid={GCAL_SETTINGS_TESTIDS.expiresAtLabel}
+                >
+                  · 到期：
+                  {new Date(status.access_token_expires_at).toLocaleString("zh-TW")}
+                </span>
+              )}
+            </div>
+
+            <div className="space-y-2">
+              <label className="text-sm font-medium">預設日曆</label>
+              {loadingCalendars ? (
+                <Skeleton className="h-10 w-[280px]" />
+              ) : (
+                <Select
+                  value={selectedCalendarId}
+                  onValueChange={setSelectedCalendarId}
+                >
+                  <SelectTrigger
+                    className="w-[280px]"
+                    data-testid={GCAL_SETTINGS_TESTIDS.defaultCalendarSelect}
+                  >
+                    <SelectValue placeholder="選擇日曆…" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {(calendarsResp?.calendars ?? []).map((cal) => (
+                      <SelectItem
+                        key={cal.id}
+                        value={cal.id}
+                        data-testid={GCAL_SETTINGS_TESTIDS.defaultCalendarOption(cal.id)}
+                      >
+                        {cal.summary}
+                        {cal.primary ? " (primary)" : ""}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              )}
+            </div>
+
+            <div className="flex gap-2">
+              <Button
+                onClick={handleSave}
+                disabled={
+                  updateMut.isPending ||
+                  !selectedCalendarId ||
+                  selectedCalendarId === status?.default_calendar_id
+                }
+                data-testid={GCAL_SETTINGS_TESTIDS.saveSettingsButton}
+              >
+                {updateMut.isPending && (
+                  <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                )}
+                儲存設定
+              </Button>
+              <Button
+                variant="outline"
+                onClick={() => setConfirmOpen(true)}
+                data-testid={GCAL_SETTINGS_TESTIDS.disconnectButton}
+              >
+                中斷連線
+              </Button>
+            </div>
+          </div>
+        )}
+      </CardContent>
+
+      <AlertDialog open={confirmOpen} onOpenChange={setConfirmOpen}>
+        <AlertDialogContent data-testid={GCAL_SETTINGS_TESTIDS.disconnectDialog}>
+          <AlertDialogHeader>
+            <AlertDialogTitle>確認中斷 Google Calendar 連線？</AlertDialogTitle>
+            <AlertDialogDescription>
+              中斷後將無法在行事曆上看到 Google Calendar 事件，但 **既有已轉成知識條目的內容會保留**。
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel
+              disabled={disconnectMut.isPending}
+              data-testid={GCAL_SETTINGS_TESTIDS.disconnectDialogCancel}
+            >
+              取消
+            </AlertDialogCancel>
+            <AlertDialogAction
+              onClick={handleDisconnect}
+              disabled={disconnectMut.isPending}
+              className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+              data-testid={GCAL_SETTINGS_TESTIDS.disconnectDialogConfirm}
+            >
+              {disconnectMut.isPending ? "中斷中…" : "確認中斷"}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </Card>
+  );
+}

--- a/dev/frontend/lib/api/gcal-settings.ts
+++ b/dev/frontend/lib/api/gcal-settings.ts
@@ -1,0 +1,49 @@
+import { apiClient } from "./client";
+
+export interface GcalStatus {
+  connected: boolean;
+  email?: string | null;
+  connected_at?: string | null;
+  access_token_expires_at?: string | null;
+  default_calendar_id?: string | null;
+  needs_reauth?: boolean;
+}
+
+export interface GcalCalendar {
+  id: string;
+  summary: string;
+  primary?: boolean;
+  time_zone?: string;
+  background_color?: string | null;
+}
+
+export interface GcalCalendarsResponse {
+  calendars: GcalCalendar[];
+}
+
+export interface UpdateGcalSettingsInput {
+  default_calendar_id: string;
+}
+
+export async function getGcalStatus(): Promise<GcalStatus> {
+  return apiClient.get<GcalStatus>("/api/v1/integrations/gcal/status");
+}
+
+export async function listGcalCalendars(): Promise<GcalCalendarsResponse> {
+  return apiClient.get<GcalCalendarsResponse>("/api/v1/integrations/gcal/calendars");
+}
+
+export async function updateGcalSettings(
+  input: UpdateGcalSettingsInput,
+): Promise<GcalStatus> {
+  return apiClient.put<GcalStatus>("/api/v1/integrations/gcal/settings", input);
+}
+
+export async function disconnectGcal(): Promise<void> {
+  await apiClient.delete("/api/v1/integrations/gcal");
+}
+
+/** 啟動 OAuth 授權：後端會回傳 auth_url，前端 redirect 過去 */
+export async function startGcalAuth(): Promise<{ auth_url: string }> {
+  return apiClient.post<{ auth_url: string }>("/api/v1/integrations/gcal/auth");
+}

--- a/dev/frontend/lib/gcal-settings/testids.ts
+++ b/dev/frontend/lib/gcal-settings/testids.ts
@@ -1,0 +1,28 @@
+/**
+ * Gcal Settings 頁面 data-testid 常數。
+ *
+ * 必須與 `test/browser/fixtures/gcal-settings.ts` 的 `GCAL_SETTINGS_TESTIDS` 一致。
+ */
+export const GCAL_SETTINGS_TESTIDS = {
+  section: "gcal-settings-section",
+
+  notConnectedState: "gcal-settings-not-connected",
+  connectButton: "gcal-settings-connect-button",
+
+  connectedState: "gcal-settings-connected",
+  emailLabel: "gcal-settings-email",
+  expiresAtLabel: "gcal-settings-expires-at",
+  defaultCalendarSelect: "gcal-settings-default-calendar-select",
+  defaultCalendarOption: (id: string) => `gcal-settings-default-calendar-option-${id}`,
+  saveSettingsButton: "gcal-settings-save-button",
+  disconnectButton: "gcal-settings-disconnect-button",
+
+  disconnectDialog: "gcal-settings-disconnect-dialog",
+  disconnectDialogConfirm: "gcal-settings-disconnect-dialog-confirm",
+  disconnectDialogCancel: "gcal-settings-disconnect-dialog-cancel",
+
+  toastSaved: "gcal-settings-toast-saved",
+  toastDisconnected: "gcal-settings-toast-disconnected",
+  reauthBanner: "gcal-settings-reauth-banner",
+  reauthBannerReconnect: "gcal-settings-reauth-banner-reconnect",
+} as const;

--- a/dev/frontend/lib/hooks/use-gcal-settings.ts
+++ b/dev/frontend/lib/hooks/use-gcal-settings.ts
@@ -1,0 +1,62 @@
+"use client";
+
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import {
+  GcalStatus,
+  GcalCalendarsResponse,
+  UpdateGcalSettingsInput,
+  disconnectGcal,
+  getGcalStatus,
+  listGcalCalendars,
+  startGcalAuth,
+  updateGcalSettings,
+} from "@/lib/api/gcal-settings";
+
+export const GCAL_STATUS_KEY = ["gcal", "status"] as const;
+export const GCAL_CALENDARS_KEY = ["gcal", "calendars"] as const;
+
+export function useGcalStatus() {
+  return useQuery<GcalStatus>({
+    queryKey: GCAL_STATUS_KEY,
+    queryFn: () => getGcalStatus(),
+    staleTime: 60_000,
+  });
+}
+
+export function useGcalCalendars(opts: { enabled?: boolean } = {}) {
+  return useQuery<GcalCalendarsResponse>({
+    queryKey: GCAL_CALENDARS_KEY,
+    queryFn: () => listGcalCalendars(),
+    enabled: opts.enabled ?? true,
+    staleTime: 5 * 60_000,
+  });
+}
+
+export function useUpdateGcalSettings() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (input: UpdateGcalSettingsInput) => updateGcalSettings(input),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: GCAL_STATUS_KEY });
+      qc.invalidateQueries({ queryKey: ["calendar"] });
+    },
+  });
+}
+
+export function useDisconnectGcal() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: () => disconnectGcal(),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: GCAL_STATUS_KEY });
+      qc.invalidateQueries({ queryKey: ["calendar"] });
+      qc.invalidateQueries({ queryKey: GCAL_CALENDARS_KEY });
+    },
+  });
+}
+
+export function useStartGcalAuth() {
+  return useMutation({
+    mutationFn: () => startGcalAuth(),
+  });
+}


### PR DESCRIPTION
Closes #104

新增 /settings/gcal 頁面：未連 / 已連 / 需 reauth 三態 + 預設日曆設定 + 中斷連線 AlertDialog。

testid 全部對齊 test/browser/fixtures/gcal-settings.ts 的 GCAL_SETTINGS_TESTIDS。

tsc --noEmit 僅剩 2 個 pre-existing 無關錯誤。

🤖 Generated with [Claude Code](https://claude.com/claude-code)