### PR TITLE
design(sprint10): D-10 Projects + Kanban + Task UI 元件規格

### DIFF
--- a/design/components/kanban/README.md
+++ b/design/components/kanban/README.md
@@ -1,0 +1,39 @@
+# Kanban Components — Sprint 10
+
+對應 issue #126、F-032b。基於 `@dnd-kit/core` + `@dnd-kit/sortable`，4 欄 Kanban（todo / in_progress / blocked / done），可拖移改 status + position。樣式沿用 shadcn/ui + Tailwind v4。
+
+## 元件清單
+
+| 元件 | 檔案 | 用途 |
+|------|------|------|
+| KanbanBoard | `kanban-board.md` | 4 欄整體 layout + DndContext |
+| KanbanColumn | `kanban-column.md` | 單一欄位（header + sortable list + drop zone） |
+| KanbanCard | `kanban-card.md` | 任務卡片（拖移單位） |
+
+## testid
+
+統一見 `testids.md`（`KANBAN_TESTIDS` 常數）。
+
+## 響應式
+
+| 斷點 | 行為 |
+|------|------|
+| `>= 768px` | 4 欄並排，欄寬 280–320px，水平 scroll |
+| `< 768px` | 顯示單欄 + status switcher（segmented control 切換 status） |
+
+## 拖移交互
+
+| 來源 | 行為 |
+|------|------|
+| Pointer / Touch（PointerSensor，activationConstraint distance=4） | 一般拖移 |
+| Keyboard（KeyboardSensor，sortableKeyboardCoordinates） | Tab 進 drag handle，Space 開始拖、`↑↓` 在欄內移、`←→` 跨欄、Enter 放下、Esc 取消 |
+
+`@dnd-kit` 內建 `<ScreenReaderInstructions>` 與 `announcements`，本專案以繁中覆寫（見 `kanban-board.md`）。
+
+## Tokens 對照
+
+色票來自 `design/tokens/projects.json`：
+- `kanban.column-bg` / `column-drag-over-bg` / `column-drag-over-ring`
+- `kanban.card-shadow-rest` / `card-shadow-hover` / `card-shadow-drag`
+- `task-status.{status}.dot/bg/fg` 用於 KanbanCard status indicator
+- `priority.{level}.bg/fg/border` 用於 priority badge

--- a/design/components/kanban/kanban-board.md
+++ b/design/components/kanban/kanban-board.md
@@ -1,0 +1,287 @@
+# KanbanBoard
+
+`/projects/:id` Board tab 的核心元件。包裝 `@dnd-kit` 的 `DndContext`，管理跨欄 / 欄內拖移與樂觀更新。
+
+---
+
+## 用途
+
+讀取 `/api/v1/projects/:id/tasks`，依 status 分組，render 4 個 `KanbanColumn`，並在拖放結束時呼叫 `PATCH /api/v1/tasks/:id` 更新 status + position。
+
+---
+
+## 結構
+
+```
+┌──────────────────────────────────────────────────────────────────────┐
+│ ┌──── todo ─────┐ ┌── in_progress ──┐ ┌── blocked ──┐ ┌── done ────┐ │
+│ │ 待辦  3        │ │ 進行中  2         │ │ 卡住  1     │ │ 完成  12   │ │
+│ │ + 加入任務     │ │ + 加入任務        │ │ + 加入任務   │ │ + 加入任務 │ │
+│ │ ┌────────────┐│ │ ┌──────────────┐  │ │ ┌─────────┐ │ │ ┌─────────┐│ │
+│ │ │ Card A     ││ │ │ Card C       │  │ │ │ Card E  │ │ │ │ Card G  ││ │
+│ │ ├────────────┤│ │ ├──────────────┤  │ │ └─────────┘ │ │ ├─────────┤│ │
+│ │ │ Card B     ││ │ │ Card D       │  │ │             │ │ │ ...     ││ │
+│ │ └────────────┘│ │ └──────────────┘  │ │             │ │ └─────────┘│ │
+│ └────────────────┘ └─────────────────┘ └──────────────┘ └────────────┘ │
+└──────────────────────────────────────────────────────────────────────┘
+```
+
+`< 768px` 改為單欄垂直 + status switcher（見 README）。
+
+---
+
+## Props
+
+```ts
+type TaskStatus = "todo" | "in_progress" | "blocked" | "done";
+
+interface KanbanBoardProps {
+  projectId: string;
+  tasks: TaskCardData[];                    // 已含所有 status 的 tasks
+  isLoading?: boolean;
+  isError?: boolean;
+  onMoveTask: (input: {
+    taskId: string;
+    fromStatus: TaskStatus;
+    toStatus: TaskStatus;
+    toIndex: number;                         // 0-based 在目標欄的位置
+  }) => Promise<void>;                       // 失敗會 throw → board rollback
+  onAddTask: (status: TaskStatus) => void;   // 開 TaskSheet (mode=create, defaultStatus)
+  onOpenTask: (taskId: string) => void;      // 點擊卡片 → 開 TaskSheet (mode=edit)
+  onCompleteTask: (taskId: string) => void;  // 點 checkbox
+}
+```
+
+`KanbanCard` cancelled tasks 不顯示在 Board（只在 List tab 顯示）。
+
+---
+
+## DndContext 設定
+
+```tsx
+import {
+  DndContext,
+  DragOverlay,
+  PointerSensor,
+  KeyboardSensor,
+  useSensor,
+  useSensors,
+  closestCorners,
+  type DragStartEvent,
+  type DragOverEvent,
+  type DragEndEvent,
+} from "@dnd-kit/core";
+import {
+  SortableContext,
+  arrayMove,
+  sortableKeyboardCoordinates,
+  verticalListSortingStrategy,
+} from "@dnd-kit/sortable";
+import { KANBAN_TESTIDS } from "@/lib/testids/kanban";
+
+const sensors = useSensors(
+  useSensor(PointerSensor, { activationConstraint: { distance: 4 } }),
+  useSensor(KeyboardSensor, { coordinateGetter: sortableKeyboardCoordinates }),
+);
+
+const COLUMNS: { status: TaskStatus; label: string }[] = [
+  { status: "todo", label: "待辦" },
+  { status: "in_progress", label: "進行中" },
+  { status: "blocked", label: "卡住" },
+  { status: "done", label: "完成" },
+];
+
+const announcements = {
+  onDragStart: ({ active }: { active: { id: string } }) => {
+    const t = tasksById[active.id];
+    return t ? `已抓起任務「${t.title}」` : "已抓起任務";
+  },
+  onDragOver: ({ active, over }: any) => {
+    if (!over) return;
+    const t = tasksById[active.id];
+    const targetCol = COLUMNS.find((c) => c.status === over.data.current?.columnStatus);
+    if (t && targetCol) return `任務「${t.title}」位於 ${targetCol.label} 欄`;
+  },
+  onDragEnd: ({ active, over }: any) => {
+    if (!over) return "已取消拖移";
+    const t = tasksById[active.id];
+    const targetCol = COLUMNS.find((c) => c.status === over.data.current?.columnStatus);
+    if (t && targetCol) return `任務「${t.title}」已放到 ${targetCol.label} 欄`;
+  },
+  onDragCancel: ({ active }: any) => {
+    const t = tasksById[active.id];
+    return t ? `已取消移動任務「${t.title}」` : "已取消拖移";
+  },
+};
+
+const screenReaderInstructions = {
+  draggable:
+    "請按 Space 或 Enter 開始拖移任務。拖移時，使用方向鍵移動到目標欄位或位置，再按 Space 或 Enter 放下。按 Esc 取消。",
+};
+
+<DndContext
+  sensors={sensors}
+  collisionDetection={closestCorners}
+  onDragStart={handleDragStart}
+  onDragOver={handleDragOver}
+  onDragEnd={handleDragEnd}
+  onDragCancel={handleDragCancel}
+  accessibility={{ announcements, screenReaderInstructions }}
+>
+  <div
+    data-testid={KANBAN_TESTIDS.board}
+    className="flex h-full gap-3 overflow-x-auto pb-2"
+  >
+    {COLUMNS.map((col) => (
+      <SortableContext
+        key={col.status}
+        id={col.status}
+        items={tasksByStatus[col.status].map((t) => t.id)}
+        strategy={verticalListSortingStrategy}
+      >
+        <KanbanColumn
+          status={col.status}
+          label={col.label}
+          tasks={tasksByStatus[col.status]}
+          onAddTask={onAddTask}
+          onOpenTask={onOpenTask}
+          onCompleteTask={onCompleteTask}
+          isDraggingOver={overColumn === col.status}
+        />
+      </SortableContext>
+    ))}
+  </div>
+
+  <DragOverlay
+    adjustScale={false}
+    dropAnimation={{ duration: 200, easing: "cubic-bezier(0.18, 0.67, 0.6, 1.22)" }}
+  >
+    {activeTask ? (
+      <div data-testid={KANBAN_TESTIDS.dragOverlay}>
+        <KanbanCard
+          task={activeTask}
+          isDragOverlay
+          onOpen={() => {}}
+          onComplete={() => {}}
+        />
+      </div>
+    ) : null}
+  </DragOverlay>
+
+  {/* a11y 額外的繁中 polite live region（@dnd-kit 內建是 assertive；複用相同訊息但延遲 100ms） */}
+  <div
+    data-testid={KANBAN_TESTIDS.boardLiveRegion}
+    role="status"
+    aria-live="polite"
+    aria-atomic="true"
+    className="sr-only"
+  >
+    {liveMessage}
+  </div>
+</DndContext>
+```
+
+---
+
+## 拖放邏輯（簡化）
+
+```ts
+function handleDragEnd(e: DragEndEvent) {
+  const { active, over } = e;
+  if (!over) return;
+
+  const activeTask = tasksById[active.id as string];
+  if (!activeTask) return;
+
+  // overId 可能是另一個 task id，或 column drop zone id（'col-{status}'）
+  const overData = over.data.current ?? {};
+  const toStatus =
+    (overData.columnStatus as TaskStatus) ?? tasksById[over.id as string]?.status;
+  if (!toStatus) return;
+
+  const targetList = tasksByStatus[toStatus];
+  let toIndex = targetList.findIndex((t) => t.id === over.id);
+  if (toIndex === -1) toIndex = targetList.length; // dropped on column body
+
+  const fromStatus = activeTask.status;
+
+  // 1. 樂觀更新本地 state（含 arrayMove）
+  applyOptimistic({ taskId: active.id as string, fromStatus, toStatus, toIndex });
+
+  // 2. 呼叫 API；失敗 rollback
+  onMoveTask({ taskId: active.id as string, fromStatus, toStatus, toIndex }).catch(() => {
+    rollbackOptimistic();
+    toast.error("更新失敗，請重試");
+  });
+}
+```
+
+---
+
+## 響應式：< 768px
+
+```tsx
+import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group";
+
+{isMobile ? (
+  <>
+    <ToggleGroup
+      type="single"
+      value={mobileStatus}
+      onValueChange={(v) => v && setMobileStatus(v as TaskStatus)}
+      data-testid={KANBAN_TESTIDS.mobileStatusSwitcher}
+      className="sticky top-0 z-10 mb-2 w-full justify-start overflow-x-auto bg-background py-1"
+      aria-label="切換任務狀態欄位"
+    >
+      {COLUMNS.map((c) => (
+        <ToggleGroupItem
+          key={c.status}
+          value={c.status}
+          data-testid={`${KANBAN_TESTIDS.mobileStatusOption}-${c.status}`}
+        >
+          {c.label}
+          <span className="ml-1.5 rounded bg-muted px-1 text-xs tabular-nums">
+            {tasksByStatus[c.status].length}
+          </span>
+        </ToggleGroupItem>
+      ))}
+    </ToggleGroup>
+    <KanbanColumn status={mobileStatus} {...} />
+  </>
+) : (
+  /* desktop 4-column layout */
+)}
+```
+
+行動版仍包在 `DndContext` 內，但只渲染當前欄；跨欄移動透過 ToggleGroup 切換後在新欄重新拖放。
+
+---
+
+## States
+
+| 狀態 | 視覺 |
+|------|------|
+| Loading | 4 欄各顯示 3 張 skeleton card（`testid={KANBAN_TESTIDS.boardSkeleton}`） |
+| Error | 替換為 `boardError` 區塊 + 重試按鈕 |
+| 拖移中 | 來源卡 `opacity-40`、Drag overlay 顯示「正在拖移」副本（旋轉 2deg + 大陰影） |
+| 跨欄 hover | 目標欄背景轉為 `kanban.column-drag-over-bg` + ring |
+| Drop 後樂觀 | 卡片立即移到新欄；失敗 rollback + toast |
+
+---
+
+## a11y
+
+- `<DndContext accessibility>` 提供繁中 announcements 與 screenReaderInstructions
+- 額外 `aria-live="polite"` region：跨欄移動成功 / 失敗訊息
+- 鍵盤：每張卡的 drag handle 為 `<button aria-label="拖移任務 {title}">`，Space 開始拖、方向鍵移動、Enter 放下、Esc 取消（@dnd-kit 內建）
+- 不依賴 hover 狀態才能拖移（鍵盤即可完成完整流程）
+- 對比通過 4.5:1
+- 尊重 `prefers-reduced-motion`：移除 dropAnimation
+- `aria-grabbed`、`aria-dropeffect` 由 `useSortable` 自動處理（@dnd-kit）
+
+---
+
+## 已知限制
+
+- TOO_MANY_TASKS（超過 500）：Board 顯示空狀態 + 提示「請使用 List 視圖並加上篩選」
+- cancelled status 不顯示在 Board，只在 List tab

--- a/design/components/kanban/kanban-card.md
+++ b/design/components/kanban/kanban-card.md
@@ -1,0 +1,235 @@
+# KanbanCard
+
+Kanban 上的單張任務卡片，是拖移最小單位。
+
+---
+
+## 用途
+
+呈現任務摘要（title / priority / due date / refs / status indicator / 完成勾勾），並透過 drag handle 支援滑鼠 + 鍵盤拖移。
+
+---
+
+## 結構
+
+```
+┌──────────────────────────────────────────────┐
+│ ⠿  ☐  設計 schema                  [急迫]    │  ← drag handle + checkbox + title + priority badge
+│       4/30  📎 3                              │  ← due date + refs count
+└──────────────────────────────────────────────┘
+```
+
+過期：due date 變紅 + clock-alert icon。
+完成（done）：title 加刪除線、整體 `opacity-70`。
+
+---
+
+## Props
+
+```ts
+interface KanbanCardProps {
+  task: {
+    id: string;
+    title: string;
+    status: TaskStatus;             // todo / in_progress / blocked / done
+    priority: "low" | "normal" | "high" | "urgent";
+    due_date: string | null;        // YYYY-MM-DD
+    refs_count: number;
+  };
+  onOpen: () => void;
+  onComplete: () => void;
+  isDragOverlay?: boolean;          // true = 在 DragOverlay 中渲染（不掛 useSortable）
+}
+```
+
+---
+
+## Tailwind / 範例
+
+```tsx
+import { useSortable } from "@dnd-kit/sortable";
+import { CSS } from "@dnd-kit/utilities";
+import { Checkbox } from "@/components/ui/checkbox";
+import { Badge } from "@/components/ui/badge";
+import { GripVerticalIcon, CalendarIcon, ClockAlertIcon, PaperclipIcon } from "lucide-react";
+import { cn } from "@/lib/utils";
+import { KANBAN_TESTIDS } from "@/lib/testids/kanban";
+
+const PRIORITY = {
+  low:    { label: "低",    cls: "border-zinc-300 bg-zinc-100 text-zinc-700 dark:bg-zinc-900/60 dark:text-zinc-300" },
+  normal: { label: "一般",  cls: "border-blue-300 bg-blue-100 text-blue-900 dark:bg-blue-950/40 dark:text-blue-200" },
+  high:   { label: "高",    cls: "border-orange-300 bg-orange-100 text-orange-900 dark:bg-orange-950/40 dark:text-orange-200" },
+  urgent: { label: "急迫",  cls: "border-red-300 bg-red-100 text-red-900 dark:bg-red-950/40 dark:text-red-200" },
+} as const;
+
+const STATUS_DOT = {
+  todo:        "bg-zinc-400",
+  in_progress: "bg-blue-500",
+  blocked:     "bg-red-500",
+  done:        "bg-green-500",
+} as const;
+
+export function KanbanCard({ task, onOpen, onComplete, isDragOverlay }: KanbanCardProps) {
+  const sortable = useSortable({
+    id: task.id,
+    data: { columnStatus: task.status },
+    disabled: isDragOverlay,
+  });
+  const { attributes, listeners, setNodeRef, transform, transition, isDragging } = sortable;
+
+  const isOverdue =
+    task.due_date && task.status !== "done" && new Date(task.due_date) < startOfTodayLocal();
+  const isDone = task.status === "done";
+
+  const style = isDragOverlay
+    ? undefined
+    : { transform: CSS.Transform.toString(transform), transition };
+
+  return (
+    <article
+      ref={isDragOverlay ? undefined : setNodeRef}
+      style={style}
+      data-testid={`${KANBAN_TESTIDS.card}-${task.id}`}
+      className={cn(
+        "group relative rounded-md border bg-card shadow-sm transition-shadow",
+        "hover:shadow-md focus-within:ring-2 focus-within:ring-ring focus-within:ring-offset-1",
+        isDragging && "opacity-40",
+        isDragOverlay && "rotate-[2deg] shadow-2xl ring-2 ring-blue-400",
+        isDone && "opacity-70",
+      )}
+    >
+      {/* status indicator dot（左側 4px 直條） */}
+      <span
+        aria-hidden="true"
+        data-testid={`${KANBAN_TESTIDS.cardStatusDot}-${task.id}`}
+        className={cn(
+          "absolute inset-y-0 left-0 w-1 rounded-l-md",
+          STATUS_DOT[task.status],
+        )}
+      />
+
+      <div className="flex items-start gap-2 p-2.5 pl-3">
+        {/* Drag handle */}
+        <button
+          type="button"
+          {...attributes}
+          {...listeners}
+          data-testid={`${KANBAN_TESTIDS.cardDragHandle}-${task.id}`}
+          aria-label={`拖移任務「${task.title}」`}
+          className={cn(
+            "mt-0.5 flex h-6 w-6 shrink-0 cursor-grab items-center justify-center rounded text-muted-foreground",
+            "hover:bg-muted hover:text-foreground active:cursor-grabbing",
+            "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
+            "touch-none", // 防止 mobile scroll 競爭
+          )}
+        >
+          <GripVerticalIcon className="h-4 w-4" aria-hidden="true" />
+        </button>
+
+        {/* Complete checkbox */}
+        <Checkbox
+          checked={isDone}
+          onCheckedChange={onComplete}
+          data-testid={`${KANBAN_TESTIDS.cardCompleteToggle}-${task.id}`}
+          aria-label={isDone ? `取消完成任務「${task.title}」` : `完成任務「${task.title}」`}
+          className="mt-1"
+        />
+
+        {/* Body */}
+        <button
+          type="button"
+          onClick={onOpen}
+          className="flex-1 text-left focus:outline-none"
+          aria-label={`開啟任務「${task.title}」詳情`}
+        >
+          <div className="mb-1 flex items-start gap-2">
+            <h4
+              data-testid={`${KANBAN_TESTIDS.cardTitle}-${task.id}`}
+              className={cn(
+                "line-clamp-2 flex-1 text-sm font-medium leading-snug",
+                isDone && "line-through text-muted-foreground",
+              )}
+            >
+              {task.title}
+            </h4>
+            {task.priority !== "normal" && (
+              <Badge
+                data-testid={`${KANBAN_TESTIDS.cardPriorityBadge}-${task.id}`}
+                className={cn("shrink-0 border text-[10px] leading-tight", PRIORITY[task.priority].cls)}
+                aria-label={`優先級：${PRIORITY[task.priority].label}`}
+              >
+                {PRIORITY[task.priority].label}
+              </Badge>
+            )}
+          </div>
+
+          <div className="flex items-center gap-3 text-xs text-muted-foreground">
+            {task.due_date && (
+              <span
+                data-testid={`${KANBAN_TESTIDS.cardDueDate}-${task.id}`}
+                className={cn(
+                  "flex items-center gap-1 tabular-nums",
+                  isOverdue && "text-destructive font-medium",
+                )}
+                aria-label={isOverdue ? `逾期：${task.due_date}` : `截止：${task.due_date}`}
+              >
+                {isOverdue ? (
+                  <ClockAlertIcon className="h-3.5 w-3.5" aria-hidden="true" />
+                ) : (
+                  <CalendarIcon className="h-3.5 w-3.5" aria-hidden="true" />
+                )}
+                {formatDateShortZh(task.due_date)}
+              </span>
+            )}
+            {task.refs_count > 0 && (
+              <span
+                data-testid={`${KANBAN_TESTIDS.cardRefsCount}-${task.id}`}
+                className="flex items-center gap-1"
+                aria-label={`${task.refs_count} 個關聯項目`}
+              >
+                <PaperclipIcon className="h-3.5 w-3.5" aria-hidden="true" />
+                {task.refs_count}
+              </span>
+            )}
+          </div>
+        </button>
+      </div>
+    </article>
+  );
+}
+```
+
+---
+
+## States
+
+| 狀態 | 視覺 |
+|------|------|
+| Default | `bg-card border` + 細 shadow |
+| Hover | `shadow-md` |
+| Focus-within | `ring-2 ring-ring ring-offset-1` |
+| isDragging（在原位的副本） | `opacity-40` |
+| isDragOverlay（拖移 portal） | `rotate-2deg` + 大 shadow + 藍色 ring |
+| done | 整體 `opacity-70`，title 刪除線 |
+| overdue | due date 變紅 + 換 clock-alert icon |
+
+---
+
+## a11y
+
+- drag handle 為 `<button>`，可 Tab，有繁中 `aria-label="拖移任務「X」"`
+- complete checkbox 使用 shadcn `<Checkbox>`，`aria-label` 包含 task title
+- 整張卡的點擊區是另一個 `<button>`，不與 drag handle 重疊（避免衝突）
+- priority badge：`aria-label="優先級：急迫"`
+- status indicator dot 為視覺輔助，狀態語意由欄位 label 提供
+- overdue 同時用「紅色 + 不同 icon + 「逾期」文字 aria-label」三重提示，不單靠顏色
+- `touch-none` class 確保 mobile 拖移不被 scroll 截走
+- `prefers-reduced-motion`：移除 transform transition
+
+---
+
+## 與 KanbanBoard 的契約
+
+- 每張卡 `useSortable({ id: task.id, data: { columnStatus: task.status } })`
+- `KanbanColumn` 提供 `useDroppable({ id: 'col-{status}', data: { columnStatus: status } })`
+- DragEnd 時 board 從 `over.data.current.columnStatus` 取得目標欄

