### PR TITLE
fix(sprint9-polish): 處理 #118 audit 的 5 個 SHOULD FIX

### DIFF
--- a/dev/__tests__/service/journal_draft_test.go
+++ b/dev/__tests__/service/journal_draft_test.go
@@ -1,0 +1,129 @@
+package service_test
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/gpwork4u/aibo/dto"
+	"github.com/gpwork4u/aibo/model"
+	"github.com/gpwork4u/aibo/repository"
+	"github.com/gpwork4u/aibo/service"
+)
+
+// stubJournalDraftEntryRepo 提供可控 ListByDateRange，其餘方法為空實作。
+type stubJournalDraftEntryRepo struct {
+	entries []dto.CalendarEntrySummary
+	err     error
+}
+
+func (s *stubJournalDraftEntryRepo) ListByDateRange(_ context.Context, _, _, _ string) ([]dto.CalendarEntrySummary, error) {
+	return s.entries, s.err
+}
+func (s *stubJournalDraftEntryRepo) Create(_ context.Context, _ *model.Entry) error { return nil }
+func (s *stubJournalDraftEntryRepo) FindByID(_ context.Context, _ uuid.UUID) (*model.Entry, error) {
+	return nil, nil
+}
+func (s *stubJournalDraftEntryRepo) List(_ context.Context, _ model.EntryFilter) (*model.EntryListResult, error) {
+	return nil, nil
+}
+func (s *stubJournalDraftEntryRepo) Update(_ context.Context, _ *model.Entry) error { return nil }
+func (s *stubJournalDraftEntryRepo) Delete(_ context.Context, _ uuid.UUID) error    { return nil }
+func (s *stubJournalDraftEntryRepo) ConfirmEntry(_ context.Context, _ uuid.UUID) (*model.Entry, error) {
+	return nil, nil
+}
+func (s *stubJournalDraftEntryRepo) FlagEntry(_ context.Context, _ uuid.UUID, _ string, _ *string) (*model.Entry, *model.EntryFlag, error) {
+	return nil, nil, nil
+}
+func (s *stubJournalDraftEntryRepo) GetFlags(_ context.Context, _ uuid.UUID) ([]model.EntryFlag, error) {
+	return nil, nil
+}
+func (s *stubJournalDraftEntryRepo) ExistsBySourceRef(_ context.Context, _, _ string) (bool, error) {
+	return false, nil
+}
+func (s *stubJournalDraftEntryRepo) CategoryExists(_ context.Context, _ uuid.UUID) (bool, error) {
+	return false, nil
+}
+func (s *stubJournalDraftEntryRepo) SupersedeEntry(_ context.Context, _, _ uuid.UUID) (*model.Entry, error) {
+	return nil, nil
+}
+func (s *stubJournalDraftEntryRepo) ClearSupersede(_ context.Context, _ uuid.UUID) (*model.Entry, error) {
+	return nil, nil
+}
+func (s *stubJournalDraftEntryRepo) GetSupersedeChain(_ context.Context, _ uuid.UUID) ([]repository.HistoryItem, error) {
+	return nil, nil
+}
+func (s *stubJournalDraftEntryRepo) CheckCircularSupersede(_ context.Context, _, _ uuid.UUID) (bool, error) {
+	return false, nil
+}
+func (s *stubJournalDraftEntryRepo) GetByGcalRef(_ context.Context, _ string) (uuid.UUID, error) {
+	return uuid.Nil, nil
+}
+
+var _ service.EntryRepository = (*stubJournalDraftEntryRepo)(nil)
+
+// -----------------------------------------------------------------------------
+// 400 INVALID_INPUT：日期格式錯
+// -----------------------------------------------------------------------------
+func TestJournalDraft_InvalidDate(t *testing.T) {
+	svc := service.NewJournalDraftService(nil, &stubJournalDraftEntryRepo{}, nil)
+	_, err := svc.Draft(context.Background(), "2026-13-99", "UTC", "primary")
+	if err == nil {
+		t.Fatal("預期 400 invalid date")
+	}
+	appErr, ok := err.(*model.AppError)
+	if !ok || appErr.Status != 400 {
+		t.Errorf("預期 400 AppError，實際 %v", err)
+	}
+}
+
+// -----------------------------------------------------------------------------
+// 400 INVALID_INPUT：tz 格式錯
+// -----------------------------------------------------------------------------
+func TestJournalDraft_InvalidTimezone(t *testing.T) {
+	svc := service.NewJournalDraftService(nil, &stubJournalDraftEntryRepo{}, nil)
+	_, err := svc.Draft(context.Background(), "2026-04-25", "Mars/Olympus", "primary")
+	if err == nil {
+		t.Fatal("預期 400 invalid tz")
+	}
+	appErr, ok := err.(*model.AppError)
+	if !ok || appErr.Status != 400 {
+		t.Errorf("預期 400 AppError，實際 %v", err)
+	}
+}
+
+// -----------------------------------------------------------------------------
+// 404 NOT_FOUND：當日無素材
+// -----------------------------------------------------------------------------
+func TestJournalDraft_NoData(t *testing.T) {
+	repo := &stubJournalDraftEntryRepo{entries: nil}
+	svc := service.NewJournalDraftService(nil, repo, nil) // gcalSvc nil → 不嘗試 gcal
+	_, err := svc.Draft(context.Background(), "2026-04-25", "UTC", "primary")
+	if err == nil {
+		t.Fatal("預期 404 no data")
+	}
+	appErr, ok := err.(*model.AppError)
+	if !ok || appErr.Status != 404 {
+		t.Errorf("預期 404 AppError，實際 %v", err)
+	}
+}
+
+// -----------------------------------------------------------------------------
+// Repo 錯誤 → 包裝後傳出（非 AppError 路徑）
+// -----------------------------------------------------------------------------
+func TestJournalDraft_RepoError(t *testing.T) {
+	repo := &stubJournalDraftEntryRepo{err: fakeRepoErr("db down")}
+	svc := service.NewJournalDraftService(nil, repo, nil)
+	_, err := svc.Draft(context.Background(), "2026-04-25", "UTC", "primary")
+	if err == nil {
+		t.Fatal("預期錯誤")
+	}
+	if !strings.Contains(err.Error(), "db down") {
+		t.Errorf("錯誤訊息應包含 repo 原因，實際 %v", err)
+	}
+}
+
+type fakeRepoErr string
+
+func (e fakeRepoErr) Error() string { return string(e) }