--- a/design/components/kanban/kanban-column.md
+++ b/design/components/kanban/kanban-column.md
@@ -1,0 +1,175 @@
+# KanbanColumn
+
+Kanban 單一欄位。包含 header（status label + count + 加入任務按鈕）、sortable list、空狀態。
+
+---
+
+## 結構
+
+```
+┌─────────────────────────┐
+│ ● 待辦   3              │  ← header（status dot + label + count）
+│                    [ + ]│  ← 加入任務按鈕
+├─────────────────────────┤
+│ ┌─────────────────────┐ │
+│ │ Card A              │ │
+│ ├─────────────────────┤ │
+│ │ Card B              │ │
+│ └─────────────────────┘ │
+│ ┌─────────────────────┐ │
+│ │   尚無任務           │ │  ← 空狀態（無 cards 時）
+│ │   點 + 新增          │ │
+│ └─────────────────────┘ │
+└─────────────────────────┘
+```
+
+拖移 hover 時整欄背景轉色 + ring。
+
+---
+
+## Props
+
+```ts
+interface KanbanColumnProps {
+  status: TaskStatus;                    // todo / in_progress / blocked / done
+  label: string;                          // 「待辦」「進行中」「卡住」「完成」
+  tasks: TaskCardData[];                  // 已排序
+  onAddTask: (status: TaskStatus) => void;
+  onOpenTask: (taskId: string) => void;
+  onCompleteTask: (taskId: string) => void;
+  isDraggingOver?: boolean;               // DndContext over 此欄時為 true
+}
+```
+
+---
+
+## Tailwind / 範例
+
+```tsx
+import { useDroppable } from "@dnd-kit/core";
+import { SortableContext, verticalListSortingStrategy } from "@dnd-kit/sortable";
+import { Button } from "@/components/ui/button";
+import { PlusIcon } from "lucide-react";
+import { cn } from "@/lib/utils";
+import { KANBAN_TESTIDS } from "@/lib/testids/kanban";
+import { KanbanCard } from "./kanban-card";
+
+const STATUS_DOT = {
+  todo:        "bg-zinc-400",
+  in_progress: "bg-blue-500",
+  blocked:     "bg-red-500",
+  done:        "bg-green-500",
+} as const;
+
+export function KanbanColumn({ status, label, tasks, onAddTask, onOpenTask, onCompleteTask, isDraggingOver }: KanbanColumnProps) {
+  const dropId = `col-${status}`;
+  const { setNodeRef } = useDroppable({
+    id: dropId,
+    data: { columnStatus: status },
+  });
+
+  return (
+    <section
+      data-testid={`${KANBAN_TESTIDS.column}-${status}`}
+      aria-label={`${label} 欄，共 ${tasks.length} 筆任務`}
+      className="flex w-72 shrink-0 flex-col rounded-lg bg-muted/40 dark:bg-muted/20"
+    >
+      {/* Header */}
+      <header
+        data-testid={`${KANBAN_TESTIDS.columnHeader}-${status}`}
+        className="flex items-center gap-2 border-b px-3 py-2"
+      >
+        <span
+          aria-hidden="true"
+          className={cn("inline-block h-2 w-2 rounded-full", STATUS_DOT[status])}
+        />
+        <h3
+          data-testid={`${KANBAN_TESTIDS.columnLabel}-${status}`}
+          className="text-sm font-medium"
+        >
+          {label}
+        </h3>
+        <span
+          data-testid={`${KANBAN_TESTIDS.columnCount}-${status}`}
+          className="rounded bg-muted px-1.5 py-0.5 text-xs font-medium tabular-nums text-muted-foreground"
+          aria-label={`共 ${tasks.length} 筆`}
+        >
+          {tasks.length}
+        </span>
+        <Button
+          variant="ghost"
+          size="icon"
+          className="ml-auto h-7 w-7"
+          onClick={() => onAddTask(status)}
+          data-testid={`${KANBAN_TESTIDS.columnAddTask}-${status}`}
+          aria-label={`在 ${label} 欄新增任務`}
+        >
+          <PlusIcon className="h-4 w-4" aria-hidden="true" />
+        </Button>
+      </header>
+
+      {/* Drop zone + sortable list */}
+      <div
+        ref={setNodeRef}
+        data-testid={`${KANBAN_TESTIDS.columnDropZone}-${status}`}
+        className={cn(
+          "flex-1 space-y-2 p-2 transition-colors",
+          isDraggingOver && "bg-blue-50 ring-2 ring-blue-400 ring-inset dark:bg-blue-950/30",
+        )}
+      >
+        <ul
+          data-testid={`${KANBAN_TESTIDS.columnList}-${status}`}
+          className="space-y-2"
+        >
+          {tasks.length === 0 ? (
+            <li
+              data-testid={`${KANBAN_TESTIDS.columnEmpty}-${status}`}
+              className="rounded-md border border-dashed py-6 text-center text-xs text-muted-foreground"
+            >
+              尚無任務
+              <button
+                onClick={() => onAddTask(status)}
+                className="ml-1 underline underline-offset-2 hover:text-foreground"
+              >
+                點 + 新增
+              </button>
+            </li>
+          ) : (
+            tasks.map((task) => (
+              <li key={task.id}>
+                <KanbanCard
+                  task={task}
+                  onOpen={() => onOpenTask(task.id)}
+                  onComplete={() => onCompleteTask(task.id)}
+                />
+              </li>
+            ))
+          )}
+        </ul>
+      </div>
+    </section>
+  );
+}
+```
+
+---
+
+## States
+
+| 狀態 | 視覺 |
+|------|------|
+| Default | 背景 `bg-muted/40` |
+| isDraggingOver | 背景 `bg-blue-50` + `ring-2 ring-blue-400 ring-inset` |
+| 空欄 | 中央顯示「尚無任務 / 點 + 新增」虛線框 |
+| 拖移中（其他欄為來源） | 仍顯示原狀，僅目標欄變色 |
+
+---
+
+## a11y
+
+- `<section aria-label>` 含欄名 + 任務數，screen reader 直接得知
+- 加入任務按鈕 `aria-label` 標明所屬欄（「在 待辦 欄新增任務」）
+- count badge 使用 `aria-label="共 N 筆"`，避免被讀成「3」這類純數字
+- status dot 為純裝飾（`aria-hidden`），語意由 label 文字提供
+- drop zone hover 視覺 + 同時透過 DndContext announcement 朗讀
+- 觸控目標：加入按鈕本體 28×28，包覆 hit area 透過 padding 撐到 ≥ 44×44pt（可在實作時加 `before:` pseudo 元素）

--- a/design/components/kanban/testids.md
+++ b/design/components/kanban/testids.md
@@ -1,0 +1,50 @@
+# KANBAN_TESTIDS
+
+> Sprint 10 Kanban（@dnd-kit）元件 `data-testid` 命名表。
+
+```ts
+export const KANBAN_TESTIDS = {
+  // Board container
+  board: "kanban-board",
+  boardScroll: "kanban-board-scroll",
+  boardSkeleton: "kanban-board-skeleton",
+  boardError: "kanban-board-error",
+  boardLiveRegion: "kanban-board-live-region",       // a11y status announcement (aria-live=polite)
+
+  // Mobile single-column switcher (< 768px)
+  mobileStatusSwitcher: "kanban-mobile-status-switcher",
+  mobileStatusOption: "kanban-mobile-status-option", // suffix -{status}
+
+  // Column
+  column: "kanban-column",                           // suffix -{status} e.g. kanban-column-todo
+  columnHeader: "kanban-column-header",              // suffix -{status}
+  columnLabel: "kanban-column-label",                // suffix -{status}
+  columnCount: "kanban-column-count",                // suffix -{status}
+  columnAddTask: "kanban-column-add-task",           // suffix -{status}
+  columnEmpty: "kanban-column-empty",                // suffix -{status}
+  columnDropZone: "kanban-column-drop-zone",         // suffix -{status}
+  columnList: "kanban-column-list",                  // suffix -{status} (sortable list)
+
+  // Card
+  card: "kanban-card",                               // suffix -{taskId}
+  cardDragHandle: "kanban-card-drag-handle",         // suffix -{taskId}
+  cardTitle: "kanban-card-title",                    // suffix -{taskId}
+  cardPriorityBadge: "kanban-card-priority",         // suffix -{taskId}
+  cardStatusDot: "kanban-card-status-dot",           // suffix -{taskId}
+  cardDueDate: "kanban-card-due-date",               // suffix -{taskId}
+  cardRefsCount: "kanban-card-refs-count",           // suffix -{taskId}
+  cardCompleteToggle: "kanban-card-complete-toggle", // suffix -{taskId}
+  cardOpenSheet: "kanban-card-open-sheet",           // suffix -{taskId}（與整張卡可點擊區重疊；卡為 button 即可）
+
+  // Drag overlay (DragOverlay portal)
+  dragOverlay: "kanban-drag-overlay",
+  dragOverlayCard: "kanban-drag-overlay-card",
+} as const;
+```
+
+## 命名規則
+
+- prefix 一律 `kanban-`
+- column / card 動態 suffix：column 用 `status`、card 用 `taskId`
+- DragOverlay 是 `@dnd-kit` 的 portal，獨立 testid 方便 QA 驗證拖移態
+- 鍵盤拖移時的狀態播報區塊：`kanban-board-live-region`，內含繁中描述（如「任務「設計 schema」已從 待辦 移動到 進行中 第 2 個位置」）

--- a/design/components/projects/README.md
+++ b/design/components/projects/README.md
@@ -1,0 +1,25 @@
+# Projects Components — Sprint 10
+
+對應 issue #126、F-031 / F-032。沿用 Sprint 8 / 9 的 shadcn/ui + Tailwind v4 風格與 design tokens。新增 status / priority 配色見 `design/tokens/projects.json`。
+
+## 元件清單
+
+| 元件 | 檔案 | 用途 |
+|------|------|------|
+| ProjectListCard | `project-list-card.md` | `/projects` 卡片 grid 單張卡片 |
+| ProjectFormDialog | `project-form-dialog.md` | 新增 / 編輯 Project Dialog |
+| ProjectOverviewTab | `project-overview-tab.md` | `/projects/:id` Overview tab 內容 |
+| ProjectStatusTabs | （內含於 list-page mock） | 列表頁 active / paused / done / archived 切換 |
+| DeleteProjectConfirmDialog | （內含於 form-dialog 末尾） | 二次確認刪除（顯示 task 數） |
+
+## testid 規範
+
+統一見 `testids.md`（`PROJECTS_TESTIDS` 常數）。
+
+## 共通
+
+- 元件庫：shadcn/ui（Dialog / Tabs / Button / Badge / Input / Calendar / Popover / DropdownMenu）
+- a11y：對比 ≥ WCAG AA、所有按鈕 `<button>` 並可 Tab、focus ring 統一 `ring-ring`
+- 動畫 150–300ms、尊重 `prefers-reduced-motion`
+- 觸控目標 ≥ 44×44pt
+- color 不單獨傳遞語意：status / priority 必有文字 label + icon

--- a/design/components/projects/README.md
+++ b/design/components/projects/README.md
@@ -10,7 +10,18 @@
 | ProjectFormDialog | `project-form-dialog.md` | 新增 / 編輯 Project Dialog |
 | ProjectOverviewTab | `project-overview-tab.md` | `/projects/:id` Overview tab 內容 |
 | ProjectStatusTabs | （內含於 list-page mock） | 列表頁 active / paused / done / archived 切換 |
-| DeleteProjectConfirmDialog | （內含於 form-dialog 末尾） | 二次確認刪除（顯示 task 數） |
+| DeleteProjectConfirmDialog | `delete-project-confirm-dialog.md` | 二次確認刪除（顯示 task 數 + force=true checkbox） |
+| RefsPicker | `refs-picker.md` | TaskSheet 內 entry/journal/gcal_event 三 tab refs 選擇器（含「來源已刪除」標記態） |
+| UpcomingTasksWidget | `upcoming-tasks-widget.md` | Sidebar 底部「近期 tasks」widget（`/tasks/upcoming?days=7`，最多 5 筆，過期紅標） |
+
+## 頁面靜態 mock
+
+`design/pages/projects/` 目錄下提供 4 份 HTML mock，所有 testid 與 `testids.md` 一致：
+
+- `projects-list.html`
+- `project-detail-board.html`
+- `project-detail-list.html`
+- `project-detail-overview.html`
 
 ## testid 規範
 

--- a/design/components/projects/delete-project-confirm-dialog.md
+++ b/design/components/projects/delete-project-confirm-dialog.md
@@ -1,0 +1,336 @@
+# DeleteProjectConfirmDialog
+
+刪除專案的二次確認 Dialog。當該專案下有 task 時，必須勾選「強制刪除」checkbox 才能送出，並於 API 加上 `?force=true`。
+
+對齊 spec：
+- F-031 API：`DELETE /api/v1/projects/:id` → 204；有 tasks 時拒絕（409 PROJECT_HAS_TASKS），須加 `?force=true` 才會 cascade 刪除
+- F-032 Edge Case：「刪除有 task 的專案」流程
+
+> 此檔取代 `project-form-dialog.md` 末尾原本的 DeleteProjectConfirmDialog 附錄；保留向後相容指引：舊 `PROJECTS_TESTIDS.deleteDialog*` 仍維持，新增 `forceCheckbox` 與 `taskWarning`。
+
+---
+
+## 用途
+
+兩種觸發路徑：
+
+1. **直接刪除（task 數已知）**：parent 在開啟 Dialog 前已從 `project.open_task_count + project.done_task_count` 等推得 `task_count`，直接傳入 props
+2. **回應 409 後再開啟**：parent 先嘗試 `DELETE /api/v1/projects/:id`，若回 409 PROJECT_HAS_TASKS（response 帶 `task_count`）→ 開 Dialog
+
+兩種情況皆可用相同元件，差別只在初始 `task_count` 來源。
+
+---
+
+## 結構
+
+### Case A：task_count = 0
+
+```
+┌───────────────────────────────────────────────┐
+│ 刪除專案「aibo v2」？                          │
+├───────────────────────────────────────────────┤
+│ 此操作無法復原。                                │
+├───────────────────────────────────────────────┤
+│                  [ 取消 ]    [ 確認刪除 ]      │
+└───────────────────────────────────────────────┘
+```
+
+### Case B：task_count > 0
+
+```
+┌───────────────────────────────────────────────┐
+│ 刪除專案「aibo v2」？                          │
+├───────────────────────────────────────────────┤
+│ ⚠ 警告                                         │
+│ 此專案下有 12 筆任務，刪除將一併移除這些任務     │
+│ 與其關聯資料，且無法復原。                      │
+│                                               │
+│ ☐ 我了解風險，仍要強制刪除（force=true）        │
+│                                               │
+├───────────────────────────────────────────────┤
+│                  [ 取消 ]    [ 確認刪除 ]      │  ← 「確認刪除」按鈕在勾選前 disabled
+└───────────────────────────────────────────────┘
+```
+
+---
+
+## Props
+
+```ts
+interface DeleteProjectConfirmDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  project: {
+    id: string;
+    name: string;
+  };
+  /**
+   * 該專案下的 task 總數（含 done / cancelled）。
+   * 來源優先：
+   * 1. parent 已知（projectDetail.stats.total）
+   * 2. 第一次嘗試 DELETE 後 409 response.task_count
+   * undefined 表示尚未取得 → Dialog 內顯示 loading state
+   */
+  taskCount: number | undefined;
+
+  /**
+   * Parent 處理刪除：
+   * - taskCount === 0 → force 為 false
+   * - taskCount > 0 → 必勾 forceCheckbox 才會呼叫且 force 為 true
+   */
+  onConfirm: (force: boolean) => Promise<{ ok: true } | { ok: false; message: string }>;
+}
+```
+
+---
+
+## Tailwind / 範例
+
+```tsx
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
+import { Checkbox } from "@/components/ui/checkbox";
+import { Label } from "@/components/ui/label";
+import { Skeleton } from "@/components/ui/skeleton";
+import { AlertTriangleIcon } from "lucide-react";
+import { useState } from "react";
+import { cn } from "@/lib/utils";
+import { PROJECTS_TESTIDS } from "@/lib/testids/projects";
+
+export function DeleteProjectConfirmDialog({
+  open, onOpenChange, project, taskCount, onConfirm,
+}: DeleteProjectConfirmDialogProps) {
+  const [force, setForce] = useState(false);
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const hasTasks = taskCount !== undefined && taskCount > 0;
+  const isLoadingCount = taskCount === undefined;
+  const canSubmit = !isLoadingCount && (!hasTasks || force) && !submitting;
+
+  const handleConfirm = async () => {
+    setSubmitting(true);
+    setError(null);
+    const res = await onConfirm(hasTasks);   // hasTasks → force=true
+    setSubmitting(false);
+    if (res.ok) {
+      onOpenChange(false);
+      setForce(false);
+    } else {
+      setError(res.message);
+    }
+  };
+
+  return (
+    <AlertDialog open={open} onOpenChange={onOpenChange}>
+      <AlertDialogContent
+        data-testid={PROJECTS_TESTIDS.deleteDialog}
+        className="sm:max-w-md"
+      >
+        <AlertDialogHeader>
+          <AlertDialogTitle data-testid={PROJECTS_TESTIDS.deleteDialogTitle}>
+            刪除專案「{project.name}」？
+          </AlertDialogTitle>
+          <AlertDialogDescription asChild>
+            <div className="space-y-3">
+              {isLoadingCount ? (
+                <Skeleton className="h-4 w-full" />
+              ) : hasTasks ? (
+                <div
+                  data-testid={PROJECTS_TESTIDS.deleteDialogTaskWarning}
+                  className="flex gap-2 rounded-md border border-destructive/30 bg-destructive/5 p-3 text-sm text-destructive"
+                >
+                  <AlertTriangleIcon
+                    className="mt-0.5 h-4 w-4 shrink-0"
+                    aria-hidden="true"
+                  />
+                  <p>
+                    此專案下有
+                    <span
+                      data-testid={PROJECTS_TESTIDS.deleteDialogTaskCount}
+                      className="mx-1 font-semibold tabular-nums"
+                    >
+                      {taskCount}
+                    </span>
+                    筆任務，刪除將一併移除這些任務與其關聯資料，且無法復原。
+                  </p>
+                </div>
+              ) : (
+                <p className="text-sm text-muted-foreground">此操作無法復原。</p>
+              )}
+
+              {hasTasks && (
+                <label
+                  className={cn(
+                    "flex cursor-pointer items-start gap-2 rounded-md border p-3 text-sm",
+                    force ? "border-destructive bg-destructive/5" : "border-border",
+                  )}
+                >
+                  <Checkbox
+                    checked={force}
+                    onCheckedChange={(v) => setForce(v === true)}
+                    data-testid={PROJECTS_TESTIDS.deleteDialogForceCheckbox}
+                    aria-describedby="delete-project-force-hint"
+                    className="mt-0.5"
+                  />
+                  <span className="leading-snug">
+                    我了解風險，仍要強制刪除
+                    <code
+                      id="delete-project-force-hint"
+                      className="ml-1 rounded bg-muted px-1 text-[11px] font-mono"
+                    >
+                      force=true
+                    </code>
+                  </span>
+                </label>
+              )}
+
+              {error && (
+                <p
+                  data-testid={PROJECTS_TESTIDS.deleteDialogError}
+                  role="alert"
+                  className="text-sm text-destructive"
+                >
+                  {error}
+                </p>
+              )}
+            </div>
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+
+        <AlertDialogFooter>
+          <AlertDialogCancel
+            data-testid={PROJECTS_TESTIDS.deleteDialogCancel}
+            disabled={submitting}
+          >
+            取消
+          </AlertDialogCancel>
+          <AlertDialogAction
+            onClick={handleConfirm}
+            disabled={!canSubmit}
+            data-testid={PROJECTS_TESTIDS.deleteDialogConfirm}
+            className="bg-destructive text-destructive-foreground hover:bg-destructive/90 disabled:opacity-50"
+          >
+            {submitting ? "刪除中…" : "確認刪除"}
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+}
+```
+
+---
+
+## Behavior
+
+| 互動 | 行為 |
+|------|------|
+| Open，taskCount=0 | 顯示簡短文案，confirm 按鈕直接可按 |
+| Open，taskCount>0 | 顯示 destructive 警告框 + force checkbox；confirm disabled，直到勾選 |
+| Open，taskCount=undefined | 顯示 Skeleton；confirm disabled |
+| 勾選 force | confirm 按鈕啟用；checkbox 容器 `border-destructive bg-destructive/5` |
+| 點 confirm（無 task） | `onConfirm(false)` → `DELETE /api/v1/projects/:id` |
+| 點 confirm（有 task + 勾選） | `onConfirm(true)` → `DELETE /api/v1/projects/:id?force=true` |
+| 失敗 | 顯示 `error` 紅字，dialog 不關閉，可重試 |
+| 成功 | 關閉 dialog（onOpenChange(false)），parent 處理 navigate + toast |
+| Esc / 背景 | shadcn AlertDialog 預設 **不可** 點背景關閉（modal）；Esc 仍關閉 |
+
+---
+
+## States
+
+| 狀態 | 視覺 |
+|------|------|
+| Loading task count | Skeleton 替代描述 |
+| Safe（無 task） | muted 文字「此操作無法復原。」 |
+| Dangerous（有 task） | destructive 警告框 + force checkbox |
+| Force unchecked | confirm 按鈕 disabled，opacity-50 |
+| Force checked | checkbox 容器 destructive 邊框 + 淡底；confirm 按鈕啟用 |
+| Submitting | 按鈕「刪除中…」，cancel disabled |
+| Error | error 訊息顯示在 footer 上方 |
+
+---
+
+## data-testid
+
+| 元素 | testid |
+|------|--------|
+| Dialog root | `PROJECTS_TESTIDS.deleteDialog` |
+| Title | `PROJECTS_TESTIDS.deleteDialogTitle` |
+| Task warning box | `PROJECTS_TESTIDS.deleteDialogTaskWarning` |
+| Task count number | `PROJECTS_TESTIDS.deleteDialogTaskCount` |
+| Force checkbox | `PROJECTS_TESTIDS.deleteDialogForceCheckbox` |
+| Cancel button | `PROJECTS_TESTIDS.deleteDialogCancel` |
+| Confirm button | `PROJECTS_TESTIDS.deleteDialogConfirm` |
+| Error msg | `PROJECTS_TESTIDS.deleteDialogError` |
+
+需新增至 `design/components/projects/testids.md`（在既有 deleteDialog* 後追加）：
+
+```ts
+deleteDialogTitle: "project-delete-dialog-title",
+deleteDialogTaskWarning: "project-delete-dialog-task-warning",
+deleteDialogForceCheckbox: "project-delete-dialog-force-checkbox",
+deleteDialogError: "project-delete-dialog-error",
+```
+
+---
+
+## a11y
+
+- AlertDialog 比 Dialog 更語意化（`role="alertdialog"`），用於破壞性操作確認
+- Title `<AlertDialogTitle>` 自動 `aria-labelledby`
+- Description `<AlertDialogDescription>` 自動 `aria-describedby`
+- Checkbox 與其 `<label>` 透過 `htmlFor` / 包裹形式連結
+- Force checkbox 有 `aria-describedby="delete-project-force-hint"`，提示中包含 `force=true` 技術詞
+- 警告以三重表達：`AlertTriangleIcon` + 「警告」語句 + destructive 色
+- Confirm 按鈕 disabled 時 `aria-disabled="true"`（shadcn 內建）
+- Reduced motion：AlertDialog 開合動畫尊重系統設定（shadcn 內建）
+- 對比：destructive / destructive-foreground 既有 token 已驗證 ≥ 4.5:1
+
+---
+
+## 整合流程（parent 範例）
+
+```tsx
+const [deleteOpen, setDeleteOpen] = useState(false);
+const [taskCount, setTaskCount] = useState<number | undefined>(undefined);
+
+const handleDeleteClick = async () => {
+  // 路徑 A：已知 taskCount
+  if (project.stats?.total !== undefined) {
+    setTaskCount(project.stats.total);
+    setDeleteOpen(true);
+    return;
+  }
+  // 路徑 B：先試打 → 409
+  setDeleteOpen(true);
+  setTaskCount(undefined);
+  const res = await api.deleteProject(project.id, false);
+  if (res.ok) { router.push("/projects"); toast.success("已刪除"); setDeleteOpen(false); return; }
+  if (res.code === "PROJECT_HAS_TASKS") setTaskCount(res.task_count);
+};
+
+const handleConfirm = async (force: boolean) => {
+  const res = await api.deleteProject(project.id, force);
+  if (!res.ok) return { ok: false as const, message: res.message };
+  router.push("/projects"); toast.success("已刪除");
+  return { ok: true as const };
+};
+
+<DeleteProjectConfirmDialog
+  open={deleteOpen}
+  onOpenChange={setDeleteOpen}
+  project={project}
+  taskCount={taskCount}
+  onConfirm={handleConfirm}
+/>
+```

--- a/design/components/projects/project-form-dialog.md
+++ b/design/components/projects/project-form-dialog.md
@@ -1,0 +1,328 @@
+# ProjectFormDialog
+
+新增 / 編輯 Project 的 Dialog，與 DeleteProjectConfirmDialog 一同使用。
+
+---
+
+## 用途
+
+- `mode="create"`：列表頁右上「新增專案」按鈕觸發
+- `mode="edit"`：卡片動作選單「編輯」/ 詳情頁 header「編輯」按鈕觸發
+- 提交成功後 parent 處理 navigate（建立後跳到 `/projects/:id` Board tab）
+
+---
+
+## 結構
+
+```
+┌─────────────────────────────────────────────┐
+│ 新增專案 / 編輯專案                    [✕]  │
+├─────────────────────────────────────────────┤
+│ 名稱 *                                       │
+│ [aibo v2                              ]      │
+│ × 名稱已存在                                  │  ← 409 錯誤態
+│                                             │
+│ 描述                                         │
+│ ┌─────────────────────────────────────────┐ │
+│ │ 知識庫 + LLM 代理人格                     │ │
+│ └─────────────────────────────────────────┘ │
+│                                             │
+│ 顏色                                         │
+│ [●][●][●][●][●][●][●][●][●][●][●][●]      │  ← 12 色 swatch + 自訂 hex
+│                                             │
+│ 起始日       結束日                          │
+│ [2026-04-01] [2026-06-30]                   │
+│ × 結束日不可早於起始日                        │
+│                                             │
+│ 狀態（編輯模式才顯示）                         │
+│ [進行中 ▾]                                   │
+├─────────────────────────────────────────────┤
+│                       [ 取消 ]  [ 儲存 ]     │
+└─────────────────────────────────────────────┘
+```
+
+---
+
+## Props
+
+```ts
+interface ProjectFormDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  mode: "create" | "edit";
+  initial?: {
+    id?: string;
+    name?: string;
+    description?: string | null;
+    color?: string;
+    start_date?: string | null;
+    end_date?: string | null;
+    status?: ProjectStatus;
+  };
+  onSubmit: (input: ProjectFormInput) => Promise<{ ok: true } | { ok: false; code: string; message: string }>;
+}
+```
+
+`onSubmit` 由 parent 串 API；error code 對應：
+- `PROJECT_NAME_DUPLICATE` → 顯示在 name 欄位下方
+- `INVALID_INPUT` → 依 detail 顯示在對應欄位
+- 其他 → 上方 banner
+
+---
+
+## Tailwind / 範例（核心結構）
+
+```tsx
+import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogFooter } from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
+import { Button } from "@/components/ui/button";
+import { Label } from "@/components/ui/label";
+import { DatePicker } from "@/components/ui/date-picker";
+import { Select, SelectTrigger, SelectValue, SelectContent, SelectItem } from "@/components/ui/select";
+import { cn } from "@/lib/utils";
+import { PROJECTS_TESTIDS } from "@/lib/testids/projects";
+import projectsTokens from "@/../design/tokens/projects.json";
+
+const PALETTE = projectsTokens["project-color-palette"];
+
+<Dialog open={open} onOpenChange={onOpenChange}>
+  <DialogContent
+    data-testid={PROJECTS_TESTIDS.dialog}
+    className="sm:max-w-md"
+  >
+    <DialogHeader>
+      <DialogTitle data-testid={PROJECTS_TESTIDS.dialogTitle}>
+        {mode === "create" ? "新增專案" : "編輯專案"}
+      </DialogTitle>
+    </DialogHeader>
+
+    <form className="space-y-4" onSubmit={handleSubmit}>
+      {/* 名稱 */}
+      <div className="space-y-1.5">
+        <Label htmlFor="project-name">
+          名稱 <span className="text-destructive">*</span>
+        </Label>
+        <Input
+          id="project-name"
+          data-testid={PROJECTS_TESTIDS.dialogNameInput}
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          maxLength={80}
+          required
+          aria-invalid={!!nameError}
+          aria-describedby={nameError ? "project-name-error" : undefined}
+          className={cn(nameError && "border-destructive focus-visible:ring-destructive")}
+        />
+        {nameError && (
+          <p
+            id="project-name-error"
+            data-testid={PROJECTS_TESTIDS.dialogNameError}
+            className="text-xs text-destructive"
+          >
+            {nameError}
+          </p>
+        )}
+      </div>
+
+      {/* 描述 */}
+      <div className="space-y-1.5">
+        <Label htmlFor="project-description">描述</Label>
+        <Textarea
+          id="project-description"
+          data-testid={PROJECTS_TESTIDS.dialogDescriptionInput}
+          value={description ?? ""}
+          onChange={(e) => setDescription(e.target.value)}
+          rows={3}
+          maxLength={5000}
+        />
+      </div>
+
+      {/* 顏色 */}
+      <div className="space-y-1.5">
+        <Label>顏色</Label>
+        <div
+          data-testid={PROJECTS_TESTIDS.dialogColorPicker}
+          role="radiogroup"
+          aria-label="專案顏色"
+          className="flex flex-wrap gap-2"
+        >
+          {Object.entries(PALETTE).map(([key, hex]) => (
+            <button
+              key={key}
+              type="button"
+              role="radio"
+              aria-checked={color === hex}
+              aria-label={`顏色 ${key}`}
+              data-testid={`${PROJECTS_TESTIDS.dialogColorSwatch}-${key}`}
+              onClick={() => setColor(hex)}
+              className={cn(
+                "h-7 w-7 rounded-full border-2 transition-transform",
+                "hover:scale-110 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
+                color === hex ? "border-foreground scale-110" : "border-transparent",
+              )}
+              style={{ backgroundColor: hex }}
+            />
+          ))}
+        </div>
+      </div>
+
+      {/* 日期 */}
+      <div className="grid grid-cols-2 gap-3">
+        <div className="space-y-1.5">
+          <Label htmlFor="project-start">起始日</Label>
+          <DatePicker
+            id="project-start"
+            data-testid={PROJECTS_TESTIDS.dialogStartDate}
+            value={startDate}
+            onChange={setStartDate}
+          />
+        </div>
+        <div className="space-y-1.5">
+          <Label htmlFor="project-end">結束日</Label>
+          <DatePicker
+            id="project-end"
+            data-testid={PROJECTS_TESTIDS.dialogEndDate}
+            value={endDate}
+            onChange={setEndDate}
+          />
+        </div>
+      </div>
+      {dateError && (
+        <p
+          data-testid={PROJECTS_TESTIDS.dialogDateError}
+          className="text-xs text-destructive"
+        >
+          {dateError}
+        </p>
+      )}
+
+      {/* 狀態（edit 才顯示） */}
+      {mode === "edit" && (
+        <div className="space-y-1.5">
+          <Label htmlFor="project-status">狀態</Label>
+          <Select value={status} onValueChange={setStatus}>
+            <SelectTrigger
+              id="project-status"
+              data-testid={PROJECTS_TESTIDS.dialogStatusSelect}
+            >
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="active">進行中</SelectItem>
+              <SelectItem value="paused">暫停</SelectItem>
+              <SelectItem value="done">已完成</SelectItem>
+              <SelectItem value="archived">封存</SelectItem>
+            </SelectContent>
+          </Select>
+        </div>
+      )}
+    </form>
+
+    <DialogFooter>
+      <Button
+        variant="outline"
+        onClick={() => onOpenChange(false)}
+        data-testid={PROJECTS_TESTIDS.dialogCancel}
+      >
+        取消
+      </Button>
+      <Button
+        type="submit"
+        onClick={handleSubmit}
+        disabled={isSubmitting || !name.trim()}
+        data-testid={PROJECTS_TESTIDS.dialogSubmit}
+      >
+        {isSubmitting ? "儲存中…" : mode === "create" ? "建立" : "儲存"}
+      </Button>
+    </DialogFooter>
+  </DialogContent>
+</Dialog>
+```
+
+---
+
+## Behavior
+
+| 互動 | 行為 |
+|------|------|
+| 開啟 | autofocus 至 name input |
+| Esc / 點背景 | 關閉（如有 dirty 變更則彈出未儲存確認） |
+| Submit 成功 | parent navigate / refetch list；toast「已建立 / 已更新」 |
+| Submit 409 NAME_DUPLICATE | name 欄位錯誤態，focus 回 name input |
+| Submit 422 INVALID_STATUS_TRANSITION | 上方 banner 顯示訊息 |
+| 名稱為空 | submit 按鈕 disabled |
+| 結束日 < 起始日 | 即時錯誤訊息（不送 API） |
+
+---
+
+## States
+
+| 狀態 | 視覺 |
+|------|------|
+| Default | shadcn Dialog 標準樣式 |
+| 表單錯誤 | 對應欄位邊框 `border-destructive`，下方紅字訊息 |
+| Submitting | submit 按鈕 disabled + 「儲存中…」 |
+| Color 已選 | swatch 加 `border-foreground scale-110` |
+
+---
+
+## a11y
+
+- Dialog 內建 focus trap、Esc 關閉、`role="dialog" aria-modal="true"`（shadcn 內建）
+- 所有 Input / Select / Date 都有 visible `<Label htmlFor>`
+- 錯誤訊息透過 `aria-describedby` + `aria-invalid` 連結
+- color picker 使用 `role="radiogroup"` + 子項 `role="radio"`，每顆有 `aria-label="顏色 blue"` 等繁中標籤
+- 對比 ≥ 4.5:1（destructive、muted-foreground 既有 token）
+- 觸控目標：swatch 雖 28px，但 padding 撐到 ≥ 44px hit area；submit / cancel 預設 ≥ 40px
+
+---
+
+## DeleteProjectConfirmDialog（同檔附錄）
+
+二次確認刪除，依 task 數變化文案。
+
+```tsx
+import { AlertDialog, AlertDialogAction, AlertDialogCancel, AlertDialogContent, AlertDialogDescription, AlertDialogFooter, AlertDialogHeader, AlertDialogTitle } from "@/components/ui/alert-dialog";
+
+<AlertDialog open={deleteOpen} onOpenChange={setDeleteOpen}>
+  <AlertDialogContent data-testid={PROJECTS_TESTIDS.deleteDialog}>
+    <AlertDialogHeader>
+      <AlertDialogTitle>刪除專案「{project.name}」？</AlertDialogTitle>
+      <AlertDialogDescription>
+        {taskCount > 0 ? (
+          <>
+            此專案下有
+            <span data-testid={PROJECTS_TESTIDS.deleteDialogTaskCount} className="font-semibold">
+              {" "}{taskCount}{" "}
+            </span>
+            筆任務，將會一併刪除且無法復原。
+          </>
+        ) : (
+          <>此操作無法復原。</>
+        )}
+      </AlertDialogDescription>
+    </AlertDialogHeader>
+    <AlertDialogFooter>
+      <AlertDialogCancel data-testid={PROJECTS_TESTIDS.deleteDialogCancel}>
+        取消
+      </AlertDialogCancel>
+      <AlertDialogAction
+        onClick={onConfirmDelete}
+        data-testid={PROJECTS_TESTIDS.deleteDialogConfirm}
+        className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+      >
+        確認刪除
+      </AlertDialogAction>
+    </AlertDialogFooter>
+  </AlertDialogContent>
+</AlertDialog>
+```
+
+### 流程
+
+1. 卡片或詳情頁 ⋯ menu 點「刪除」
+2. 先嘗試 `DELETE /api/v1/projects/:id`
+3. 若回 409 PROJECT_HAS_TASKS → 開 AlertDialog，文案帶 task count
+4. 確認 → `DELETE /api/v1/projects/:id?force=true`
+5. 成功 → toast「已刪除」+ navigate 回列表

--- a/design/components/projects/project-list-card.md
+++ b/design/components/projects/project-list-card.md
@@ -1,0 +1,248 @@
+# ProjectListCard
+
+`/projects` 列表頁的單張專案卡片。
+
+---
+
+## 用途
+
+呈現專案核心摘要（color stripe / 名稱 / 描述 / 進度條 / status badge / 未完成 task 數 / 下一個 due date / 動作選單），點擊整張卡片進入 detail。
+
+---
+
+## 結構
+
+```
+┌──────────────────────────────────────────────────────┐
+│ ▌ ← color stripe（左側 4px 直條，project.color）     │
+│ ┌──────────────────────────────────────────────────┐ │
+│ │ aibo v2                          [進行中] ⋯       │ │  ← name + status badge + menu
+│ │ 知識庫 + LLM 代理人格                              │ │  ← description（line-clamp-2）
+│ │ ────────────────────────────  60%                  │ │  ← progress bar + label
+│ │ 12 未完成 · 下一個：4/30 設計 schema  >>           │ │  ← meta footer（task count + next due）
+│ └──────────────────────────────────────────────────┘ │
+└──────────────────────────────────────────────────────┘
+```
+
+Hover：`bg-muted/40` + `shadow-sm`，整張卡 cursor-pointer。
+
+---
+
+## Props
+
+```ts
+interface ProjectListCardProps {
+  project: {
+    id: string;
+    name: string;
+    description: string | null;
+    color: string;                   // hex
+    status: "active" | "paused" | "done" | "archived";
+    progress: number;                // 0..100
+    start_date: string | null;       // YYYY-MM-DD
+    end_date: string | null;
+    open_task_count: number;
+    next_due?: { task_id: string; title: string; due_date: string } | null;
+    updated_at: string;
+  };
+  onClick: () => void;
+  onEdit: () => void;
+  onArchive: () => void;
+  onDelete: () => void;
+}
+```
+
+---
+
+## Tailwind / 範例
+
+```tsx
+import { Badge } from "@/components/ui/badge";
+import { Progress } from "@/components/ui/progress";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { Button } from "@/components/ui/button";
+import { MoreHorizontalIcon, ArchiveIcon, PencilIcon, Trash2Icon, CalendarIcon } from "lucide-react";
+import { cn } from "@/lib/utils";
+import { PROJECTS_TESTIDS } from "@/lib/testids/projects";
+
+const STATUS_LABEL = {
+  active: "進行中",
+  paused: "暫停",
+  done: "已完成",
+  archived: "封存",
+} as const;
+
+const STATUS_CLASS = {
+  active:   "border-green-300 bg-green-100 text-green-900 dark:bg-green-950/40 dark:text-green-200",
+  paused:   "border-amber-300 bg-amber-100 text-amber-900 dark:bg-amber-950/40 dark:text-amber-200",
+  done:     "border-blue-300 bg-blue-100 text-blue-900 dark:bg-blue-950/40 dark:text-blue-200",
+  archived: "border-zinc-300 bg-zinc-100 text-zinc-700 dark:bg-zinc-900/60 dark:text-zinc-300",
+} as const;
+
+<div
+  data-testid={`${PROJECTS_TESTIDS.card}-${project.id}`}
+  className={cn(
+    "group relative flex overflow-hidden rounded-lg border bg-card transition-all",
+    "hover:bg-muted/40 hover:shadow-sm",
+    "focus-within:ring-2 focus-within:ring-ring focus-within:ring-offset-2",
+  )}
+>
+  {/* Color stripe */}
+  <span
+    aria-hidden="true"
+    data-testid={PROJECTS_TESTIDS.cardColorStripe}
+    className="w-1 shrink-0"
+    style={{ backgroundColor: project.color }}
+  />
+
+  {/* Click area */}
+  <button
+    onClick={onClick}
+    aria-label={`開啟專案：${project.name}（${STATUS_LABEL[project.status]}，進度 ${project.progress}%）`}
+    className="flex-1 p-4 text-left focus:outline-none"
+  >
+    {/* Header */}
+    <div className="mb-1 flex items-start gap-2">
+      <h3
+        data-testid={PROJECTS_TESTIDS.cardName}
+        className="line-clamp-1 flex-1 text-base font-semibold leading-snug"
+      >
+        {project.name}
+      </h3>
+      <Badge
+        data-testid={PROJECTS_TESTIDS.cardStatusBadge}
+        className={cn("shrink-0 gap-1 border", STATUS_CLASS[project.status])}
+        aria-label={`狀態：${STATUS_LABEL[project.status]}`}
+      >
+        {STATUS_LABEL[project.status]}
+      </Badge>
+    </div>
+
+    {/* Description */}
+    {project.description && (
+      <p
+        data-testid={PROJECTS_TESTIDS.cardDescription}
+        className="mb-3 line-clamp-2 text-sm text-muted-foreground"
+      >
+        {project.description}
+      </p>
+    )}
+
+    {/* Progress */}
+    <div className="mb-2 flex items-center gap-3">
+      <Progress
+        value={project.progress}
+        className="h-1.5 flex-1"
+        data-testid={PROJECTS_TESTIDS.cardProgressBar}
+        aria-label={`進度 ${project.progress}%`}
+      />
+      <span
+        data-testid={PROJECTS_TESTIDS.cardProgressLabel}
+        className="w-10 shrink-0 text-right text-xs font-medium tabular-nums text-muted-foreground"
+      >
+        {project.progress}%
+      </span>
+    </div>
+
+    {/* Meta footer */}
+    <div className="flex items-center gap-3 text-xs text-muted-foreground">
+      <span data-testid={PROJECTS_TESTIDS.cardOpenTaskCount}>
+        {project.open_task_count} 未完成
+      </span>
+      {project.next_due && (
+        <span
+          data-testid={PROJECTS_TESTIDS.cardNextDue}
+          className="flex items-center gap-1 truncate"
+        >
+          <CalendarIcon className="h-3.5 w-3.5" aria-hidden="true" />
+          下一個：{formatDateZh(project.next_due.due_date)}
+          <span className="ml-1 truncate">{project.next_due.title}</span>
+        </span>
+      )}
+    </div>
+  </button>
+
+  {/* Action menu (絕對定位 overlay；不嵌套於主 button 內以避免 nested button) */}
+  <div className="absolute right-2 top-2 opacity-0 transition-opacity group-hover:opacity-100 focus-within:opacity-100">
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button
+          variant="ghost"
+          size="icon"
+          className="h-8 w-8"
+          data-testid={PROJECTS_TESTIDS.cardMenuTrigger}
+          aria-label={`${project.name} 動作選單`}
+        >
+          <MoreHorizontalIcon className="h-4 w-4" aria-hidden="true" />
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end">
+        <DropdownMenuItem
+          onClick={onEdit}
+          data-testid={PROJECTS_TESTIDS.cardMenuEdit}
+        >
+          <PencilIcon className="mr-2 h-4 w-4" aria-hidden="true" />
+          編輯
+        </DropdownMenuItem>
+        <DropdownMenuItem
+          onClick={onArchive}
+          data-testid={PROJECTS_TESTIDS.cardMenuArchive}
+        >
+          <ArchiveIcon className="mr-2 h-4 w-4" aria-hidden="true" />
+          {project.status === "archived" ? "取消封存" : "封存"}
+        </DropdownMenuItem>
+        <DropdownMenuItem
+          onClick={onDelete}
+          className="text-destructive focus:text-destructive"
+          data-testid={PROJECTS_TESTIDS.cardMenuDelete}
+        >
+          <Trash2Icon className="mr-2 h-4 w-4" aria-hidden="true" />
+          刪除
+        </DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  </div>
+</div>
+```
+
+---
+
+## States
+
+| 狀態 | 視覺 |
+|------|------|
+| Default | `bg-card border-border` |
+| Hover | `bg-muted/40 shadow-sm`，menu trigger 顯現 |
+| Focus-within | `ring-2 ring-ring ring-offset-2` |
+| archived | 整體 `opacity-70`、color stripe 仍顯示但 saturate-50 |
+| 無描述 | description 區塊不渲染 |
+| 無 next_due | meta footer 只顯示 open_task_count |
+| open_task_count = 0 | 仍顯示「0 未完成」（不省略，避免誤判） |
+
+---
+
+## Behavior
+
+| 互動 | 行為 |
+|------|------|
+| 點擊主區 | router.push(`/projects/${id}`)（Board tab 為預設） |
+| Enter / Space | 同點擊 |
+| 右上 ⋯ menu | 編輯 / 封存 / 刪除（刪除走二次確認） |
+| Hover | menu trigger 顯現（鍵盤 focus 也會顯現） |
+
+---
+
+## a11y
+
+- 整張卡 click area 為 `<button>`，可鍵盤 Tab 並有焦點環
+- color stripe 為純裝飾，`aria-hidden="true"`
+- status 永遠以「文字 + 顏色」雙重表達，不單靠顏色
+- 進度條：`<Progress>` 內建 `role="progressbar"` + `aria-valuenow`
+- 動作 menu：focus / Tab 可進入；Esc 關閉
+- 對比：所有 status badge 配色已通過 4.5:1（見 `design/tokens/projects.json`）
+- `prefers-reduced-motion`：移除 hover transition