--- a/dev/frontend/components/gcal-settings/gcal-status-card.tsx
+++ b/dev/frontend/components/gcal-settings/gcal-status-card.tsx
@@ -54,7 +54,10 @@ export function GcalStatusCard() {
   const handleConnect = async () => {
     try {
       const res = await startAuth.mutateAsync();
-      window.location.href = res.auth_url;
+      // OAuth 必須 hard redirect 到外部 URL，但需 SSR guard 避免 server-side 誤觸發
+      if (typeof window !== "undefined") {
+        window.location.href = res.auth_url;
+      }
     } catch (err) {
       toast.error(err instanceof Error ? err.message : "啟動授權失敗");
     }

--- a/dev/frontend/components/journal/journal-heatmap.tsx
+++ b/dev/frontend/components/journal/journal-heatmap.tsx
@@ -19,8 +19,16 @@ interface JournalHeatmapProps {
   data: HeatmapDatum[];
 }
 
+// 以瀏覽器當地時區算出 YYYY-MM-DD，避免使用 toISOString() 在非 UTC 時區
+// 凌晨打開頁面時 heatmap 格子被歸到前一天的問題。
+const LOCAL_YMD_FORMATTER = new Intl.DateTimeFormat("en-CA", {
+  year: "numeric",
+  month: "2-digit",
+  day: "2-digit",
+});
+
 function ymd(d: Date): string {
-  return d.toISOString().slice(0, 10);
+  return LOCAL_YMD_FORMATTER.format(d);
 }
 
 function eachDay(start: Date, end: Date): Date[] {
@@ -78,6 +86,7 @@ export function JournalHeatmap({
               data-testid={JOURNAL_TESTIDS.heatmapCell(ds)}
               data-intensity={intensity}
               title={`${ds}${intensity > 0 ? " · 已寫" : ""}`}
+              aria-label={`${ds}${intensity > 0 ? "（已寫日記）" : "（尚未撰寫）"}`}
               className={cn(
                 "aspect-square rounded-sm transition-opacity hover:opacity-70",
                 INTENSITY_CLASS[Math.min(intensity, 4)],

--- a/dev/frontend/lib/hooks/use-journals.ts
+++ b/dev/frontend/lib/hooks/use-journals.ts
@@ -1,6 +1,7 @@
 "use client";
 
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { ApiError } from "@/lib/api/client";
 import {
   CreateJournalInput,
   UpdateJournalInput,
@@ -9,6 +10,7 @@ import {
   draftJournal,
   getJournal,
   listJournals,
+  updateJournal,
   ListJournalsParams,
   ListJournalsResponse,
   JournalEntry,
@@ -24,11 +26,21 @@ export function useJournals(params: ListJournalsParams = {}) {
   });
 }
 
+/**
+ * 讀取單日日記。
+ *
+ * 404 是「該日尚未撰寫」的正常狀態（編輯頁打開新一天），需要把錯誤
+ * 暴露給 UI 來顯示空表單，但不應 retry / 重複 log。
+ */
 export function useJournal(date: string | null | undefined) {
   return useQuery<JournalEntry>({
     queryKey: journalKey(date ?? ""),
     queryFn: () => getJournal(date as string),
     enabled: !!date,
+    retry: (failureCount, error) => {
+      if (error instanceof ApiError && error.status === 404) return false;
+      return failureCount < 2;
+    },
   });
 }
 
@@ -47,16 +59,13 @@ export function useUpdateJournal() {
   const qc = useQueryClient();
   return useMutation({
     mutationFn: ({ date, payload }: { date: string; payload: UpdateJournalInput }) =>
-      updateJournalApi(date, payload),
+      updateJournal(date, payload),
     onSuccess: (_data, vars) => {
       qc.invalidateQueries({ queryKey: JOURNALS_QUERY_KEY });
       qc.invalidateQueries({ queryKey: journalKey(vars.date) });
     },
   });
 }
-
-// 重新匯出 update 以保留 hook 內 import 簡潔
-import { updateJournal as updateJournalApi } from "@/lib/api/journal";
 
 export function useDeleteJournal() {
   const qc = useQueryClient();


### PR DESCRIPTION
Refs #118

## 摘要
Sprint 9 Wave 2/3 retrospective audit 的 5 個 SHOULD FIX 一次處理完。

## 變更
| Audit 項 | PR | 修法 |
|---|---|---|
| heatmap timezone bug | #115 | `ymd()` 改用 `Intl.DateTimeFormat('en-CA')`，依瀏覽器 tz 取本地 YYYY-MM-DD |
| heatmap aria-label | #115 | `<Link aria-label="...">` 加日期 + 撰寫狀態 |
| use-journals.ts import 位置 | #115 | 移除中段 import，統一頂部 |
| gcal connect SSR guard | #116 | `window.location.href` 加 `typeof window !== 'undefined'` |
| useJournal 404 retry | #117 | `retry: (count, err) => !(404)` |
| F-028c unit test | #114 | 新增 4 個路徑測試（invalid_date / invalid_tz / no_data / repo error） |

## 測試
- `npx tsc --noEmit` 僅剩 2 個 pre-existing 無關錯誤
- `go build ./...` 通過
- `go vet ./...` 通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)