--- a/design/components/projects/project-overview-tab.md
+++ b/design/components/projects/project-overview-tab.md
@@ -1,0 +1,262 @@
+# ProjectOverviewTab
+
+`/projects/:id` 詳情頁的 Overview tab 內容：description、時程、整體進度、stats、最近活動。
+
+---
+
+## 用途
+
+讓使用者在不切到 Board / List 的情況下，快速理解專案輪廓與進度。
+
+---
+
+## 結構
+
+```
+┌──────────────────────────────────────────────────────┐
+│ 進度                                                   │
+│ ─────────────────────────────────────────────  60%    │  ← 大號 progress bar + label
+│ 12 / 20 完成                                           │
+├──────────────────────────────────────────────────────┤
+│ ┌─────────┐ ┌─────────┐ ┌─────────┐ ┌─────────┐      │
+│ │ 全部    │ │ 完成    │ │ 卡住    │ │ 逾期    │      │
+│ │ 20      │ │ 12      │ │ 1       │ │ 3       │      │  ← 4 個 Stat Cards
+│ └─────────┘ └─────────┘ └─────────┘ └─────────┘      │
+├──────────────────────────────────────────────────────┤
+│ 時程                                                   │
+│ 📅 2026-04-01 → 2026-06-30（剩 67 天）                │
+├──────────────────────────────────────────────────────┤
+│ 描述                                                   │
+│ ┌──────────────────────────────────────────────────┐ │
+│ │ 知識庫 + LLM 代理人格                              │ │  ← markdown / 純文字
+│ └──────────────────────────────────────────────────┘ │
+├──────────────────────────────────────────────────────┤
+│ 最近活動                                               │
+│ • 2 小時前  完成「設計 schema」                         │
+│ • 昨天      新增「資料庫 migration」                    │
+│ • 3 天前    建立此專案                                  │
+└──────────────────────────────────────────────────────┘
+```
+
+---
+
+## Props
+
+```ts
+interface ProjectOverviewTabProps {
+  project: {
+    id: string;
+    name: string;
+    description: string | null;
+    color: string;
+    status: ProjectStatus;
+    progress: number;
+    start_date: string | null;
+    end_date: string | null;
+    task_counts: {
+      total: number;
+      by_status: Record<TaskStatus, number>;
+      overdue: number;
+    };
+    created_at: string;
+    updated_at: string;
+  };
+  recentActivity: Array<{
+    id: string;
+    type: "task_created" | "task_completed" | "task_status_changed" | "project_created" | "project_updated";
+    label: string;        // 已格式化的繁中描述
+    at: string;           // ISO
+    task_id?: string;
+  }>;
+}
+```
+
+---
+
+## Tailwind / 範例
+
+```tsx
+import { Progress } from "@/components/ui/progress";
+import { Card, CardContent } from "@/components/ui/card";
+import { CalendarIcon, ListTodoIcon, CheckCircle2Icon, AlertOctagonIcon, ClockAlertIcon } from "lucide-react";
+import { MarkdownViewer } from "@/components/markdown-viewer";
+import { cn } from "@/lib/utils";
+import { PROJECTS_TESTIDS } from "@/lib/testids/projects";
+
+<div data-testid={PROJECTS_TESTIDS.detailTabOverview} className="space-y-6 py-4">
+  {/* Progress block */}
+  <section
+    data-testid={PROJECTS_TESTIDS.overviewProgress}
+    aria-label="專案整體進度"
+  >
+    <div className="mb-2 flex items-baseline justify-between">
+      <h2 className="text-sm font-medium text-muted-foreground">進度</h2>
+      <span className="text-2xl font-semibold tabular-nums">
+        {project.progress}%
+      </span>
+    </div>
+    <Progress
+      value={project.progress}
+      className="h-2.5"
+      data-testid={PROJECTS_TESTIDS.overviewProgressBar}
+      aria-label={`進度 ${project.progress}%`}
+    />
+    <p className="mt-1.5 text-xs text-muted-foreground tabular-nums">
+      {project.task_counts.by_status.done ?? 0} / {project.task_counts.total} 完成
+    </p>
+  </section>
+
+  {/* Stats grid */}
+  <section
+    data-testid={PROJECTS_TESTIDS.overviewStats}
+    className="grid grid-cols-2 gap-3 sm:grid-cols-4"
+  >
+    <StatCard
+      testid={PROJECTS_TESTIDS.overviewStatTotal}
+      icon={<ListTodoIcon className="h-4 w-4" aria-hidden="true" />}
+      label="全部"
+      value={project.task_counts.total}
+    />
+    <StatCard
+      testid={PROJECTS_TESTIDS.overviewStatDone}
+      icon={<CheckCircle2Icon className="h-4 w-4 text-green-700 dark:text-green-300" aria-hidden="true" />}
+      label="完成"
+      value={project.task_counts.by_status.done ?? 0}
+    />
+    <StatCard
+      testid={PROJECTS_TESTIDS.overviewStatBlocked}
+      icon={<AlertOctagonIcon className="h-4 w-4 text-red-700 dark:text-red-300" aria-hidden="true" />}
+      label="卡住"
+      value={project.task_counts.by_status.blocked ?? 0}
+    />
+    <StatCard
+      testid={PROJECTS_TESTIDS.overviewStatOverdue}
+      icon={<ClockAlertIcon className="h-4 w-4 text-orange-700 dark:text-orange-300" aria-hidden="true" />}
+      label="逾期"
+      value={project.task_counts.overdue}
+      highlight={project.task_counts.overdue > 0}
+    />
+  </section>
+
+  {/* Timeline */}
+  <section
+    data-testid={PROJECTS_TESTIDS.overviewTimeline}
+    aria-label="專案時程"
+  >
+    <h2 className="mb-2 text-sm font-medium text-muted-foreground">時程</h2>
+    <p className="flex items-center gap-2 text-sm">
+      <CalendarIcon className="h-4 w-4 text-muted-foreground" aria-hidden="true" />
+      {project.start_date ? formatDateZh(project.start_date) : "未設定"}
+      <span className="text-muted-foreground">→</span>
+      {project.end_date ? formatDateZh(project.end_date) : "未設定"}
+      {project.end_date && (
+        <span className="text-xs text-muted-foreground">
+          （{daysRemainingZh(project.end_date)}）
+        </span>
+      )}
+    </p>
+  </section>
+
+  {/* Description */}
+  {project.description && (
+    <section
+      data-testid={PROJECTS_TESTIDS.overviewDescription}
+      aria-label="專案描述"
+    >
+      <h2 className="mb-2 text-sm font-medium text-muted-foreground">描述</h2>
+      <article className="prose prose-sm dark:prose-invert max-w-none rounded-md border bg-card p-4">
+        <MarkdownViewer source={project.description} />
+      </article>
+    </section>
+  )}
+
+  {/* Recent activity */}
+  <section
+    data-testid={PROJECTS_TESTIDS.overviewActivity}
+    aria-label="最近活動"
+  >
+    <h2 className="mb-2 text-sm font-medium text-muted-foreground">最近活動</h2>
+    {recentActivity.length === 0 ? (
+      <p className="text-sm italic text-muted-foreground">尚無活動</p>
+    ) : (
+      <ol className="space-y-2">
+        {recentActivity.slice(0, 8).map((a, i) => (
+          <li
+            key={a.id}
+            data-testid={`${PROJECTS_TESTIDS.overviewActivityItem}-${i}`}
+            className="flex items-start gap-3 text-sm"
+          >
+            <span
+              aria-hidden="true"
+              className="mt-1.5 inline-block h-1.5 w-1.5 shrink-0 rounded-full bg-muted-foreground"
+            />
+            <div className="flex-1">
+              <span className="text-muted-foreground tabular-nums">
+                {formatRelativeZh(a.at)}
+              </span>
+              <span className="mx-2 text-muted-foreground/60">·</span>
+              <span>{a.label}</span>
+            </div>
+          </li>
+        ))}
+      </ol>
+    )}
+  </section>
+</div>
+```
+
+`StatCard` 是內部小元件：
+
+```tsx
+function StatCard({ testid, icon, label, value, highlight }: {
+  testid: string; icon: React.ReactNode; label: string; value: number; highlight?: boolean;
+}) {
+  return (
+    <Card
+      data-testid={testid}
+      className={cn(
+        "transition-colors",
+        highlight && "border-orange-300 bg-orange-50/60 dark:border-orange-900/60 dark:bg-orange-950/20",
+      )}
+    >
+      <CardContent className="flex flex-col gap-1 p-3">
+        <span className="flex items-center gap-1.5 text-xs text-muted-foreground">
+          {icon}
+          {label}
+        </span>
+        <span className="text-2xl font-semibold tabular-nums">{value}</span>
+      </CardContent>
+    </Card>
+  );
+}
+```
+
+---
+
+## States
+
+| 狀態 | 視覺 |
+|------|------|
+| total = 0 | progress 顯示 0%、stat 全部 0、無「最近活動」→ 顯示「尚無活動」 |
+| overdue > 0 | stat 卡橘色背景 + 邊框 |
+| 無 description | 不渲染描述 section |
+| 無 start/end date | 顯示「未設定」灰字 |
+
+---
+
+## Behavior
+
+| 互動 | 行為 |
+|------|------|
+| 點擊 activity item（task_*） | 開啟對應 TaskSheet（parent 處理） |
+| 點擊「描述」中的連結 | new tab 開啟（MarkdownViewer 處理） |
+
+---
+
+## a11y
+
+- 每個 section 有 `aria-label`
+- progress 用 shadcn `<Progress>` 內建 `role="progressbar"` + `aria-valuenow`
+- 圖示 `aria-hidden="true"`，文字 label 提供語意
+- stats 卡顏色強調僅輔助；數字 + 文字提供主要資訊
+- 對比通過 4.5:1（重點色階皆來自 `design/tokens/projects.json`）

--- a/design/components/projects/refs-picker.md
+++ b/design/components/projects/refs-picker.md
@@ -1,0 +1,387 @@
+# RefsPicker
+
+Task Sheet 內「關聯項目」選擇器。支援 Entry / Journal / Gcal Event 三種來源切換、搜尋、選取，已選項目以 chip 形式列在下方；當來源已被刪除時以「來源已刪除」標記態呈現。
+
+對齊 spec：F-032c（Task Sheet refs picker）、F-031（task_refs schema：ref_type ∈ entry|journal|gcal_event, ref_id）。
+
+---
+
+## 用途
+
+- 在 TaskSheet 中觸發「+ 新增關聯」時開啟 Popover / 內嵌 panel
+- 使用者可以：
+  1. 切換 tab（Entry / Journal / Gcal）
+  2. 輸入關鍵字 → debounce 300ms 呼叫對應搜尋 API
+  3. 從結果列表點選 → 加入「已選 chips」
+  4. 點 chip 上的 ✕ 移除
+  5. 點 chip 主體跳轉到原始來源（在新分頁）
+- 提交時將整個 `refs[]` 隨 PATCH /api/v1/tasks/:id 一併送出
+
+---
+
+## 結構
+
+```
+┌──────────────── RefsPicker ────────────────────┐
+│ [📄 Entry] [📔 Journal] [📅 Gcal]              │  ← Tabs（3 個 ref_type）
+│ ┌────────────────────────────────────────────┐ │
+│ │ 🔍 搜尋 entry…                              │ │  ← Search input（debounce 300ms）
+│ └────────────────────────────────────────────┘ │
+│ ┌────────────────────────────────────────────┐ │
+│ │ 📄 今天學會的 pytest fixture 技巧            │ │
+│ │   2026-04-23 · #engineering                 │ │  ← 結果列表（最多顯示 8 筆）
+│ │ 📄 讀: Atomic Habits 心得                    │ │
+│ │ 📄 設計 schema 想法                          │ │
+│ └────────────────────────────────────────────┘ │
+│ ─────────────────────────────────────────────── │
+│ 已選（3）                                        │
+│ ┌─ chip ─┐ ┌─ chip ─┐ ┌─ chip（缺漏） ────────┐ │
+│ │📄 entry│ │📔 04-23│ │📅 (來源已刪除) ✕      │ │
+│ │ ✕      │ │ ✕      │ │                       │ │
+│ └────────┘ └────────┘ └───────────────────────┘ │
+└─────────────────────────────────────────────────┘
+```
+
+---
+
+## Props
+
+```ts
+type RefType = "entry" | "journal" | "gcal_event";
+
+interface RefItem {
+  ref_type: RefType;
+  ref_id: string;
+  /** 顯示用（API 取得後快取於 ref；若 missing 表示來源已刪除） */
+  display?: {
+    title: string | null;
+    subtitle?: string | null;   // e.g. 日期、tag
+    href?: string;              // 點 chip 主體可跳轉
+  } | null;
+}
+
+interface RefsPickerProps {
+  value: RefItem[];                              // 已選 refs（受控）
+  onChange: (next: RefItem[]) => void;
+  /** 由 parent 注入，封裝對應 search API 呼叫 */
+  search: (type: RefType, q: string) => Promise<RefSearchResult[]>;
+  /** 是否可新增；達上限後 input + 列表 disabled（spec 上限 50） */
+  max?: number;
+  disabled?: boolean;
+}
+
+interface RefSearchResult {
+  ref_type: RefType;
+  ref_id: string;
+  title: string | null;
+  subtitle?: string | null;
+  href?: string;
+}
+```
+
+> 註：`value` 中若某筆 `display === null`（後端回傳 `ref_resolved=false`）則 chip 顯示「來源已刪除」標記態，整個 chip 變灰並僅可移除，不可點開。
+
+---
+
+## Tailwind / 範例（核心結構）
+
+```tsx
+import { Tabs, TabsList, TabsTrigger, TabsContent } from "@/components/ui/tabs";
+import { Input } from "@/components/ui/input";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Skeleton } from "@/components/ui/skeleton";
+import { FileTextIcon, BookTextIcon, CalendarIcon, SearchIcon, XIcon, AlertTriangleIcon, ExternalLinkIcon } from "lucide-react";
+import { cn } from "@/lib/utils";
+import { PROJECTS_TESTIDS } from "@/lib/testids/projects";
+
+const TYPE_META: Record<RefType, { label: string; icon: any }> = {
+  entry:       { label: "Entry",   icon: FileTextIcon },
+  journal:     { label: "Journal", icon: BookTextIcon },
+  gcal_event:  { label: "Gcal",    icon: CalendarIcon },
+};
+
+<div
+  data-testid={PROJECTS_TESTIDS.refsPicker}
+  className="rounded-md border bg-card p-3 space-y-3"
+  aria-label="關聯項目選擇器"
+>
+  <Tabs value={activeType} onValueChange={(v) => setActiveType(v as RefType)}>
+    <TabsList
+      data-testid={PROJECTS_TESTIDS.refsPickerTabs}
+      className="grid w-full grid-cols-3"
+    >
+      {(Object.keys(TYPE_META) as RefType[]).map((t) => {
+        const Icon = TYPE_META[t].icon;
+        return (
+          <TabsTrigger
+            key={t}
+            value={t}
+            data-testid={`${PROJECTS_TESTIDS.refsPickerTab}-${t}`}
+            className="gap-1.5"
+          >
+            <Icon className="h-3.5 w-3.5" aria-hidden="true" />
+            {TYPE_META[t].label}
+          </TabsTrigger>
+        );
+      })}
+    </TabsList>
+
+    {(Object.keys(TYPE_META) as RefType[]).map((t) => (
+      <TabsContent key={t} value={t} className="mt-3 space-y-2">
+        {/* Search input */}
+        <div className="relative">
+          <SearchIcon
+            className="pointer-events-none absolute left-2.5 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground"
+            aria-hidden="true"
+          />
+          <Input
+            data-testid={PROJECTS_TESTIDS.refsPickerSearch}
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            placeholder={`搜尋 ${TYPE_META[t].label}…`}
+            aria-label={`搜尋 ${TYPE_META[t].label}`}
+            className="pl-8"
+            disabled={disabled || atMax}
+          />
+        </div>
+
+        {/* Result list */}
+        <ul
+          data-testid={PROJECTS_TESTIDS.refsPickerResults}
+          role="listbox"
+          aria-label={`${TYPE_META[t].label} 搜尋結果`}
+          className="max-h-64 space-y-1 overflow-auto rounded-md border bg-background p-1"
+        >
+          {isSearching ? (
+            <>
+              <Skeleton className="h-9 w-full" />
+              <Skeleton className="h-9 w-full" />
+              <Skeleton className="h-9 w-full" />
+            </>
+          ) : results.length === 0 ? (
+            <li
+              data-testid={PROJECTS_TESTIDS.refsPickerEmpty}
+              className="py-6 text-center text-xs text-muted-foreground"
+            >
+              {query ? "沒有符合的結果" : `輸入關鍵字搜尋 ${TYPE_META[t].label}`}
+            </li>
+          ) : (
+            results.map((r) => {
+              const selected = isSelected(r);
+              return (
+                <li key={r.ref_id}>
+                  <button
+                    type="button"
+                    role="option"
+                    aria-selected={selected}
+                    disabled={selected || atMax}
+                    onClick={() => addRef(r)}
+                    data-testid={`${PROJECTS_TESTIDS.refsPickerResultItem}-${r.ref_id}`}
+                    className={cn(
+                      "flex w-full items-start gap-2 rounded px-2 py-1.5 text-left text-sm",
+                      "hover:bg-muted focus-visible:bg-muted focus-visible:outline-none",
+                      "focus-visible:ring-2 focus-visible:ring-ring",
+                      "disabled:opacity-50 disabled:cursor-not-allowed",
+                    )}
+                  >
+                    {(() => { const Icon = TYPE_META[t].icon; return <Icon className="mt-0.5 h-3.5 w-3.5 shrink-0 text-muted-foreground" aria-hidden="true" />; })()}
+                    <span className="min-w-0 flex-1">
+                      <span className="block truncate">{r.title || <span className="italic text-muted-foreground">（無標題）</span>}</span>
+                      {r.subtitle && (
+                        <span className="block truncate text-xs text-muted-foreground">{r.subtitle}</span>
+                      )}
+                    </span>
+                    {selected && (
+                      <Badge variant="secondary" className="ml-2 shrink-0 text-[10px]">已選</Badge>
+                    )}
+                  </button>
+                </li>
+              );
+            })
+          )}
+        </ul>
+      </TabsContent>
+    ))}
+  </Tabs>
+
+  {/* Selected chips */}
+  <div data-testid={PROJECTS_TESTIDS.refsPickerSelected} className="space-y-1.5">
+    <p className="text-xs font-medium text-muted-foreground">
+      已選（{value.length}{max ? ` / ${max}` : ""}）
+    </p>
+    {value.length === 0 ? (
+      <p
+        data-testid={PROJECTS_TESTIDS.refsPickerSelectedEmpty}
+        className="rounded-md border border-dashed py-3 text-center text-xs text-muted-foreground"
+      >
+        尚未選取任何關聯
+      </p>
+    ) : (
+      <ul className="flex flex-wrap gap-1.5">
+        {value.map((ref) => {
+          const Icon = TYPE_META[ref.ref_type].icon;
+          const missing = ref.display === null;
+          return (
+            <li
+              key={`${ref.ref_type}-${ref.ref_id}`}
+              data-testid={`${PROJECTS_TESTIDS.refsPickerChip}-${ref.ref_id}`}
+              data-missing={missing ? "true" : "false"}
+              className={cn(
+                "group inline-flex items-center gap-1 rounded-full border px-2 py-1 text-xs",
+                missing
+                  ? "border-dashed border-destructive/40 bg-destructive/5 text-destructive"
+                  : "border-border bg-muted/40",
+              )}
+            >
+              <Icon className="h-3 w-3 shrink-0" aria-hidden="true" />
+              {missing ? (
+                <span
+                  data-testid={PROJECTS_TESTIDS.refsPickerChipMissing}
+                  className="inline-flex items-center gap-1"
+                >
+                  <AlertTriangleIcon className="h-3 w-3" aria-hidden="true" />
+                  來源已刪除
+                </span>
+              ) : ref.display?.href ? (
+                <a
+                  href={ref.display.href}
+                  target="_blank"
+                  rel="noreferrer"
+                  className="max-w-[12rem] truncate underline-offset-2 hover:underline focus-visible:outline-none focus-visible:underline"
+                >
+                  {ref.display.title || "（無標題）"}
+                  <ExternalLinkIcon className="ml-0.5 inline h-2.5 w-2.5" aria-hidden="true" />
+                </a>
+              ) : (
+                <span className="max-w-[12rem] truncate">
+                  {ref.display?.title || "（無標題）"}
+                </span>
+              )}
+              <button
+                type="button"
+                onClick={() => removeRef(ref)}
+                aria-label={`移除關聯：${ref.display?.title || ref.ref_id}`}
+                data-testid={`${PROJECTS_TESTIDS.refsPickerChipRemove}-${ref.ref_id}`}
+                className="ml-0.5 inline-flex h-4 w-4 shrink-0 items-center justify-center rounded-full hover:bg-destructive/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+              >
+                <XIcon className="h-3 w-3" aria-hidden="true" />
+              </button>
+            </li>
+          );
+        })}
+      </ul>
+    )}
+  </div>
+</div>
+```
+
+---
+
+## Behavior
+
+| 互動 | 行為 |
+|------|------|
+| 切 tab | 清空 query + 重置結果（保留各 tab 自己的 query 可選；本元件採重置） |
+| 輸入 query | debounce 300ms → `search(type, q)` → 更新結果列表 |
+| 點結果項 | 加入 value（呼叫 onChange），同時 result 顯示「已選」 badge 並 disable |
+| 點 chip 主體 | 若 `display.href` → `target="_blank"` 開新分頁；missing 不可點 |
+| 點 chip ✕ | 從 value 移除（onChange） |
+| 達 max（預設 50） | search input + 結果列表 disabled，顯示提示 |
+| 重複加入 | 已選的 result 會 disabled 顯示「已選」badge |
+
+---
+
+## States
+
+| 狀態 | 視覺 |
+|------|------|
+| Idle（未搜尋） | 結果列表顯示「輸入關鍵字搜尋 {type}」 |
+| Searching | 3 row Skeleton |
+| Empty result | 「沒有符合的結果」 |
+| Item 已選 | 該 row `disabled` + 右側 `Badge variant=secondary 已選` |
+| Chip 正常 | `border-border bg-muted/40`，標題為 `<a target=_blank>` |
+| Chip 來源已刪除 | `border-dashed border-destructive/40 bg-destructive/5 text-destructive`，附 `AlertTriangleIcon` + 「來源已刪除」文字，`data-missing="true"` |
+| At max | input 與結果列表 disabled，顯示提示 |
+| Disabled（parent 禁用） | 整個元件 `aria-disabled="true"`，無互動 |
+
+---
+
+## data-testid
+
+| 元素 | testid |
+|------|--------|
+| Picker root | `PROJECTS_TESTIDS.refsPicker` |
+| Tabs list | `PROJECTS_TESTIDS.refsPickerTabs` |
+| Tab trigger | `projects-refs-picker-tab-{type}` |
+| Search input | `PROJECTS_TESTIDS.refsPickerSearch` |
+| Result list | `PROJECTS_TESTIDS.refsPickerResults` |
+| Result item | `projects-refs-picker-result-{refId}` |
+| Empty state | `PROJECTS_TESTIDS.refsPickerEmpty` |
+| Selected wrap | `PROJECTS_TESTIDS.refsPickerSelected` |
+| Selected empty | `PROJECTS_TESTIDS.refsPickerSelectedEmpty` |
+| Chip | `projects-refs-picker-chip-{refId}` |
+| Chip remove btn | `projects-refs-picker-chip-remove-{refId}` |
+| Missing label | `PROJECTS_TESTIDS.refsPickerChipMissing` |
+
+需新增至 `design/components/projects/testids.md` 的 PROJECTS_TESTIDS（refs-picker 區塊）：
+
+```ts
+// Refs picker（TaskSheet 內）
+refsPicker: "projects-refs-picker",
+refsPickerTabs: "projects-refs-picker-tabs",
+refsPickerTab: "projects-refs-picker-tab",                  // suffix -{type}
+refsPickerSearch: "projects-refs-picker-search",
+refsPickerResults: "projects-refs-picker-results",
+refsPickerResultItem: "projects-refs-picker-result",        // suffix -{refId}
+refsPickerEmpty: "projects-refs-picker-empty",
+refsPickerSelected: "projects-refs-picker-selected",
+refsPickerSelectedEmpty: "projects-refs-picker-selected-empty",
+refsPickerChip: "projects-refs-picker-chip",                // suffix -{refId}
+refsPickerChipRemove: "projects-refs-picker-chip-remove",   // suffix -{refId}
+refsPickerChipMissing: "projects-refs-picker-chip-missing",
+```
+
+---
+
+## API 串接
+
+| Tab | 搜尋 endpoint |
+|-----|--------------|
+| entry | `GET /api/v1/entries?q={q}&limit=8` |
+| journal | `GET /api/v1/journal?q={q}&limit=8` |
+| gcal_event | `GET /api/v1/gcal/events?q={q}&limit=8` |
+
+PATCH 提交時：
+
+```json
+PATCH /api/v1/tasks/:id
+{ "refs": [
+  { "ref_type": "entry", "ref_id": "uuid-1" },
+  { "ref_type": "journal", "ref_id": "uuid-2" }
+] }
+```
+
+「來源已刪除」由後端 `ref_resolved=false` 標記（F-031 task_refs JOIN 失敗時 display=null）。
+
+---
+
+## 響應式
+
+| 斷點 | 行為 |
+|------|------|
+| `>= 640px` | Tabs 3 欄水平；結果 max-h 16rem |
+| `< 640px` | Tabs 仍 3 欄但縮小字體；chip 區可換行 |
+
+---
+
+## a11y
+
+- Tabs：shadcn 內建 `role="tablist"` / `role="tab"` / `aria-selected`，左右鍵切換
+- Search input：`aria-label`，與下方 listbox 透過 `aria-controls` 可選擇性連結
+- Result list：`role="listbox"`，每筆 `role="option" aria-selected`
+- 已選 chip：`<li>` 內含跳轉 `<a>` 與移除 `<button>`，皆可 Tab；移除按鈕 `aria-label` 包含 ref 標題
+- 「來源已刪除」狀態：`AlertTriangleIcon` + 文字雙重表達，不單靠顏色
+- 觸控目標：tab trigger / chip remove 至少 32px hit area；search input 預設 40px；result item 至少 36px（行高 + padding）
+- 對比：destructive token 已通過 4.5:1（既有設計系統驗證）
+- Reduced motion：`hover:bg-muted` 為瞬時，無 transition

--- a/design/components/projects/testids.md
+++ b/design/components/projects/testids.md
@@ -53,9 +53,39 @@ export const PROJECTS_TESTIDS = {
 
   // Delete Confirm Dialog
   deleteDialog: "project-delete-dialog",
+  deleteDialogTitle: "project-delete-dialog-title",
+  deleteDialogTaskWarning: "project-delete-dialog-task-warning",
   deleteDialogTaskCount: "project-delete-dialog-task-count",
+  deleteDialogForceCheckbox: "project-delete-dialog-force-checkbox",
   deleteDialogConfirm: "project-delete-dialog-confirm",
   deleteDialogCancel: "project-delete-dialog-cancel",
+  deleteDialogError: "project-delete-dialog-error",
+
+  // Refs Picker（TaskSheet 內）
+  refsPicker: "projects-refs-picker",
+  refsPickerTabs: "projects-refs-picker-tabs",
+  refsPickerTab: "projects-refs-picker-tab",                  // suffix -{type}
+  refsPickerSearch: "projects-refs-picker-search",
+  refsPickerResults: "projects-refs-picker-results",
+  refsPickerResultItem: "projects-refs-picker-result",        // suffix -{refId}
+  refsPickerEmpty: "projects-refs-picker-empty",
+  refsPickerSelected: "projects-refs-picker-selected",
+  refsPickerSelectedEmpty: "projects-refs-picker-selected-empty",
+  refsPickerChip: "projects-refs-picker-chip",                // suffix -{refId}
+  refsPickerChipRemove: "projects-refs-picker-chip-remove",   // suffix -{refId}
+  refsPickerChipMissing: "projects-refs-picker-chip-missing",
+
+  // Sidebar Upcoming Tasks Widget
+  upcomingWidget: "projects-upcoming-widget",
+  upcomingWidgetCount: "projects-upcoming-count",
+  upcomingWidgetRefresh: "projects-upcoming-refresh",
+  upcomingWidgetSkeleton: "projects-upcoming-skeleton",
+  upcomingWidgetError: "projects-upcoming-error",
+  upcomingWidgetEmpty: "projects-upcoming-empty",
+  upcomingWidgetCreateCta: "projects-upcoming-create-cta",
+  upcomingWidgetItem: "projects-upcoming-item",                  // suffix -{taskId}
+  upcomingWidgetItemTitle: "projects-upcoming-item-title",       // suffix -{taskId}
+  upcomingWidgetItemDue: "projects-upcoming-item-due",           // suffix -{taskId}
 
   // Detail page (container)
   detailPage: "project-detail-page",

--- a/design/components/projects/testids.md
+++ b/design/components/projects/testids.md
@@ -1,0 +1,90 @@
+# PROJECTS_TESTIDS
+
+> Sprint 10 Projects 元件統一 `data-testid` 命名表。所有 design / dev / qa 必須引用此命名。
+
+```ts
+export const PROJECTS_TESTIDS = {
+  // List page
+  listPage: "projects-list-page",
+  listGrid: "projects-list-grid",
+  listEmpty: "projects-list-empty",
+  listEmptyCta: "projects-list-empty-cta",
+  listSkeleton: "projects-list-skeleton",
+  listError: "projects-list-error",
+  listCreateButton: "projects-list-create",
+
+  // Status tabs
+  statusTabs: "projects-status-tabs",
+  statusTab: "projects-status-tab",            // suffix -{status} e.g. projects-status-tab-active
+  statusTabActive: "projects-status-tab-active",
+  statusTabPaused: "projects-status-tab-paused",
+  statusTabDone: "projects-status-tab-done",
+  statusTabArchived: "projects-status-tab-archived",
+
+  // Project Card
+  card: "project-card",                         // suffix -{projectId}
+  cardColorStripe: "project-card-color-stripe",
+  cardName: "project-card-name",
+  cardDescription: "project-card-description",
+  cardProgressBar: "project-card-progress-bar",
+  cardProgressLabel: "project-card-progress-label",
+  cardStatusBadge: "project-card-status-badge",
+  cardOpenTaskCount: "project-card-open-task-count",
+  cardNextDue: "project-card-next-due",
+  cardMenuTrigger: "project-card-menu",
+  cardMenuEdit: "project-card-menu-edit",
+  cardMenuArchive: "project-card-menu-archive",
+  cardMenuDelete: "project-card-menu-delete",
+
+  // Project Dialog (Create / Edit)
+  dialog: "project-dialog",
+  dialogTitle: "project-dialog-title",
+  dialogNameInput: "project-dialog-name",
+  dialogNameError: "project-dialog-name-error",
+  dialogDescriptionInput: "project-dialog-description",
+  dialogColorPicker: "project-dialog-color-picker",
+  dialogColorSwatch: "project-dialog-color-swatch",     // suffix -{key} e.g. -blue
+  dialogStartDate: "project-dialog-start-date",
+  dialogEndDate: "project-dialog-end-date",
+  dialogDateError: "project-dialog-date-error",
+  dialogStatusSelect: "project-dialog-status-select",
+  dialogSubmit: "project-dialog-submit",
+  dialogCancel: "project-dialog-cancel",
+
+  // Delete Confirm Dialog
+  deleteDialog: "project-delete-dialog",
+  deleteDialogTaskCount: "project-delete-dialog-task-count",
+  deleteDialogConfirm: "project-delete-dialog-confirm",
+  deleteDialogCancel: "project-delete-dialog-cancel",
+
+  // Detail page (container)
+  detailPage: "project-detail-page",
+  detailHeader: "project-detail-header",
+  detailHeaderName: "project-detail-header-name",
+  detailHeaderEdit: "project-detail-header-edit",
+  detailTabs: "project-detail-tabs",
+  detailTabBoard: "project-detail-tab-board",
+  detailTabList: "project-detail-tab-list",
+  detailTabOverview: "project-detail-tab-overview",
+  detailNewTaskButton: "project-detail-new-task",
+
+  // Overview tab
+  overviewProgress: "project-overview-progress",
+  overviewProgressBar: "project-overview-progress-bar",
+  overviewStats: "project-overview-stats",
+  overviewStatTotal: "project-overview-stat-total",
+  overviewStatDone: "project-overview-stat-done",
+  overviewStatBlocked: "project-overview-stat-blocked",
+  overviewStatOverdue: "project-overview-stat-overdue",
+  overviewTimeline: "project-overview-timeline",
+  overviewDescription: "project-overview-description",
+  overviewActivity: "project-overview-activity",
+  overviewActivityItem: "project-overview-activity-item",   // suffix -{idx}
+} as const;
+```
+
+## 命名規則
+
+- 所有 testid 以 `project-` 或 `projects-` 為 prefix（list 多筆用複數，單筆用單數）
+- 動態 suffix：`{base}-{id}`，id 不含空白
+- QA 範例：`page.getByTestId('project-card-${projectId}')`

--- a/design/components/projects/upcoming-tasks-widget.md
+++ b/design/components/projects/upcoming-tasks-widget.md
@@ -1,0 +1,330 @@
+# UpcomingTasksWidget
+
+側邊欄底部的「近期 tasks」widget，呼叫 `GET /api/v1/tasks/upcoming?days=7`，最多顯示 5 筆，依 `due_at asc` 排序，過期項目以 destructive 色標示。
+
+對齊 spec：F-032（側邊欄底部新增「近期 tasks」widget）、F-031（`/tasks/upcoming?days=7` endpoint，跨專案）。
+
+---
+
+## 用途
+
+- 嵌入主 sidebar `<NavigationSidebar>` 底部
+- 提供使用者一眼看到「最近 7 天內到期 / 已過期」的未完成 task
+- 點擊單筆 → 跳到對應 `/projects/:projectId` 並開啟該 task sheet
+
+---
+
+## 結構
+
+```
+┌────────── 近期 tasks ──────────┐
+│ 近期 tasks（5）         [↻]     │  ← header（標題 + count + 重整 icon）
+│ ─────────────────────────────── │
+│ ⚠ 設計 schema                   │  ← 過期：destructive 色 + AlertCircleIcon
+│   昨天 · aibo v2                │
+│ ─────────────────────────────── │
+│ ● 寫 e2e 測試                   │  ← 今天到期：warning 色 dot
+│   今天 · aibo v2                │
+│ ─────────────────────────────── │
+│ ● 做技術 survey                 │  ← 未來：normal dot
+│   明天 · aibo v2                │
+│ ─────────────────────────────── │
+│ ● Sprint review 準備            │
+│   4/29 · aibo v2                │
+│ ─────────────────────────────── │
+│ ● 上線部署                       │
+│   5/01 · 部署                   │
+└─────────────────────────────────┘
+```
+
+Empty state：
+
+```
+┌────────── 近期 tasks ──────────┐
+│ 近期 tasks               [↻]    │
+│ ─────────────────────────────── │
+│ ✨ 未來 7 天沒有待辦 task        │
+│    建立任務 →                    │
+└─────────────────────────────────┘
+```
+
+---
+
+## Props
+
+```ts
+interface UpcomingTasksWidgetProps {
+  /** 預設 7 天，可由 parent 改 */
+  days?: number;
+  /** 預設 5；spec 上限 5 */
+  limit?: number;
+  /** 控制是否顯示 widget header（折疊時 false） */
+  collapsed?: boolean;
+  /** 點 task 時跳轉的 callback */
+  onOpenTask: (task: UpcomingTask) => void;
+  /** 空狀態 CTA */
+  onCreateTask?: () => void;
+}
+
+interface UpcomingTask {
+  id: string;
+  project_id: string;
+  project_name: string;
+  project_color: string;     // hex
+  title: string;
+  status: TaskStatus;
+  priority: Priority;
+  due_at: string;            // ISO（API 已過濾 due_date <= now+days 且 status != done/cancelled）
+  is_overdue: boolean;       // 由前端 derive 或 API 帶
+}
+```
+
+內部使用 `useUpcomingTasks(days, limit)` SWR hook，`refreshInterval: 60_000`，且在 task PATCH 後 `mutate()`。
+
+---
+
+## Tailwind / 範例
+
+```tsx
+import { Button } from "@/components/ui/button";
+import { Skeleton } from "@/components/ui/skeleton";
+import { AlertCircleIcon, CalendarIcon, RefreshCwIcon, SparklesIcon, ChevronRightIcon } from "lucide-react";
+import { cn } from "@/lib/utils";
+import { PROJECTS_TESTIDS } from "@/lib/testids/projects";
+import { formatDueLabel } from "@/lib/format";
+
+<aside
+  data-testid={PROJECTS_TESTIDS.upcomingWidget}
+  aria-labelledby="upcoming-tasks-title"
+  className={cn(
+    "rounded-md border bg-card",
+    "mx-2 mb-2 mt-auto",                  // 在 sidebar 底部
+  )}
+>
+  {/* Header */}
+  <div className="flex items-center justify-between px-3 pb-1.5 pt-2.5">
+    <h3
+      id="upcoming-tasks-title"
+      className="flex items-center gap-1.5 text-xs font-semibold text-muted-foreground"
+    >
+      <CalendarIcon className="h-3.5 w-3.5" aria-hidden="true" />
+      近期 tasks
+      {data && data.length > 0 && (
+        <span
+          data-testid={PROJECTS_TESTIDS.upcomingWidgetCount}
+          className="rounded-full bg-muted px-1.5 text-[10px] tabular-nums"
+        >
+          {data.length}
+        </span>
+      )}
+    </h3>
+    <Button
+      variant="ghost"
+      size="icon"
+      className="h-6 w-6"
+      onClick={() => mutate()}
+      aria-label="重新整理近期 tasks"
+      data-testid={PROJECTS_TESTIDS.upcomingWidgetRefresh}
+    >
+      <RefreshCwIcon
+        className={cn("h-3 w-3", isValidating && "animate-spin")}
+        aria-hidden="true"
+      />
+    </Button>
+  </div>
+
+  {/* Body */}
+  {isLoading ? (
+    <div data-testid={PROJECTS_TESTIDS.upcomingWidgetSkeleton} className="space-y-1.5 px-2 pb-2">
+      <Skeleton className="h-10 w-full" />
+      <Skeleton className="h-10 w-full" />
+      <Skeleton className="h-10 w-full" />
+    </div>
+  ) : error ? (
+    <div data-testid={PROJECTS_TESTIDS.upcomingWidgetError} className="px-3 pb-3 text-xs text-destructive">
+      載入失敗
+      <button onClick={() => mutate()} className="ml-1 underline">重試</button>
+    </div>
+  ) : !data || data.length === 0 ? (
+    <div
+      data-testid={PROJECTS_TESTIDS.upcomingWidgetEmpty}
+      className="px-3 pb-3 text-xs text-muted-foreground"
+    >
+      <p className="flex items-center gap-1">
+        <SparklesIcon className="h-3 w-3" aria-hidden="true" />
+        未來 {days} 天沒有待辦 task
+      </p>
+      {onCreateTask && (
+        <button
+          onClick={onCreateTask}
+          data-testid={PROJECTS_TESTIDS.upcomingWidgetCreateCta}
+          className="mt-1 inline-flex items-center gap-0.5 text-primary hover:underline focus-visible:outline-none focus-visible:underline"
+        >
+          建立任務
+          <ChevronRightIcon className="h-3 w-3" aria-hidden="true" />
+        </button>
+      )}
+    </div>
+  ) : (
+    <ul role="list" className="px-1 pb-1.5">
+      {data.slice(0, limit).map((t) => (
+        <li key={t.id}>
+          <button
+            type="button"
+            onClick={() => onOpenTask(t)}
+            data-testid={`${PROJECTS_TESTIDS.upcomingWidgetItem}-${t.id}`}
+            data-overdue={t.is_overdue ? "true" : "false"}
+            aria-label={`${t.title}，${formatDueLabel(t.due_at, t.is_overdue)}，專案 ${t.project_name}`}
+            className={cn(
+              "flex w-full items-start gap-2 rounded px-2 py-1.5 text-left",
+              "transition-colors hover:bg-muted focus-visible:bg-muted focus-visible:outline-none",
+              "focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1",
+            )}
+          >
+            {t.is_overdue ? (
+              <AlertCircleIcon
+                className="mt-0.5 h-3.5 w-3.5 shrink-0 text-destructive"
+                aria-hidden="true"
+              />
+            ) : (
+              <span
+                aria-hidden="true"
+                className="mt-1.5 h-2 w-2 shrink-0 rounded-full"
+                style={{ backgroundColor: t.project_color }}
+              />
+            )}
+            <span className="min-w-0 flex-1">
+              <span
+                data-testid={`${PROJECTS_TESTIDS.upcomingWidgetItemTitle}-${t.id}`}
+                className={cn(
+                  "block truncate text-xs font-medium",
+                  t.is_overdue && "text-destructive",
+                )}
+              >
+                {t.title}
+              </span>
+              <span className="block truncate text-[10px] text-muted-foreground">
+                <span
+                  data-testid={`${PROJECTS_TESTIDS.upcomingWidgetItemDue}-${t.id}`}
+                  className={cn(t.is_overdue && "text-destructive")}
+                >
+                  {formatDueLabel(t.due_at, t.is_overdue)}
+                </span>
+                <span aria-hidden="true"> · </span>
+                <span className="truncate">{t.project_name}</span>
+              </span>
+            </span>
+          </button>
+        </li>
+      ))}
+    </ul>
+  )}
+</aside>
+```
+
+`formatDueLabel` 規則（由 `lib/format` 提供）：
+- `is_overdue=true` 且 < 24h → 「今天逾期」
+- `is_overdue=true` 且 ≥ 24h → 「逾期 N 天」
+- 今天 → 「今天」
+- 明天 → 「明天」
+- ≤ 7 天 → `M/D`
+- 其他 → `YYYY-MM-DD`
+
+---
+
+## Behavior
+
+| 互動 | 行為 |
+|------|------|
+| 點刷新 icon | `mutate()`，icon 旋轉直到完成 |
+| 點 task item | `onOpenTask(task)`，由 parent 處理 navigate（通常 `router.push('/projects/:projectId?taskId=:id')`） |
+| 點空狀態 CTA | `onCreateTask?.()` |
+| Sidebar collapsed | 隱藏整個 widget（或僅顯示 icon hover tooltip，視 sidebar 設計；本元件由 parent 控制） |
+| 自動刷新 | 60s |
+
+---
+
+## States
+
+| 狀態 | 視覺 |
+|------|------|
+| Loading | 3 row Skeleton |
+| Empty | 「未來 N 天沒有待辦 task」+ 建立任務 CTA |
+| Error | destructive 文字「載入失敗」+ 重試 |
+| Has data | List of items |
+| Item overdue | `AlertCircleIcon` + `text-destructive`，標題 / 日期皆 destructive 色 |
+| Item normal | 左側 project color dot + 標題 normal、日期 muted |
+| Refreshing | 刷新 icon `animate-spin`，list 維持顯示 |
+
+---
+
+## data-testid
+
+| 元素 | testid |
+|------|--------|
+| Widget root | `PROJECTS_TESTIDS.upcomingWidget` |
+| Count badge | `PROJECTS_TESTIDS.upcomingWidgetCount` |
+| Refresh button | `PROJECTS_TESTIDS.upcomingWidgetRefresh` |
+| Skeleton | `PROJECTS_TESTIDS.upcomingWidgetSkeleton` |
+| Error | `PROJECTS_TESTIDS.upcomingWidgetError` |
+| Empty | `PROJECTS_TESTIDS.upcomingWidgetEmpty` |
+| Empty CTA | `PROJECTS_TESTIDS.upcomingWidgetCreateCta` |
+| Item | `projects-upcoming-item-{taskId}` |
+| Item title | `projects-upcoming-item-title-{taskId}` |
+| Item due | `projects-upcoming-item-due-{taskId}` |
+
+需新增至 `design/components/projects/testids.md`：
+
+```ts
+// Sidebar Upcoming Tasks Widget
+upcomingWidget: "projects-upcoming-widget",
+upcomingWidgetCount: "projects-upcoming-count",
+upcomingWidgetRefresh: "projects-upcoming-refresh",
+upcomingWidgetSkeleton: "projects-upcoming-skeleton",
+upcomingWidgetError: "projects-upcoming-error",
+upcomingWidgetEmpty: "projects-upcoming-empty",
+upcomingWidgetCreateCta: "projects-upcoming-create-cta",
+upcomingWidgetItem: "projects-upcoming-item",                  // suffix -{taskId}
+upcomingWidgetItemTitle: "projects-upcoming-item-title",       // suffix -{taskId}
+upcomingWidgetItemDue: "projects-upcoming-item-due",           // suffix -{taskId}
+```
+
+---
+
+## API 串接
+
+```
+GET /api/v1/tasks/upcoming?days=7&limit=5
+→ 200 [
+  {
+    id, project_id, project_name, project_color,
+    title, status, priority,
+    due_at,                  // ISO
+    is_overdue: boolean
+  },
+  ...（依 due_at asc）
+]
+```
+
+> 過期判定：`is_overdue = (due_at < now())`，由 API 計算或前端 derive 皆可（spec 未強制；本元件接受任一）。
+
+---
+
+## 響應式
+
+| 斷點 | 行為 |
+|------|------|
+| Sidebar 展開（>= 1024px） | 完整顯示 |
+| Sidebar 折疊 / mobile drawer | 由 parent 控制是否渲染；本元件本身不負責折疊樣式 |
+
+---
+
+## a11y
+
+- `<aside>` + `aria-labelledby` 構成地標
+- 每筆 task 為 `<button>`，`aria-label` 完整描述（標題 + 到期 + 專案）
+- 過期狀態：`AlertCircleIcon` + 文字「逾期 N 天」 + destructive 色，三重表達
+- Project color dot 為純裝飾，`aria-hidden="true"`
+- 對比：destructive 與 muted-foreground 既有 token 已通過 4.5:1
+- 觸控目標：每 row hit area 約 36–40px（含 padding 1.5），整 widget 在 sidebar 底部建議 parent 保留 8px 間距
+- Reduced motion：`animate-spin` 在 `prefers-reduced-motion: reduce` 下停用（Tailwind 預設行為，或在 globals 補規則）

--- a/design/components/task/README.md
+++ b/design/components/task/README.md
@@ -1,0 +1,30 @@
+# Task Components — Sprint 10
+
+對應 issue #126、F-032b / F-032c。Task 相關的 List 視圖列、TaskSheet（右側抽屜）、RefsPicker（多源關聯選擇）、UpcomingTasksWidget（dashboard 用 widget）。
+
+## 元件清單
+
+| 元件 | 檔案 | 用途 |
+|------|------|------|
+| TaskListRow | `task-list-row.md` | 詳情頁 List tab 表格列 |
+| TaskSheet | `task-sheet.md` | 右側 Sheet 任務詳情編輯 |
+| RefsPicker | `refs-picker.md` | 多源（entry / journal / gcal_event）關聯選擇器 |
+| UpcomingTasksWidget | `upcoming-tasks-widget.md` | Sidebar 底部「即將到期 / 逾期」widget |
+
+## testid
+
+統一見 `testids.md`（`TASK_TESTIDS` 常數）。
+
+## 共通
+
+- shadcn/ui：Sheet / Dialog（RefsPicker 內嵌）/ Table / Tabs / Select / Calendar / Popover / Checkbox / Input / Textarea
+- 對比 ≥ WCAG AA、focus ring 統一 `ring-ring`
+- status / priority 雙重表達（顏色 + 文字 + icon）
+- 動畫 150–300ms、尊重 `prefers-reduced-motion`
+- 觸控目標 ≥ 44×44pt
+
+## 與 Kanban 的關係
+
+- KanbanCard 點擊 → 開 TaskSheet（mode=edit）
+- KanbanColumn 「+ 加入任務」 → 開 TaskSheet（mode=create, defaultStatus=該欄）
+- TaskSheet PATCH 後，board 用 React Query invalidate 重新拉清單

--- a/design/components/task/task-list-row.md
+++ b/design/components/task/task-list-row.md
@@ -1,0 +1,190 @@
+# TaskListRow
+
+`/projects/:id` List tab 的單列。基於 shadcn `<Table>`。
+
+---
+
+## 用途
+
+以表格形式顯示專案內所有任務（含 cancelled），便於排序 / 批次瀏覽 / 鍵盤瀏覽。
+
+---
+
+## 結構
+
+```
+| ☐ | Title                | Status     | Priority | Due       | Refs | ⋯ |
+| ☐ | 設計 schema           | 進行中 ●   | 急迫 🔥  | 4/30      | 📎 3 |   |
+| ☑ | 撰寫遷移腳本           | 完成 ●     | 一般     | —         | —    |   |
+| ☐ | 部署到 staging       | 待辦 ●     | 高      | 5/12 逾期 | 📎 1 |   |
+```
+
+---
+
+## Props
+
+```ts
+interface TaskListRowProps {
+  task: {
+    id: string;
+    title: string;
+    status: TaskStatus;
+    priority: "low" | "normal" | "high" | "urgent";
+    due_date: string | null;
+    refs_count: number;
+  };
+  selected?: boolean;             // 預留批次選取（v1 不啟用）
+  onToggleComplete: () => void;
+  onOpen: () => void;
+  onMenu: { edit: () => void; delete: () => void };
+}
+```
+
+---
+
+## Tailwind / 範例
+
+```tsx
+import { TableRow, TableCell } from "@/components/ui/table";
+import { Checkbox } from "@/components/ui/checkbox";
+import { Badge } from "@/components/ui/badge";
+import { DropdownMenu, DropdownMenuTrigger, DropdownMenuContent, DropdownMenuItem } from "@/components/ui/dropdown-menu";
+import { Button } from "@/components/ui/button";
+import { MoreHorizontalIcon, PaperclipIcon, ClockAlertIcon, CalendarIcon, PencilIcon, Trash2Icon } from "lucide-react";
+import { cn } from "@/lib/utils";
+import { TASK_TESTIDS } from "@/lib/testids/task";
+
+const STATUS = {
+  todo:        { label: "待辦",    cls: "bg-zinc-100 text-zinc-800",       dot: "bg-zinc-400" },
+  in_progress: { label: "進行中",  cls: "bg-blue-100 text-blue-900",       dot: "bg-blue-500" },
+  blocked:     { label: "卡住",    cls: "bg-red-100 text-red-900",         dot: "bg-red-500" },
+  done:        { label: "完成",    cls: "bg-green-100 text-green-900",     dot: "bg-green-500" },
+  cancelled:   { label: "已取消",  cls: "bg-zinc-100 text-zinc-500 line-through", dot: "bg-zinc-300" },
+} as const;
+
+const PRIORITY_LABEL = { low: "低", normal: "一般", high: "高", urgent: "急迫" } as const;
+
+<TableRow
+  data-testid={`${TASK_TESTIDS.listRow}-${task.id}`}
+  className={cn(
+    "cursor-pointer hover:bg-muted/40",
+    task.status === "done" && "opacity-70",
+    task.status === "cancelled" && "opacity-50",
+  )}
+  onClick={onOpen}
+>
+  <TableCell className="w-10">
+    <Checkbox
+      checked={task.status === "done"}
+      onCheckedChange={onToggleComplete}
+      onClick={(e) => e.stopPropagation()}
+      data-testid={`${TASK_TESTIDS.listRowCheckbox}-${task.id}`}
+      aria-label={task.status === "done" ? `取消完成「${task.title}」` : `完成「${task.title}」`}
+    />
+  </TableCell>
+
+  <TableCell
+    data-testid={`${TASK_TESTIDS.listRowTitle}-${task.id}`}
+    className={cn(
+      "max-w-[40ch] truncate font-medium",
+      task.status === "done" && "line-through text-muted-foreground",
+    )}
+  >
+    {task.title}
+  </TableCell>
+
+  <TableCell data-testid={`${TASK_TESTIDS.listRowStatus}-${task.id}`}>
+    <Badge className={cn("gap-1.5 border-transparent", STATUS[task.status].cls)}>
+      <span aria-hidden="true" className={cn("h-1.5 w-1.5 rounded-full", STATUS[task.status].dot)} />
+      {STATUS[task.status].label}
+    </Badge>
+  </TableCell>
+
+  <TableCell data-testid={`${TASK_TESTIDS.listRowPriority}-${task.id}`}>
+    <span className="text-sm text-muted-foreground">{PRIORITY_LABEL[task.priority]}</span>
+  </TableCell>
+
+  <TableCell data-testid={`${TASK_TESTIDS.listRowDue}-${task.id}`}>
+    <DueCell dueDate={task.due_date} status={task.status} />
+  </TableCell>
+
+  <TableCell data-testid={`${TASK_TESTIDS.listRowRefs}-${task.id}`}>
+    {task.refs_count > 0 ? (
+      <span className="flex items-center gap-1 text-sm text-muted-foreground">
+        <PaperclipIcon className="h-3.5 w-3.5" aria-hidden="true" />
+        {task.refs_count}
+      </span>
+    ) : (
+      <span className="text-sm text-muted-foreground/60">—</span>
+    )}
+  </TableCell>
+
+  <TableCell className="w-10">
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button
+          variant="ghost"
+          size="icon"
+          className="h-8 w-8"
+          onClick={(e) => e.stopPropagation()}
+          data-testid={`${TASK_TESTIDS.listRowMenu}-${task.id}`}
+          aria-label={`「${task.title}」動作選單`}
+        >
+          <MoreHorizontalIcon className="h-4 w-4" aria-hidden="true" />
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end">
+        <DropdownMenuItem onClick={onMenu.edit}>
+          <PencilIcon className="mr-2 h-4 w-4" aria-hidden="true" /> 編輯
+        </DropdownMenuItem>
+        <DropdownMenuItem
+          onClick={onMenu.delete}
+          className="text-destructive focus:text-destructive"
+        >
+          <Trash2Icon className="mr-2 h-4 w-4" aria-hidden="true" /> 刪除
+        </DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  </TableCell>
+</TableRow>
+```
+
+`DueCell`：
+
+```tsx
+function DueCell({ dueDate, status }: { dueDate: string | null; status: TaskStatus }) {
+  if (!dueDate) return <span className="text-muted-foreground/60">—</span>;
+  const isOverdue = status !== "done" && status !== "cancelled" && new Date(dueDate) < startOfTodayLocal();
+  return (
+    <span className={cn(
+      "flex items-center gap-1 text-sm tabular-nums",
+      isOverdue ? "text-destructive font-medium" : "text-foreground",
+    )}>
+      {isOverdue ? <ClockAlertIcon className="h-3.5 w-3.5" /> : <CalendarIcon className="h-3.5 w-3.5" />}
+      {formatDateShortZh(dueDate)}
+      {isOverdue && <span className="ml-1 text-xs">逾期</span>}
+    </span>
+  );
+}
+```
+
+---
+
+## Behavior
+
+| 互動 | 行為 |
+|------|------|
+| 點擊 row（非 checkbox / menu） | onOpen → TaskSheet |
+| 點擊 checkbox | onToggleComplete（不冒泡） |
+| 點擊 ⋯ menu | 編輯 / 刪除（不冒泡） |
+| Enter（focus 在 row） | onOpen |
+
+---
+
+## a11y
+
+- row 為可點擊區，`tabIndex=0` + `role="row"`（shadcn TableRow 已是 `<tr>`）
+- 內部 checkbox / menu 阻止冒泡，避免誤觸 onOpen
+- status 同時用「dot 顏色 + 文字 label」表達
+- overdue 用「紅色 + 不同 icon + 「逾期」文字」三重提示
+- 對比通過 4.5:1

--- a/design/components/task/task-sheet.md
+++ b/design/components/task/task-sheet.md
@@ -1,0 +1,379 @@
+# TaskSheet
+
+任務詳情編輯抽屜（右側 Sheet），使用 shadcn `<Sheet side="right">`。
+
+---
+
+## 用途
+
+- mode=create：從 KanbanColumn「+」或 List 頁「新增任務」觸發，建立新 task
+- mode=edit：從 KanbanCard、TaskListRow 點擊觸發，編輯既有 task
+- 內含完整表單：title、description、status、priority、due_date、refs
+
+---
+
+## 結構
+
+```
+                                        ┌─────────────────────────────────┐
+                                        │ 任務詳情                    [✕]  │
+                                        ├─────────────────────────────────┤
+                                        │ 標題 *                            │
+                                        │ [設計 schema                  ]   │
+                                        │                                 │
+                                        │ 描述                             │
+                                        │ ┌─────────────────────────────┐ │
+                                        │ │ Markdown 描述...             │ │
+                                        │ └─────────────────────────────┘ │
+                                        │                                 │
+                                        │ 狀態         優先級              │
+                                        │ [進行中ˇ]   [急迫ˇ]              │
+                                        │                                 │
+                                        │ 截止日                           │
+                                        │ [📅 2026-04-30      ✕清除]      │
+                                        │                                 │
+                                        │ 關聯項目                         │
+                                        │ ┌─────────────────────────────┐ │
+                                        │ │ 📄 entry：每週設計回顧 ✕     │ │
+                                        │ │ 📔 journal：2026-04-23  ✕    │ │
+                                        │ │ 📅 gcal：與小明會議 ✕        │ │
+                                        │ └─────────────────────────────┘ │
+                                        │ [ + 新增關聯 ]                   │
+                                        │                                 │
+                                        │ 儲存中…                          │  ← saving indicator
+                                        ├─────────────────────────────────┤
+                                        │ [刪除]            [完成 / 取消]   │
+                                        └─────────────────────────────────┘
+```
+
+寬度 desktop 480px、tablet 100% 但保留 `max-w-md`、mobile 100%。
+
+---
+
+## Props
+
+```ts
+interface TaskSheetProps {
+  open: boolean;
+  onOpenChange: (v: boolean) => void;
+  mode: "create" | "edit";
+  projectId: string;
+  initial?: Partial<TaskFull>;          // edit 時帶入
+  defaultStatus?: TaskStatus;            // create 時可指定欄位
+  onSaved: (task: TaskFull) => void;    // 成功 PATCH/POST 後回傳給 parent
+  onDeleted?: (taskId: string) => void;
+}
+```
+
+每次欄位變動以 debounce 800ms 自動 `PATCH /api/v1/tasks/:id`（edit 模式）。create 模式則需點「建立」按鈕送出。
+
+---
+
+## Tailwind / 範例（核心結構）
+
+```tsx
+import { Sheet, SheetContent, SheetHeader, SheetTitle, SheetFooter } from "@/components/ui/sheet";
+import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
+import { Label } from "@/components/ui/label";
+import { Button } from "@/components/ui/button";
+import { Select, SelectTrigger, SelectValue, SelectContent, SelectItem } from "@/components/ui/select";
+import { DatePicker } from "@/components/ui/date-picker";
+import { Trash2Icon, CheckIcon, PaperclipIcon, XIcon, FileTextIcon, BookOpenIcon, CalendarIcon } from "lucide-react";
+import { TASK_TESTIDS } from "@/lib/testids/task";
+import { RefsPicker } from "./refs-picker";
+
+const STATUS_OPTIONS = [
+  { value: "todo",        label: "待辦" },
+  { value: "in_progress", label: "進行中" },
+  { value: "blocked",     label: "卡住" },
+  { value: "done",        label: "完成" },
+  { value: "cancelled",   label: "已取消" },
+];
+const PRIORITY_OPTIONS = [
+  { value: "low",    label: "低" },
+  { value: "normal", label: "一般" },
+  { value: "high",   label: "高" },
+  { value: "urgent", label: "急迫" },
+];
+
+const REF_ICON = {
+  entry:       FileTextIcon,
+  journal:     BookOpenIcon,
+  gcal_event:  CalendarIcon,
+};
+const REF_LABEL = {
+  entry: "條目",
+  journal: "日記",
+  gcal_event: "行事曆",
+};
+
+<Sheet open={open} onOpenChange={onOpenChange}>
+  <SheetContent
+    side="right"
+    data-testid={TASK_TESTIDS.sheet}
+    className="flex w-full flex-col gap-0 sm:max-w-md"
+  >
+    <SheetHeader className="border-b px-5 py-3">
+      <SheetTitle data-testid={TASK_TESTIDS.sheetTitle}>
+        {mode === "create" ? "新增任務" : "任務詳情"}
+      </SheetTitle>
+    </SheetHeader>
+
+    <div className="flex-1 overflow-y-auto px-5 py-4 space-y-4">
+      {/* Title */}
+      <div className="space-y-1.5">
+        <Label htmlFor="task-title">
+          標題 <span className="text-destructive">*</span>
+        </Label>
+        <Input
+          id="task-title"
+          data-testid={TASK_TESTIDS.sheetTitleInput}
+          value={title}
+          onChange={(e) => setTitle(e.target.value)}
+          maxLength={200}
+          required
+          placeholder="輸入任務標題..."
+          autoFocus={mode === "create"}
+        />
+      </div>
+
+      {/* Description */}
+      <div className="space-y-1.5">
+        <Label htmlFor="task-description">描述</Label>
+        <Textarea
+          id="task-description"
+          data-testid={TASK_TESTIDS.sheetDescriptionInput}
+          value={description ?? ""}
+          onChange={(e) => setDescription(e.target.value)}
+          rows={5}
+          maxLength={5000}
+          placeholder="補充細節（支援 Markdown）"
+          className="resize-none"
+        />
+      </div>
+
+      {/* Status + Priority 雙欄 */}
+      <div className="grid grid-cols-2 gap-3">
+        <div className="space-y-1.5">
+          <Label htmlFor="task-status">狀態</Label>
+          <Select value={status} onValueChange={setStatus}>
+            <SelectTrigger id="task-status" data-testid={TASK_TESTIDS.sheetStatusSelect}>
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              {STATUS_OPTIONS.map((o) => (
+                <SelectItem
+                  key={o.value}
+                  value={o.value}
+                  data-testid={`${TASK_TESTIDS.sheetStatusOption}-${o.value}`}
+                >
+                  {o.label}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+        <div className="space-y-1.5">
+          <Label htmlFor="task-priority">優先級</Label>
+          <Select value={priority} onValueChange={setPriority}>
+            <SelectTrigger id="task-priority" data-testid={TASK_TESTIDS.sheetPrioritySelect}>
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              {PRIORITY_OPTIONS.map((o) => (
+                <SelectItem
+                  key={o.value}
+                  value={o.value}
+                  data-testid={`${TASK_TESTIDS.sheetPriorityOption}-${o.value}`}
+                >
+                  {o.label}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+      </div>
+
+      {/* Due date */}
+      <div className="space-y-1.5">
+        <Label htmlFor="task-due">截止日</Label>
+        <div className="flex items-center gap-2">
+          <DatePicker
+            id="task-due"
+            data-testid={TASK_TESTIDS.sheetDuePicker}
+            value={dueDate}
+            onChange={setDueDate}
+            className="flex-1"
+          />
+          {dueDate && (
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={() => setDueDate(null)}
+              data-testid={TASK_TESTIDS.sheetDueClear}
+              aria-label="清除截止日"
+            >
+              <XIcon className="h-4 w-4" aria-hidden="true" />
+              <span className="ml-1">清除</span>
+            </Button>
+          )}
+        </div>
+      </div>
+
+      {/* Refs */}
+      <section
+        data-testid={TASK_TESTIDS.sheetRefsSection}
+        aria-label="關聯項目"
+        className="space-y-2"
+      >
+        <Label>關聯項目（{refs.length}）</Label>
+        {refs.length === 0 ? (
+          <p className="rounded-md border border-dashed py-3 text-center text-xs text-muted-foreground">
+            尚未關聯任何項目
+          </p>
+        ) : (
+          <ul className="space-y-1.5">
+            {refs.map((r) => {
+              const Icon = REF_ICON[r.ref_type];
+              return (
+                <li
+                  key={`${r.ref_type}-${r.ref_id}`}
+                  data-testid={`${TASK_TESTIDS.sheetRefItem}-${r.ref_type}-${r.ref_id}`}
+                  className="flex items-center gap-2 rounded-md border bg-muted/30 px-2 py-1.5 text-sm"
+                >
+                  <Icon className="h-4 w-4 shrink-0 text-muted-foreground" aria-hidden="true" />
+                  <span className="text-xs text-muted-foreground">{REF_LABEL[r.ref_type]}</span>
+                  <span className="flex-1 truncate">{r.label}</span>
+                  {r.deleted && (
+                    <span className="rounded bg-destructive/10 px-1.5 py-0.5 text-[10px] text-destructive">
+                      已刪除
+                    </span>
+                  )}
+                  <Button
+                    variant="ghost"
+                    size="icon"
+                    className="h-6 w-6"
+                    onClick={() => removeRef(r)}
+                    data-testid={`${TASK_TESTIDS.sheetRefRemove}-${r.ref_type}-${r.ref_id}`}
+                    aria-label={`移除關聯：${REF_LABEL[r.ref_type]} ${r.label}`}
+                  >
+                    <XIcon className="h-3.5 w-3.5" aria-hidden="true" />
+                  </Button>
+                </li>
+              );
+            })}
+          </ul>
+        )}
+        <Button
+          variant="outline"
+          size="sm"
+          onClick={() => setRefsPickerOpen(true)}
+          data-testid={TASK_TESTIDS.sheetRefsAddButton}
+        >
+          <PaperclipIcon className="mr-1.5 h-4 w-4" aria-hidden="true" />
+          新增關聯
+        </Button>
+      </section>
+
+      {/* Saving indicator */}
+      {isSaving && (
+        <p
+          data-testid={TASK_TESTIDS.sheetSavingIndicator}
+          className="text-xs text-success"
+          role="status"
+          aria-live="polite"
+        >
+          儲存中…
+        </p>
+      )}
+      {errorBanner && (
+        <p
+          data-testid={TASK_TESTIDS.sheetErrorBanner}
+          className="rounded-md border border-destructive/50 bg-destructive/5 px-3 py-2 text-xs text-destructive"
+          role="alert"
+        >
+          {errorBanner}
+        </p>
+      )}
+    </div>
+
+    <SheetFooter className="flex flex-row items-center justify-between border-t px-5 py-3">
+      {mode === "edit" ? (
+        <Button
+          variant="ghost"
+          size="sm"
+          className="text-destructive hover:bg-destructive/10 hover:text-destructive"
+          onClick={handleDelete}
+          data-testid={TASK_TESTIDS.sheetDeleteButton}
+        >
+          <Trash2Icon className="mr-1.5 h-4 w-4" aria-hidden="true" />
+          刪除
+        </Button>
+      ) : <span />}
+
+      {mode === "edit" ? (
+        <Button
+          onClick={handleComplete}
+          disabled={status === "done"}
+          data-testid={TASK_TESTIDS.sheetCompleteButton}
+        >
+          <CheckIcon className="mr-1.5 h-4 w-4" aria-hidden="true" />
+          {status === "done" ? "已完成" : "標記完成"}
+        </Button>
+      ) : (
+        <Button onClick={handleCreate} disabled={!title.trim()}>
+          建立任務
+        </Button>
+      )}
+    </SheetFooter>
+
+    {/* Refs Picker（巢狀 Dialog 也可以；建議放 Sheet 內以共享 focus context） */}
+    <RefsPicker
+      open={refsPickerOpen}
+      onOpenChange={setRefsPickerOpen}
+      currentRefs={refs}
+      onConfirm={(next) => { setRefs(next); setRefsPickerOpen(false); }}
+    />
+  </SheetContent>
+</Sheet>
+```
+
+---
+
+## Behavior
+
+| 互動 | 行為 |
+|------|------|
+| 開啟 | autofocus 至 title input；edit 模式不 autofocus（避免不小心改名） |
+| 欄位變動（edit） | debounce 800ms 觸發 PATCH；視覺顯示「儲存中…」 |
+| Esc / 點背景 | 關閉（dirty + 未儲存時顯示 Unsaved confirm dialog） |
+| 點「標記完成」 | POST `/tasks/:id/complete`；status 切到 done，footer 顯示「已完成」disabled |
+| 點「刪除」 | AlertDialog 二次確認，DELETE 後 onDeleted + close sheet |
+| 跨 status 改 done | 顯示 toast「已完成」，並若在 Kanban，移到 done 欄 |
+| API 錯誤 | error banner 顯示繁中訊息，可點「重試」 |
+
+---
+
+## States
+
+| 狀態 | 視覺 |
+|------|------|
+| Default | 標準 Sheet |
+| Saving | 「儲存中…」`text-success` 出現於底部欄位區 |
+| Error | error banner（destructive 色） |
+| Refs 已刪除 | ref item 末尾紅色「已刪除」徽章；點擊不導航 |
+| status=cancelled | title 加刪除線 |
+| status=done | 「標記完成」按鈕變「已完成」disabled |
+
+---
+
+## a11y
+
+- Sheet 內建 focus trap、Esc 關閉、`aria-modal`
+- 所有 Input / Select / Date 都有 visible `<Label htmlFor>`
+- saving indicator `role="status" aria-live="polite"`
+- error banner `role="alert"`
+- 巢狀的 RefsPicker 為另一個 Dialog/Popover，自身有 focus trap，關閉後焦點回到「新增關聯」按鈕
+- 觸控目標：所有按鈕 ≥ 40px height（shadcn 預設）
+- 對比通過 4.5:1

--- a/design/components/task/testids.md
+++ b/design/components/task/testids.md
@@ -1,0 +1,73 @@
+# TASK_TESTIDS
+
+> Sprint 10 Task 相關元件 `data-testid` 命名表（List 視圖、Sheet、RefsPicker、Upcoming widget）。
+
+```ts
+export const TASK_TESTIDS = {
+  // List view (project detail List tab)
+  listTable: "task-list-table",
+  listEmpty: "task-list-empty",
+  listSkeleton: "task-list-skeleton",
+  listRow: "task-list-row",                       // suffix -{taskId}
+  listRowCheckbox: "task-list-row-checkbox",      // suffix -{taskId}
+  listRowTitle: "task-list-row-title",            // suffix -{taskId}
+  listRowStatus: "task-list-row-status",          // suffix -{taskId}
+  listRowPriority: "task-list-row-priority",      // suffix -{taskId}
+  listRowDue: "task-list-row-due",                // suffix -{taskId}
+  listRowRefs: "task-list-row-refs",              // suffix -{taskId}
+  listRowMenu: "task-list-row-menu",              // suffix -{taskId}
+
+  // Task Sheet (right-side drawer)
+  sheet: "task-sheet",
+  sheetTitle: "task-sheet-title",
+  sheetClose: "task-sheet-close",
+  sheetTitleInput: "task-sheet-title-input",
+  sheetDescriptionInput: "task-sheet-description-input",
+  sheetStatusSelect: "task-sheet-status-select",
+  sheetStatusOption: "task-sheet-status-option",  // suffix -{status}
+  sheetPrioritySelect: "task-sheet-priority-select",
+  sheetPriorityOption: "task-sheet-priority-option", // suffix -{priority}
+  sheetDuePicker: "task-sheet-due-picker",
+  sheetDueClear: "task-sheet-due-clear",
+  sheetRefsSection: "task-sheet-refs-section",
+  sheetRefsAddButton: "task-sheet-refs-add",      // 開啟 RefsPicker
+  sheetRefItem: "task-sheet-ref-item",            // suffix -{refType}-{refId}
+  sheetRefRemove: "task-sheet-ref-remove",        // suffix -{refType}-{refId}
+  sheetCompleteButton: "task-sheet-complete",
+  sheetDeleteButton: "task-sheet-delete",
+  sheetSavingIndicator: "task-sheet-saving",
+  sheetErrorBanner: "task-sheet-error",
+
+  // Refs Picker (Dialog/Popover)
+  refsPicker: "refs-picker",
+  refsPickerTabs: "refs-picker-tabs",
+  refsPickerTab: "refs-picker-tab",               // suffix -{refType} entry|journal|gcal_event
+  refsPickerSearchInput: "refs-picker-search",
+  refsPickerLoading: "refs-picker-loading",
+  refsPickerEmpty: "refs-picker-empty",
+  refsPickerResultList: "refs-picker-result-list",
+  refsPickerResultItem: "refs-picker-result-item",     // suffix -{refType}-{refId}
+  refsPickerSelectedChips: "refs-picker-selected-chips",
+  refsPickerSelectedChip: "refs-picker-selected-chip", // suffix -{refType}-{refId}
+  refsPickerChipRemove: "refs-picker-chip-remove",     // suffix -{refType}-{refId}
+  refsPickerConfirm: "refs-picker-confirm",
+  refsPickerCancel: "refs-picker-cancel",
+  refsPickerDeletedBadge: "refs-picker-deleted-badge", // 顯示「已刪除」狀態
+
+  // Upcoming Tasks Widget (sidebar)
+  upcomingWidget: "upcoming-tasks-widget",
+  upcomingWidgetTitle: "upcoming-tasks-widget-title",
+  upcomingWidgetEmpty: "upcoming-tasks-widget-empty",
+  upcomingWidgetLoading: "upcoming-tasks-widget-loading",
+  upcomingWidgetItem: "upcoming-tasks-widget-item",   // suffix -{taskId}
+  upcomingWidgetItemDue: "upcoming-tasks-widget-item-due", // suffix -{taskId}
+  upcomingWidgetSeeAll: "upcoming-tasks-widget-see-all",
+  upcomingWidgetOverdueBadge: "upcoming-tasks-widget-overdue-badge", // suffix -{taskId}
+} as const;
+```
+
+## 命名規則
+
+- prefix：列表用 `task-list-`、Sheet 用 `task-sheet-`、RefsPicker 用 `refs-picker-`、Widget 用 `upcoming-tasks-widget-`
+- 動態 suffix：`taskId` / `refType-refId` / `status` / `priority`
+- ref 複合 key：`{refType}-{refId}`，refType 為 `entry` | `journal` | `gcal_event`

--- a/design/pages/projects/README.md
+++ b/design/pages/projects/README.md
@@ -1,0 +1,41 @@
+# Projects 頁面 HTML Mocks — Sprint 10
+
+對應 issue #126、F-031 / F-032。本目錄收錄 4 份靜態 HTML mock，所有 `data-testid` 與 `design/components/projects/testids.md`、`design/components/kanban/testids.md` 對齊，可直接給 QA 對 selector、給 engineer 對 layout。
+
+## 檔案
+
+| 檔案 | 對應 spec / 元件 | 涵蓋狀態 |
+|------|------------------|---------|
+| `projects-list.html` | F-032 `/projects` 列表頁；ProjectListCard、ProjectStatusTabs | active tab 選中、3 張卡（normal / different color / archived 半透明）、empty state（hidden 區塊示範） |
+| `project-detail-board.html` | F-032b `/projects/:id` Board tab；KanbanBoard / Column / Card | 4 欄齊列、進行中欄拖移高亮（drag-over）、drop indicator、被拖卡片 rotate 預覽態 |
+| `project-detail-list.html` | F-032 List tab；TaskListRow + DataTable | 篩選列、4 row（含逾期紅標、refs chip、`來源已刪除` dashed chip、已完成 line-through） |
+| `project-detail-overview.html` | F-032 Overview tab；ProjectOverviewTab | 大進度條、4 個 stat card、時程、描述、最近活動 timeline |
+
+## 使用方式
+
+直接以瀏覽器開啟即可（純靜態 + Tailwind CDN，不需建置）：
+
+```
+open design/pages/projects/projects-list.html
+open design/pages/projects/project-detail-board.html
+open design/pages/projects/project-detail-list.html
+open design/pages/projects/project-detail-overview.html
+```
+
+## testid 對齊
+
+- 全部測試 selector 命名沿用 `PROJECTS_TESTIDS` / `KANBAN_TESTIDS`
+- 動態 ID 以 `-{id}` suffix（範例 mock 用 `t1` / `t4` / `p1` 等假 id）
+- QA 在 e2e 中可：
+
+  ```ts
+  await page.getByTestId(`project-card-${id}`).click();
+  await page.getByTestId(`kanban-column-in_progress`);
+  await page.getByTestId(`task-list-row-${id}`);
+  ```
+
+## 注意事項
+
+- HTML mock **僅用於對齊版型 / a11y / testid**，不是最終實作；正式元件請以 shadcn/ui + Tailwind v4 重新組合
+- 顏色對比度已對照 `design/tokens/projects.json` 採 HSL 值，皆 ≥ WCAG AA
+- 拖移視覺（drop indicator、rotate、drag-over ring）在 mock 中以靜態狀態呈現，實際由 `@dnd-kit` 動態切換

--- a/design/pages/projects/project-detail-board.html
+++ b/design/pages/projects/project-detail-board.html
@@ -1,0 +1,160 @@
+<!DOCTYPE html>
+<html lang="zh-Hant">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width,initial-scale=1" />
+  <title>Project Detail · Board — Mock</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <style>
+    body { font-family: 'Inter', system-ui, -apple-system, 'PingFang TC', sans-serif; }
+    .col { background: hsl(240 4.8% 97%); border-radius: 8px; }
+    .col[data-drag-over="true"] { background: hsl(217 91% 95%); box-shadow: 0 0 0 2px hsl(217 91% 60%); }
+    .card { background: #fff; border-radius: 6px; box-shadow: 0 1px 2px 0 rgb(0 0 0 / 0.06); padding: 10px 12px; }
+    .card[data-dragging="true"] { transform: rotate(2deg); box-shadow: 0 12px 24px -8px rgb(0 0 0 / 0.30), 0 0 0 2px hsl(217 91% 60% / 0.40); }
+    .badge { display: inline-flex; align-items: center; gap: 3px; padding: 1px 6px; border-radius: 9999px; font-size: 10px; font-weight: 500; border: 1px solid; }
+    .pri-low { background: hsl(240 4.8% 95.9%); color: hsl(240 5% 30%); border-color: hsl(240 5.9% 80%); }
+    .pri-normal { background: hsl(217 91% 95%); color: hsl(217 91% 30%); border-color: hsl(217 91% 75%); }
+    .pri-high { background: hsl(25 95% 94%); color: hsl(25 95% 30%); border-color: hsl(25 95% 70%); }
+    .pri-urgent { background: hsl(0 84% 95%); color: hsl(0 84% 35%); border-color: hsl(0 84% 70%); }
+    .drop-indicator { height: 3px; background: hsl(217 91% 55%); border-radius: 2px; margin: 4px 0; }
+  </style>
+</head>
+<body class="bg-[hsl(240,4.8%,98%)] text-[hsl(240,10%,4%)] min-h-screen">
+  <main data-testid="project-detail-page" class="mx-auto max-w-7xl px-6 py-6">
+
+    <!-- Header -->
+    <header data-testid="project-detail-header" class="mb-4 flex items-center gap-3">
+      <span aria-hidden="true" class="h-6 w-1.5 rounded-full" style="background: #3b82f6"></span>
+      <div class="flex-1">
+        <nav class="text-xs text-[hsl(240,4%,45%)]"><a href="#" class="hover:underline">專案</a> / aibo v2</nav>
+        <h1 data-testid="project-detail-header-name" class="text-xl font-semibold">aibo v2</h1>
+      </div>
+      <button data-testid="project-detail-header-edit" class="inline-flex h-9 items-center gap-1 rounded border bg-white px-3 text-sm hover:bg-[hsl(240,4.8%,95.9%)]">編輯</button>
+      <button data-testid="project-detail-new-task" class="inline-flex h-9 items-center gap-1.5 rounded bg-[hsl(217,91%,50%)] px-3 text-sm font-medium text-white">
+        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" aria-hidden="true"><path d="M12 5v14M5 12h14"/></svg>
+        新增任務
+      </button>
+    </header>
+
+    <!-- Tabs -->
+    <div role="tablist" data-testid="project-detail-tabs" class="mb-5 inline-flex rounded-md border bg-white p-1">
+      <button role="tab" aria-selected="true" data-testid="project-detail-tab-board" class="rounded px-4 py-1.5 text-sm font-medium bg-[hsl(240,4.8%,95.9%)]">看板</button>
+      <button role="tab" aria-selected="false" data-testid="project-detail-tab-list" class="rounded px-4 py-1.5 text-sm text-[hsl(240,4%,45%)]">列表</button>
+      <button role="tab" aria-selected="false" data-testid="project-detail-tab-overview" class="rounded px-4 py-1.5 text-sm text-[hsl(240,4%,45%)]">總覽</button>
+    </div>
+
+    <!-- Kanban Board -->
+    <section data-testid="kanban-board" class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-3">
+
+      <!-- TODO column -->
+      <div role="list" data-testid="kanban-column-todo" class="col p-3" aria-label="待辦">
+        <header class="mb-2 flex items-center justify-between px-1">
+          <h2 class="flex items-center gap-1.5 text-sm font-semibold text-[hsl(240,5%,25%)]">
+            <span aria-hidden="true" class="h-2 w-2 rounded-full" style="background: hsl(240 5% 60%)"></span>
+            待辦
+            <span class="rounded bg-white px-1.5 text-[10px] tabular-nums">3</span>
+          </h2>
+          <button class="inline-flex h-6 w-6 items-center justify-center rounded hover:bg-white" aria-label="在待辦欄新增任務">
+            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="M12 5v14M5 12h14"/></svg>
+          </button>
+        </header>
+        <ul class="space-y-2">
+          <li data-testid="kanban-card-t1" class="card">
+            <p class="text-sm font-medium">設計 schema</p>
+            <div class="mt-1.5 flex items-center gap-1.5 text-xs text-[hsl(240,4%,45%)]">
+              <span class="badge pri-high">高</span>
+              <span class="ml-auto">4/30</span>
+            </div>
+          </li>
+          <li data-testid="kanban-card-t2" class="card">
+            <p class="text-sm font-medium">研究 dnd-kit 鍵盤導航</p>
+            <div class="mt-1.5 flex items-center gap-1.5 text-xs text-[hsl(240,4%,45%)]">
+              <span class="badge pri-normal">一般</span>
+              <span class="ml-auto">5/02</span>
+            </div>
+          </li>
+          <li data-testid="kanban-card-t3" class="card">
+            <p class="text-sm font-medium">寫部落格：Atomic Habits 心得</p>
+            <div class="mt-1.5 flex items-center gap-1.5 text-xs text-[hsl(240,4%,45%)]">
+              <span class="badge pri-low">低</span>
+            </div>
+          </li>
+        </ul>
+      </div>
+
+      <!-- IN PROGRESS column with drag-over preview -->
+      <div role="list" data-testid="kanban-column-in_progress" data-drag-over="true" class="col p-3" aria-label="進行中（拖移至此）">
+        <header class="mb-2 flex items-center justify-between px-1">
+          <h2 class="flex items-center gap-1.5 text-sm font-semibold text-[hsl(240,5%,25%)]">
+            <span aria-hidden="true" class="h-2 w-2 rounded-full" style="background: hsl(217 91% 50%)"></span>
+            進行中
+            <span class="rounded bg-white px-1.5 text-[10px] tabular-nums">2</span>
+          </h2>
+        </header>
+        <ul class="space-y-2">
+          <li data-testid="kanban-card-t4" class="card">
+            <p class="text-sm font-medium">F-031 後端 API</p>
+            <div class="mt-1.5 flex items-center gap-1.5 text-xs text-[hsl(240,4%,45%)]">
+              <span class="badge pri-urgent">急迫</span>
+              <span class="ml-auto text-[hsl(0,84%,40%)] font-medium">逾期 1 天</span>
+            </div>
+          </li>
+          <!-- Drop indicator (拖曳預覽態) -->
+          <div data-testid="kanban-drop-indicator" class="drop-indicator" aria-hidden="true"></div>
+          <li data-testid="kanban-card-t5-dragging" class="card" data-dragging="true">
+            <p class="text-sm font-medium">F-032 前端 Kanban UI</p>
+            <div class="mt-1.5 flex items-center gap-1.5 text-xs text-[hsl(240,4%,45%)]">
+              <span class="badge pri-high">高</span>
+              <span class="ml-auto">5/05</span>
+            </div>
+          </li>
+        </ul>
+      </div>
+
+      <!-- BLOCKED column -->
+      <div role="list" data-testid="kanban-column-blocked" class="col p-3" aria-label="卡住">
+        <header class="mb-2 flex items-center justify-between px-1">
+          <h2 class="flex items-center gap-1.5 text-sm font-semibold text-[hsl(240,5%,25%)]">
+            <span aria-hidden="true" class="h-2 w-2 rounded-full" style="background: hsl(0 84% 55%)"></span>
+            卡住
+            <span class="rounded bg-white px-1.5 text-[10px] tabular-nums">1</span>
+          </h2>
+        </header>
+        <ul class="space-y-2">
+          <li data-testid="kanban-card-t6" class="card">
+            <p class="text-sm font-medium">等 design tokens 確認</p>
+            <div class="mt-1.5 flex items-center gap-1.5 text-xs text-[hsl(240,4%,45%)]">
+              <span class="badge pri-normal">一般</span>
+            </div>
+          </li>
+        </ul>
+      </div>
+
+      <!-- DONE column -->
+      <div role="list" data-testid="kanban-column-done" class="col p-3" aria-label="完成">
+        <header class="mb-2 flex items-center justify-between px-1">
+          <h2 class="flex items-center gap-1.5 text-sm font-semibold text-[hsl(240,5%,25%)]">
+            <span aria-hidden="true" class="h-2 w-2 rounded-full" style="background: hsl(142 76% 36%)"></span>
+            完成
+            <span class="rounded bg-white px-1.5 text-[10px] tabular-nums">12</span>
+          </h2>
+        </header>
+        <ul class="space-y-2">
+          <li data-testid="kanban-card-t7" class="card opacity-70">
+            <p class="text-sm font-medium line-through text-[hsl(240,4%,45%)]">建立 GitHub repo</p>
+          </li>
+          <li data-testid="kanban-card-t8" class="card opacity-70">
+            <p class="text-sm font-medium line-through text-[hsl(240,4%,45%)]">spec / tech survey</p>
+          </li>
+        </ul>
+      </div>
+
+    </section>
+
+    <!-- Screen reader instructions placeholder -->
+    <div class="sr-only" aria-live="polite" data-testid="kanban-sr-announcer">
+      可用 Tab 進入 task，按 Space 開始拖移，方向鍵移動，Enter 放下，Esc 取消。
+    </div>
+  </main>
+</body>
+</html>

--- a/design/pages/projects/project-detail-list.html
+++ b/design/pages/projects/project-detail-list.html
@@ -1,0 +1,137 @@
+<!DOCTYPE html>
+<html lang="zh-Hant">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width,initial-scale=1" />
+  <title>Project Detail · List — Mock</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <style>
+    body { font-family: 'Inter', system-ui, -apple-system, 'PingFang TC', sans-serif; }
+    th { font-weight: 500; font-size: 12px; color: hsl(240 4% 45%); text-align: left; padding: 10px 12px; border-bottom: 1px solid hsl(240 5.9% 90%); }
+    td { padding: 12px; border-bottom: 1px solid hsl(240 5.9% 92%); font-size: 14px; vertical-align: middle; }
+    tr:hover td { background: hsl(240 4.8% 97%); }
+    .badge { display: inline-flex; align-items: center; gap: 4px; padding: 2px 8px; border-radius: 9999px; font-size: 11px; font-weight: 500; border: 1px solid; }
+    .st-todo { background: hsl(240 4.8% 95.9%); color: hsl(240 5% 25%); border-color: hsl(240 5.9% 80%); }
+    .st-ip { background: hsl(217 91% 95%); color: hsl(217 91% 28%); border-color: hsl(217 91% 75%); }
+    .st-blocked { background: hsl(0 84% 95%); color: hsl(0 84% 35%); border-color: hsl(0 84% 70%); }
+    .st-done { background: hsl(142 60% 92%); color: hsl(142 76% 25%); border-color: hsl(142 60% 70%); }
+    .pri-low { background: hsl(240 4.8% 95.9%); color: hsl(240 5% 30%); border-color: hsl(240 5.9% 80%); }
+    .pri-normal { background: hsl(217 91% 95%); color: hsl(217 91% 30%); border-color: hsl(217 91% 75%); }
+    .pri-high { background: hsl(25 95% 94%); color: hsl(25 95% 30%); border-color: hsl(25 95% 70%); }
+    .pri-urgent { background: hsl(0 84% 95%); color: hsl(0 84% 35%); border-color: hsl(0 84% 70%); }
+    .ref { display: inline-flex; align-items: center; gap: 3px; padding: 1px 6px; border: 1px solid hsl(240 5.9% 88%); border-radius: 9999px; font-size: 10px; background: hsl(240 4.8% 97%); }
+    .ref-missing { border-style: dashed; border-color: hsl(0 84% 60% / 0.4); color: hsl(0 84% 40%); background: hsl(0 84% 97%); }
+  </style>
+</head>
+<body class="bg-[hsl(240,4.8%,98%)] text-[hsl(240,10%,4%)] min-h-screen">
+  <main data-testid="project-detail-page" class="mx-auto max-w-7xl px-6 py-6">
+    <!-- Header reused -->
+    <header data-testid="project-detail-header" class="mb-4 flex items-center gap-3">
+      <span aria-hidden="true" class="h-6 w-1.5 rounded-full" style="background: #3b82f6"></span>
+      <div class="flex-1">
+        <nav class="text-xs text-[hsl(240,4%,45%)]"><a href="#" class="hover:underline">專案</a> / aibo v2</nav>
+        <h1 data-testid="project-detail-header-name" class="text-xl font-semibold">aibo v2</h1>
+      </div>
+      <button data-testid="project-detail-header-edit" class="inline-flex h-9 items-center gap-1 rounded border bg-white px-3 text-sm hover:bg-[hsl(240,4.8%,95.9%)]">編輯</button>
+      <button data-testid="project-detail-new-task" class="inline-flex h-9 items-center gap-1.5 rounded bg-[hsl(217,91%,50%)] px-3 text-sm font-medium text-white">
+        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" aria-hidden="true"><path d="M12 5v14M5 12h14"/></svg>
+        新增任務
+      </button>
+    </header>
+
+    <!-- Tabs -->
+    <div role="tablist" data-testid="project-detail-tabs" class="mb-5 inline-flex rounded-md border bg-white p-1">
+      <button role="tab" aria-selected="false" data-testid="project-detail-tab-board" class="rounded px-4 py-1.5 text-sm text-[hsl(240,4%,45%)]">看板</button>
+      <button role="tab" aria-selected="true" data-testid="project-detail-tab-list" class="rounded px-4 py-1.5 text-sm font-medium bg-[hsl(240,4.8%,95.9%)]">列表</button>
+      <button role="tab" aria-selected="false" data-testid="project-detail-tab-overview" class="rounded px-4 py-1.5 text-sm text-[hsl(240,4%,45%)]">總覽</button>
+    </div>
+
+    <!-- Filter / search bar -->
+    <div class="mb-3 flex items-center gap-2">
+      <div class="relative flex-1 max-w-sm">
+        <svg class="absolute left-2.5 top-1/2 -translate-y-1/2" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><circle cx="11" cy="11" r="8"/><path d="m21 21-4.3-4.3"/></svg>
+        <input data-testid="task-list-search" type="search" placeholder="搜尋任務…" class="h-9 w-full rounded-md border bg-white pl-8 pr-3 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[hsl(217,91%,50%)]" aria-label="搜尋任務"/>
+      </div>
+      <select data-testid="task-list-filter-status" class="h-9 rounded-md border bg-white px-3 text-sm" aria-label="狀態篩選">
+        <option>全部狀態</option><option>待辦</option><option>進行中</option><option>卡住</option><option>完成</option>
+      </select>
+      <select data-testid="task-list-filter-priority" class="h-9 rounded-md border bg-white px-3 text-sm" aria-label="優先級篩選">
+        <option>全部優先級</option><option>急迫</option><option>高</option><option>一般</option><option>低</option>
+      </select>
+    </div>
+
+    <!-- Table -->
+    <div data-testid="task-list-table" class="overflow-hidden rounded-lg border bg-white">
+      <table class="w-full">
+        <thead>
+          <tr>
+            <th style="width: 40%">標題</th>
+            <th style="width: 110px">狀態</th>
+            <th style="width: 90px">優先級</th>
+            <th style="width: 110px">截止</th>
+            <th>關聯</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr data-testid="task-list-row-t1">
+            <td>
+              <div class="flex items-center gap-2">
+                <input type="checkbox" data-testid="task-list-row-t1-check" aria-label="完成 設計 schema"/>
+                <span class="font-medium">設計 schema</span>
+              </div>
+            </td>
+            <td><span class="badge st-todo">待辦</span></td>
+            <td><span class="badge pri-high">高</span></td>
+            <td class="tabular-nums">4/30</td>
+            <td>
+              <span class="ref">📄 entry：技術選型</span>
+              <span class="ref">📅 4/29 規劃會議</span>
+            </td>
+          </tr>
+          <tr data-testid="task-list-row-t4">
+            <td>
+              <div class="flex items-center gap-2">
+                <input type="checkbox" aria-label="完成 F-031 後端 API"/>
+                <span class="font-medium">F-031 後端 API</span>
+              </div>
+            </td>
+            <td><span class="badge st-ip">進行中</span></td>
+            <td><span class="badge pri-urgent">急迫</span></td>
+            <td class="text-[hsl(0,84%,40%)] font-medium">逾期 1 天</td>
+            <td>
+              <span class="ref">📔 04-23 日記</span>
+              <span class="ref ref-missing">⚠ 來源已刪除</span>
+            </td>
+          </tr>
+          <tr data-testid="task-list-row-t6">
+            <td>
+              <div class="flex items-center gap-2">
+                <input type="checkbox" aria-label="完成 等 design tokens 確認"/>
+                <span class="font-medium">等 design tokens 確認</span>
+              </div>
+            </td>
+            <td><span class="badge st-blocked">卡住</span></td>
+            <td><span class="badge pri-normal">一般</span></td>
+            <td class="text-[hsl(240,4%,45%)]">—</td>
+            <td>—</td>
+          </tr>
+          <tr data-testid="task-list-row-t7" class="opacity-70">
+            <td>
+              <div class="flex items-center gap-2">
+                <input type="checkbox" checked aria-label="已完成 建立 GitHub repo"/>
+                <span class="font-medium line-through text-[hsl(240,4%,45%)]">建立 GitHub repo</span>
+              </div>
+            </td>
+            <td><span class="badge st-done">完成</span></td>
+            <td><span class="badge pri-low">低</span></td>
+            <td class="text-[hsl(240,4%,45%)]">4/20</td>
+            <td>—</td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+
+    <p class="mt-3 text-xs text-[hsl(240,4%,45%)]" data-testid="task-list-footer">共 4 筆</p>
+  </main>
+</body>
+</html>

--- a/design/pages/projects/project-detail-overview.html
+++ b/design/pages/projects/project-detail-overview.html
@@ -1,0 +1,113 @@
+<!DOCTYPE html>
+<html lang="zh-Hant">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width,initial-scale=1" />
+  <title>Project Detail · Overview — Mock</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <style>
+    body { font-family: 'Inter', system-ui, -apple-system, 'PingFang TC', sans-serif; }
+    .stat { background: #fff; border: 1px solid hsl(240 5.9% 90%); border-radius: 8px; padding: 16px; }
+    .progress-bar { height: 10px; background: hsl(240 4.8% 95.9%); border-radius: 9999px; overflow: hidden; }
+    .progress-fill { height: 100%; background: hsl(217 91% 50%); transition: width .2s; }
+  </style>
+</head>
+<body class="bg-[hsl(240,4.8%,98%)] text-[hsl(240,10%,4%)] min-h-screen">
+  <main data-testid="project-detail-page" class="mx-auto max-w-5xl px-6 py-6">
+    <!-- Header -->
+    <header data-testid="project-detail-header" class="mb-4 flex items-center gap-3">
+      <span aria-hidden="true" class="h-6 w-1.5 rounded-full" style="background: #3b82f6"></span>
+      <div class="flex-1">
+        <nav class="text-xs text-[hsl(240,4%,45%)]"><a href="#" class="hover:underline">專案</a> / aibo v2</nav>
+        <h1 data-testid="project-detail-header-name" class="text-xl font-semibold">aibo v2</h1>
+      </div>
+      <button data-testid="project-detail-header-edit" class="inline-flex h-9 items-center gap-1 rounded border bg-white px-3 text-sm hover:bg-[hsl(240,4.8%,95.9%)]">編輯</button>
+    </header>
+
+    <!-- Tabs -->
+    <div role="tablist" data-testid="project-detail-tabs" class="mb-6 inline-flex rounded-md border bg-white p-1">
+      <button role="tab" aria-selected="false" data-testid="project-detail-tab-board" class="rounded px-4 py-1.5 text-sm text-[hsl(240,4%,45%)]">看板</button>
+      <button role="tab" aria-selected="false" data-testid="project-detail-tab-list" class="rounded px-4 py-1.5 text-sm text-[hsl(240,4%,45%)]">列表</button>
+      <button role="tab" aria-selected="true" data-testid="project-detail-tab-overview" class="rounded px-4 py-1.5 text-sm font-medium bg-[hsl(240,4.8%,95.9%)]">總覽</button>
+    </div>
+
+    <!-- Progress -->
+    <section data-testid="project-overview-progress" class="mb-6 rounded-lg border bg-white p-5">
+      <div class="mb-2 flex items-baseline justify-between">
+        <h2 class="text-sm font-semibold text-[hsl(240,5%,25%)]">整體進度</h2>
+        <span class="text-2xl font-semibold tabular-nums">60<span class="text-base text-[hsl(240,4%,45%)]">%</span></span>
+      </div>
+      <div data-testid="project-overview-progress-bar" class="progress-bar" role="progressbar" aria-valuenow="60" aria-valuemin="0" aria-valuemax="100" aria-label="整體進度 60%">
+        <div class="progress-fill" style="width: 60%"></div>
+      </div>
+      <p class="mt-2 text-xs text-[hsl(240,4%,45%)]">12 / 20 完成</p>
+    </section>
+
+    <!-- Stats -->
+    <section data-testid="project-overview-stats" class="mb-6 grid grid-cols-2 sm:grid-cols-4 gap-3">
+      <div data-testid="project-overview-stat-total" class="stat">
+        <p class="text-xs text-[hsl(240,4%,45%)] mb-1">全部</p>
+        <p class="text-2xl font-semibold tabular-nums">20</p>
+      </div>
+      <div data-testid="project-overview-stat-done" class="stat">
+        <p class="text-xs text-[hsl(240,4%,45%)] mb-1 flex items-center gap-1">
+          <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="hsl(142 76% 36%)" stroke-width="2.5" aria-hidden="true"><path d="M20 6 9 17l-5-5"/></svg>
+          完成
+        </p>
+        <p class="text-2xl font-semibold tabular-nums text-[hsl(142,76%,25%)]">12</p>
+      </div>
+      <div data-testid="project-overview-stat-blocked" class="stat">
+        <p class="text-xs text-[hsl(240,4%,45%)] mb-1 flex items-center gap-1">
+          <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="hsl(0 84% 55%)" stroke-width="2" aria-hidden="true"><path d="M12 2 2 22h20L12 2z"/><path d="M12 9v4"/><circle cx="12" cy="17" r="0.5"/></svg>
+          卡住
+        </p>
+        <p class="text-2xl font-semibold tabular-nums text-[hsl(0,84%,35%)]">1</p>
+      </div>
+      <div data-testid="project-overview-stat-overdue" class="stat">
+        <p class="text-xs text-[hsl(240,4%,45%)] mb-1 flex items-center gap-1">
+          <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="hsl(0 84% 55%)" stroke-width="2" aria-hidden="true"><circle cx="12" cy="12" r="10"/><path d="M12 6v6l4 2"/></svg>
+          逾期
+        </p>
+        <p class="text-2xl font-semibold tabular-nums text-[hsl(0,84%,35%)]">3</p>
+      </div>
+    </section>
+
+    <!-- Timeline -->
+    <section data-testid="project-overview-timeline" class="mb-6 rounded-lg border bg-white p-5">
+      <h2 class="text-sm font-semibold text-[hsl(240,5%,25%)] mb-2">時程</h2>
+      <p class="flex items-center gap-2 text-sm">
+        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><rect x="3" y="4" width="18" height="18" rx="2"/><path d="M16 2v4M8 2v4M3 10h18"/></svg>
+        <span class="tabular-nums">2026-04-01</span>
+        <span aria-hidden="true">→</span>
+        <span class="tabular-nums">2026-06-30</span>
+        <span class="ml-2 text-[hsl(240,4%,45%)]">（剩 67 天）</span>
+      </p>
+    </section>
+
+    <!-- Description -->
+    <section data-testid="project-overview-description" class="mb-6 rounded-lg border bg-white p-5">
+      <h2 class="text-sm font-semibold text-[hsl(240,5%,25%)] mb-2">描述</h2>
+      <p class="text-sm leading-relaxed">知識庫 + LLM 代理人格，整合 entries / journal / gcal 三向資料；目標讓 LLM 取代/代理使用者人格而非單純知識管理。</p>
+    </section>
+
+    <!-- Activity -->
+    <section data-testid="project-overview-activity" class="rounded-lg border bg-white p-5">
+      <h2 class="text-sm font-semibold text-[hsl(240,5%,25%)] mb-3">最近活動</h2>
+      <ul class="space-y-2.5 text-sm">
+        <li data-testid="project-overview-activity-item-0" class="flex gap-3">
+          <span class="mt-1.5 h-1.5 w-1.5 shrink-0 rounded-full bg-[hsl(142,76%,36%)]" aria-hidden="true"></span>
+          <span class="flex-1">完成「設計 schema」<span class="ml-2 text-xs text-[hsl(240,4%,45%)]">2 小時前</span></span>
+        </li>
+        <li data-testid="project-overview-activity-item-1" class="flex gap-3">
+          <span class="mt-1.5 h-1.5 w-1.5 shrink-0 rounded-full bg-[hsl(217,91%,50%)]" aria-hidden="true"></span>
+          <span class="flex-1">新增「資料庫 migration」<span class="ml-2 text-xs text-[hsl(240,4%,45%)]">昨天</span></span>
+        </li>
+        <li data-testid="project-overview-activity-item-2" class="flex gap-3">
+          <span class="mt-1.5 h-1.5 w-1.5 shrink-0 rounded-full bg-[hsl(240,5%,60%)]" aria-hidden="true"></span>
+          <span class="flex-1">建立此專案<span class="ml-2 text-xs text-[hsl(240,4%,45%)]">3 天前</span></span>
+        </li>
+      </ul>
+    </section>
+  </main>
+</body>
+</html>

--- a/design/pages/projects/projects-list.html
+++ b/design/pages/projects/projects-list.html
@@ -1,0 +1,158 @@
+<!DOCTYPE html>
+<html lang="zh-Hant">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width,initial-scale=1" />
+  <title>Projects List — Mock</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <script>
+    tailwind.config = {
+      theme: {
+        extend: {
+          colors: {
+            border: "hsl(240 5.9% 90%)",
+            ring: "hsl(217 91% 50%)",
+            card: "hsl(0 0% 100%)",
+            muted: { DEFAULT: "hsl(240 4.8% 95.9%)", foreground: "hsl(240 4% 45%)" },
+            primary: { DEFAULT: "hsl(217 91% 50%)", foreground: "#fff" },
+            destructive: { DEFAULT: "hsl(0 84% 50%)", foreground: "#fff" },
+          },
+        },
+      },
+    };
+  </script>
+  <style>
+    body { font-family: 'Inter', system-ui, -apple-system, 'PingFang TC', sans-serif; }
+    .stripe { width: 4px; flex-shrink: 0; }
+    .progress-bar { height: 6px; background: hsl(240 4.8% 95.9%); border-radius: 9999px; overflow: hidden; }
+    .progress-fill { height: 100%; background: hsl(217 91% 50%); }
+    .badge { display: inline-flex; align-items: center; gap: 4px; padding: 2px 8px; border-radius: 9999px; font-size: 11px; font-weight: 500; border: 1px solid; }
+    .badge-active { background: hsl(142 60% 92%); color: hsl(142 76% 25%); border-color: hsl(142 60% 70%); }
+    .badge-paused { background: hsl(38 92% 92%); color: hsl(38 92% 28%); border-color: hsl(38 92% 70%); }
+    .badge-done { background: hsl(217 91% 94%); color: hsl(217 91% 28%); border-color: hsl(217 91% 70%); }
+    .badge-archived { background: hsl(240 4% 92%); color: hsl(240 5% 40%); border-color: hsl(240 5% 70%); }
+  </style>
+</head>
+<body class="bg-[hsl(240,4.8%,98%)] text-[hsl(240,10%,4%)] min-h-screen">
+  <main data-testid="projects-list-page" class="mx-auto max-w-6xl px-6 py-8">
+    <!-- Page header -->
+    <header class="mb-6 flex items-center justify-between">
+      <div>
+        <h1 class="text-2xl font-semibold">專案</h1>
+        <p class="text-sm text-muted-foreground mt-1">追蹤所有進行中的專案與任務</p>
+      </div>
+      <button
+        type="button"
+        data-testid="projects-list-create"
+        class="inline-flex h-10 items-center gap-1.5 rounded-md bg-primary px-4 text-sm font-medium text-white shadow-sm hover:bg-primary/90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+      >
+        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M12 5v14M5 12h14"/></svg>
+        新增專案
+      </button>
+    </header>
+
+    <!-- Status tabs -->
+    <div role="tablist" data-testid="projects-status-tabs" class="mb-6 inline-flex rounded-md border bg-card p-1">
+      <button role="tab" aria-selected="true" data-testid="projects-status-tab-active" class="rounded px-3 py-1.5 text-sm font-medium bg-muted text-foreground">
+        進行中 <span class="ml-1 text-xs text-muted-foreground tabular-nums">3</span>
+      </button>
+      <button role="tab" aria-selected="false" data-testid="projects-status-tab-paused" class="rounded px-3 py-1.5 text-sm text-muted-foreground hover:text-foreground">
+        暫停 <span class="ml-1 text-xs tabular-nums">1</span>
+      </button>
+      <button role="tab" aria-selected="false" data-testid="projects-status-tab-done" class="rounded px-3 py-1.5 text-sm text-muted-foreground hover:text-foreground">
+        已完成 <span class="ml-1 text-xs tabular-nums">2</span>
+      </button>
+      <button role="tab" aria-selected="false" data-testid="projects-status-tab-archived" class="rounded px-3 py-1.5 text-sm text-muted-foreground hover:text-foreground">
+        封存 <span class="ml-1 text-xs tabular-nums">0</span>
+      </button>
+    </div>
+
+    <!-- Grid -->
+    <div data-testid="projects-list-grid" class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+
+      <!-- Card 1 -->
+      <div data-testid="project-card-p1" class="group relative flex overflow-hidden rounded-lg border bg-card transition-all hover:bg-muted/40 hover:shadow-sm">
+        <span aria-hidden="true" data-testid="project-card-color-stripe" class="stripe" style="background: #3b82f6"></span>
+        <button class="flex-1 p-4 text-left">
+          <div class="mb-1 flex items-start gap-2">
+            <h3 data-testid="project-card-name" class="line-clamp-1 flex-1 text-base font-semibold leading-snug">aibo v2</h3>
+            <span data-testid="project-card-status-badge" class="badge badge-active">進行中</span>
+          </div>
+          <p data-testid="project-card-description" class="mb-3 line-clamp-2 text-sm text-muted-foreground">知識庫 + LLM 代理人格，整合 entries / journal / gcal 三向資料</p>
+          <div class="mb-2 flex items-center gap-3">
+            <div class="progress-bar flex-1" data-testid="project-card-progress-bar" role="progressbar" aria-valuenow="60" aria-valuemin="0" aria-valuemax="100" aria-label="進度 60%"><div class="progress-fill" style="width: 60%"></div></div>
+            <span data-testid="project-card-progress-label" class="w-10 text-right text-xs font-medium tabular-nums text-muted-foreground">60%</span>
+          </div>
+          <div class="flex items-center gap-3 text-xs text-muted-foreground">
+            <span data-testid="project-card-open-task-count">12 未完成</span>
+            <span data-testid="project-card-next-due" class="flex items-center gap-1 truncate">
+              <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><rect x="3" y="4" width="18" height="18" rx="2"/><path d="M16 2v4M8 2v4M3 10h18"/></svg>
+              下一個：4/30 設計 schema
+            </span>
+          </div>
+        </button>
+        <div class="absolute right-2 top-2 opacity-0 transition-opacity group-hover:opacity-100">
+          <button data-testid="project-card-menu" class="inline-flex h-8 w-8 items-center justify-center rounded hover:bg-muted" aria-label="aibo v2 動作選單">
+            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><circle cx="5" cy="12" r="1.5"/><circle cx="12" cy="12" r="1.5"/><circle cx="19" cy="12" r="1.5"/></svg>
+          </button>
+        </div>
+      </div>
+
+      <!-- Card 2 -->
+      <div data-testid="project-card-p2" class="group relative flex overflow-hidden rounded-lg border bg-card transition-all hover:bg-muted/40 hover:shadow-sm">
+        <span aria-hidden="true" class="stripe" style="background: #10b981"></span>
+        <button class="flex-1 p-4 text-left">
+          <div class="mb-1 flex items-start gap-2">
+            <h3 class="line-clamp-1 flex-1 text-base font-semibold">習慣養成</h3>
+            <span class="badge badge-active">進行中</span>
+          </div>
+          <p class="mb-3 line-clamp-2 text-sm text-muted-foreground">每日運動、閱讀、寫作三項習慣</p>
+          <div class="mb-2 flex items-center gap-3">
+            <div class="progress-bar flex-1"><div class="progress-fill" style="width: 35%; background: #10b981"></div></div>
+            <span class="w-10 text-right text-xs font-medium tabular-nums text-muted-foreground">35%</span>
+          </div>
+          <div class="flex items-center gap-3 text-xs text-muted-foreground">
+            <span>7 未完成</span>
+            <span class="flex items-center gap-1">
+              <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><rect x="3" y="4" width="18" height="18" rx="2"/><path d="M16 2v4M8 2v4M3 10h18"/></svg>
+              下一個：今天 晨跑 5km
+            </span>
+          </div>
+        </button>
+      </div>
+
+      <!-- Card 3：封存態（opacity-70） -->
+      <div data-testid="project-card-p3" class="group relative flex overflow-hidden rounded-lg border bg-card opacity-70 transition-all hover:bg-muted/40">
+        <span aria-hidden="true" class="stripe" style="background: #71717a; filter: saturate(0.5)"></span>
+        <button class="flex-1 p-4 text-left">
+          <div class="mb-1 flex items-start gap-2">
+            <h3 class="line-clamp-1 flex-1 text-base font-semibold">2025 Q4 OKR</h3>
+            <span class="badge badge-archived">封存</span>
+          </div>
+          <p class="mb-3 line-clamp-2 text-sm text-muted-foreground">已歸檔的舊季目標</p>
+          <div class="mb-2 flex items-center gap-3">
+            <div class="progress-bar flex-1"><div class="progress-fill" style="width: 100%; background: #71717a"></div></div>
+            <span class="w-10 text-right text-xs font-medium tabular-nums text-muted-foreground">100%</span>
+          </div>
+          <div class="flex items-center gap-3 text-xs text-muted-foreground">
+            <span>0 未完成</span>
+          </div>
+        </button>
+      </div>
+
+    </div>
+
+    <!-- Empty state（額外示範，預設 hidden） -->
+    <section data-testid="projects-list-empty" hidden class="mt-12 rounded-lg border border-dashed bg-card p-10 text-center">
+      <div class="mx-auto mb-3 inline-flex h-12 w-12 items-center justify-center rounded-full bg-muted text-muted-foreground">
+        <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="M3 7l9-4 9 4v10l-9 4-9-4V7z"/></svg>
+      </div>
+      <h2 class="text-base font-semibold">尚無專案</h2>
+      <p class="mt-1 text-sm text-muted-foreground">建立第一個專案來組織你的任務與筆記</p>
+      <button data-testid="projects-list-empty-cta" class="mt-4 inline-flex h-10 items-center gap-1.5 rounded-md bg-primary px-4 text-sm font-medium text-white">
+        新增專案
+      </button>
+    </section>
+  </main>
+</body>
+</html>

--- a/design/tokens/projects.json
+++ b/design/tokens/projects.json
@@ -1,0 +1,136 @@
+{
+  "$comment": "Sprint 10 Projects / Tasks / Kanban 配色 tokens。語意 token，不直接寫死於元件樣式；統一以 CSS 變數 / Tailwind utility 引用。色彩皆通過 WCAG 2.1 AA（>= 4.5:1，文字搭配對應 -foreground）。色盲友善：每個語意都同時提供 emoji icon / 文字 label，顏色不作為唯一資訊載體。",
+  "priority": {
+    "low": {
+      "label": "低",
+      "icon": "ArrowDownIcon",
+      "bg": "hsl(240 4.8% 95.9%)",
+      "fg": "hsl(240 5% 30%)",
+      "border": "hsl(240 5.9% 80%)",
+      "ring": "hsl(240 5% 50%)"
+    },
+    "normal": {
+      "label": "一般",
+      "icon": "MinusIcon",
+      "bg": "hsl(217 91% 95%)",
+      "fg": "hsl(217 91% 30%)",
+      "border": "hsl(217 91% 75%)",
+      "ring": "hsl(217 91% 50%)"
+    },
+    "high": {
+      "label": "高",
+      "icon": "ArrowUpIcon",
+      "bg": "hsl(25 95% 94%)",
+      "fg": "hsl(25 95% 30%)",
+      "border": "hsl(25 95% 70%)",
+      "ring": "hsl(25 95% 50%)"
+    },
+    "urgent": {
+      "label": "急迫",
+      "icon": "FlameIcon",
+      "bg": "hsl(0 84% 95%)",
+      "fg": "hsl(0 84% 35%)",
+      "border": "hsl(0 84% 70%)",
+      "ring": "hsl(0 84% 55%)"
+    }
+  },
+  "task-status": {
+    "todo": {
+      "label": "待辦",
+      "icon": "CircleIcon",
+      "bg": "hsl(240 4.8% 95.9%)",
+      "fg": "hsl(240 5% 25%)",
+      "dot": "hsl(240 5% 60%)"
+    },
+    "in_progress": {
+      "label": "進行中",
+      "icon": "PlayCircleIcon",
+      "bg": "hsl(217 91% 95%)",
+      "fg": "hsl(217 91% 28%)",
+      "dot": "hsl(217 91% 50%)"
+    },
+    "blocked": {
+      "label": "卡住",
+      "icon": "AlertOctagonIcon",
+      "bg": "hsl(0 84% 95%)",
+      "fg": "hsl(0 84% 35%)",
+      "dot": "hsl(0 84% 55%)"
+    },
+    "done": {
+      "label": "完成",
+      "icon": "CheckCircle2Icon",
+      "bg": "hsl(142 60% 92%)",
+      "fg": "hsl(142 76% 25%)",
+      "dot": "hsl(142 76% 36%)"
+    },
+    "cancelled": {
+      "label": "已取消",
+      "icon": "XCircleIcon",
+      "bg": "hsl(240 4% 92%)",
+      "fg": "hsl(240 5% 45%)",
+      "dot": "hsl(240 5% 65%)"
+    }
+  },
+  "project-status": {
+    "active": {
+      "label": "進行中",
+      "icon": "ZapIcon",
+      "bg": "hsl(142 60% 92%)",
+      "fg": "hsl(142 76% 25%)",
+      "border": "hsl(142 60% 70%)"
+    },
+    "paused": {
+      "label": "暫停",
+      "icon": "PauseCircleIcon",
+      "bg": "hsl(38 92% 92%)",
+      "fg": "hsl(38 92% 28%)",
+      "border": "hsl(38 92% 70%)"
+    },
+    "done": {
+      "label": "已完成",
+      "icon": "CheckCircle2Icon",
+      "bg": "hsl(217 91% 94%)",
+      "fg": "hsl(217 91% 28%)",
+      "border": "hsl(217 91% 70%)"
+    },
+    "archived": {
+      "label": "封存",
+      "icon": "ArchiveIcon",
+      "bg": "hsl(240 4% 92%)",
+      "fg": "hsl(240 5% 40%)",
+      "border": "hsl(240 5% 70%)"
+    }
+  },
+  "kanban": {
+    "column-bg": "hsl(240 4.8% 97%)",
+    "column-bg-dark": "hsl(240 6% 12%)",
+    "column-header-fg": "hsl(240 5% 25%)",
+    "column-drag-over-bg": "hsl(217 91% 95%)",
+    "column-drag-over-bg-dark": "hsl(217 60% 18%)",
+    "column-drag-over-ring": "hsl(217 91% 60%)",
+    "card-bg": "hsl(0 0% 100%)",
+    "card-bg-dark": "hsl(240 6% 16%)",
+    "card-shadow-rest": "0 1px 2px 0 rgb(0 0 0 / 0.06)",
+    "card-shadow-hover": "0 2px 6px -1px rgb(0 0 0 / 0.10)",
+    "card-shadow-drag": "0 12px 24px -8px rgb(0 0 0 / 0.30), 0 0 0 2px hsl(217 91% 60% / 0.40)",
+    "card-rotate-drag": "2deg",
+    "drop-indicator": "hsl(217 91% 55%)",
+    "drag-handle-fg": "hsl(240 5% 55%)",
+    "drag-handle-hover-fg": "hsl(240 5% 25%)"
+  },
+  "project-color-palette": {
+    "$comment": "Project.color 預設色票，Project Dialog Color Picker 用；皆為 hex，與 DB 欄位一致。",
+    "blue":   "#3b82f6",
+    "violet": "#8b5cf6",
+    "pink":   "#ec4899",
+    "rose":   "#f43f5e",
+    "orange": "#f97316",
+    "amber":  "#f59e0b",
+    "lime":   "#84cc16",
+    "emerald":"#10b981",
+    "teal":   "#14b8a6",
+    "cyan":   "#06b6d4",
+    "slate":  "#64748b",
+    "zinc":   "#71717a"
+  }
+}


### PR DESCRIPTION
## Summary

- D-10 Sprint 10 UI 元件規格 dataset：Projects / Kanban / Task Sheet 三大區塊
- 新增 `design/tokens/projects.json`（projects 模組專屬 tokens）
- 沿用 Sprint 9 元件規格 pattern：每個元件目錄含 README + testids + 元件 md + 範例

## Files

```
design/components/kanban/   (5 份: README, testids, kanban-board, kanban-column, kanban-card)
design/components/projects/ (5 份: README, testids, project-list-card, project-form-dialog, project-overview-tab)
design/components/task/     (4 份: README, testids, task-list-row, task-sheet)
design/tokens/projects.json (136 行)
```

## Closes

Closes #126

## Test plan

- [ ] code-review 確認 spec 對齊 `specs/features/f031-projects-tasks.md` 與 `specs/features/f032-projects-frontend.md`
- [ ] testids 命名一致（沿用 Sprint 9 慣例）

🤖 Generated with [Claude Code](https://claude.com/claude-code)