### PR TITLE
feat(backend): F-031b Project CRUD + archive + force delete

### DIFF
--- a/dev/src/handler/project.go
+++ b/dev/src/handler/project.go
@@ -1,0 +1,294 @@
+package handler
+
+import (
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+	"github.com/gpwork4u/aibo/dto"
+	"github.com/gpwork4u/aibo/model"
+	"github.com/gpwork4u/aibo/repository"
+	"github.com/gpwork4u/aibo/service"
+)
+
+// ProjectHandler 專案 HTTP handlers（F-031b）
+type ProjectHandler struct {
+	svc *service.ProjectService
+}
+
+// NewProjectHandler 建立 ProjectHandler
+func NewProjectHandler(svc *service.ProjectService) *ProjectHandler {
+	return &ProjectHandler{svc: svc}
+}
+
+// formatProjectDate 將 *time.Time 轉成 *string（YYYY-MM-DD），nil 對 nil
+func formatProjectDate(t *time.Time) *string {
+	if t == nil {
+		return nil
+	}
+	s := t.UTC().Format("2006-01-02")
+	return &s
+}
+
+// toProjectResponse 將 model + counts 組成 dto.ProjectResponse
+func toProjectResponse(p *model.Project, counts *dto.TaskCountsResponse) dto.ProjectResponse {
+	return dto.ProjectResponse{
+		ID:          p.ID,
+		Name:        p.Name,
+		Description: p.Description,
+		Color:       p.Color,
+		Status:      p.Status,
+		StartDate:   formatProjectDate(p.StartDate),
+		EndDate:     formatProjectDate(p.EndDate),
+		Progress:    p.Progress,
+		TaskCounts:  counts,
+		CreatedAt:   p.CreatedAt,
+		UpdatedAt:   p.UpdatedAt,
+	}
+}
+
+// toProjectListItem 列表項目（無 task_counts 以避免 N+1）
+func toProjectListItem(p *model.Project) dto.ProjectListItem {
+	return dto.ProjectListItem{
+		ID:        p.ID,
+		Name:      p.Name,
+		Color:     p.Color,
+		Status:    p.Status,
+		StartDate: formatProjectDate(p.StartDate),
+		EndDate:   formatProjectDate(p.EndDate),
+		Progress:  p.Progress,
+		CreatedAt: p.CreatedAt,
+		UpdatedAt: p.UpdatedAt,
+	}
+}
+
+// writeProjectError 統一輸出 AppError
+func writeProjectError(c *gin.Context, err error) {
+	if appErr, ok := err.(*model.AppError); ok {
+		c.JSON(appErr.Status, dto.ErrorResponse{Code: appErr.Code, Message: appErr.Message})
+		return
+	}
+	c.JSON(http.StatusInternalServerError, dto.ErrorResponse{
+		Code:    "INTERNAL_ERROR",
+		Message: "伺服器內部錯誤",
+	})
+}
+
+// parseProjectIDParam 從 URL :id 取出 uuid.UUID；錯誤回 400 INVALID_INPUT
+func parseProjectIDParam(c *gin.Context) (uuid.UUID, bool) {
+	id, err := uuid.Parse(c.Param("id"))
+	if err != nil {
+		c.JSON(http.StatusBadRequest, dto.ErrorResponse{
+			Code:    model.ErrCodeInvalidInput,
+			Message: "id 必須為合法的 UUID",
+		})
+		return uuid.Nil, false
+	}
+	return id, true
+}
+
+// Create POST /api/v1/projects
+func (h *ProjectHandler) Create(c *gin.Context) {
+	var req dto.CreateProjectRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, dto.ErrorResponse{
+			Code:    model.ErrCodeInvalidInput,
+			Message: err.Error(),
+		})
+		return
+	}
+
+	p, err := h.svc.Create(c.Request.Context(), &req)
+	if err != nil {
+		writeProjectError(c, err)
+		return
+	}
+	// 新建立的專案 task_counts 必為 0
+	counts := &dto.TaskCountsResponse{Total: 0, ByStatus: map[string]int{}}
+	c.JSON(http.StatusCreated, toProjectResponse(p, counts))
+}
+
+// GetByID GET /api/v1/projects/:id
+func (h *ProjectHandler) GetByID(c *gin.Context) {
+	id, ok := parseProjectIDParam(c)
+	if !ok {
+		return
+	}
+	p, counts, err := h.svc.Get(c.Request.Context(), id)
+	if err != nil {
+		writeProjectError(c, err)
+		return
+	}
+	c.JSON(http.StatusOK, toProjectResponse(p, counts))
+}
+
+// Update PATCH /api/v1/projects/:id
+func (h *ProjectHandler) Update(c *gin.Context) {
+	id, ok := parseProjectIDParam(c)
+	if !ok {
+		return
+	}
+	var req dto.UpdateProjectRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, dto.ErrorResponse{
+			Code:    model.ErrCodeInvalidInput,
+			Message: err.Error(),
+		})
+		return
+	}
+	p, err := h.svc.Update(c.Request.Context(), id, &req)
+	if err != nil {
+		writeProjectError(c, err)
+		return
+	}
+	// PATCH 後也帶 task_counts，與 GET 對齊
+	_, counts, err := h.svc.Get(c.Request.Context(), id)
+	if err != nil {
+		writeProjectError(c, err)
+		return
+	}
+	c.JSON(http.StatusOK, toProjectResponse(p, counts))
+}
+
+// Delete DELETE /api/v1/projects/:id[?force=true]
+func (h *ProjectHandler) Delete(c *gin.Context) {
+	id, ok := parseProjectIDParam(c)
+	if !ok {
+		return
+	}
+	force := false
+	if v := c.Query("force"); v != "" {
+		parsed, err := strconv.ParseBool(v)
+		if err != nil {
+			c.JSON(http.StatusBadRequest, dto.ErrorResponse{
+				Code:    model.ErrCodeInvalidInput,
+				Message: "force 必須為 bool",
+			})
+			return
+		}
+		force = parsed
+	}
+	if err := h.svc.Delete(c.Request.Context(), id, force); err != nil {
+		writeProjectError(c, err)
+		return
+	}
+	c.Status(http.StatusNoContent)
+}
+
+// Archive POST /api/v1/projects/:id/archive
+func (h *ProjectHandler) Archive(c *gin.Context) {
+	id, ok := parseProjectIDParam(c)
+	if !ok {
+		return
+	}
+	p, err := h.svc.Archive(c.Request.Context(), id)
+	if err != nil {
+		writeProjectError(c, err)
+		return
+	}
+	_, counts, err := h.svc.Get(c.Request.Context(), id)
+	if err != nil {
+		writeProjectError(c, err)
+		return
+	}
+	c.JSON(http.StatusOK, toProjectResponse(p, counts))
+}
+
+// List GET /api/v1/projects?status=&page=&per_page=&sort=&order=
+func (h *ProjectHandler) List(c *gin.Context) {
+	opts := repository.ProjectListOptions{
+		Page:    1,
+		PerPage: 20,
+	}
+
+	// 預設 status=active；明確傳 "all" 則不過濾
+	statusQ := c.Query("status")
+	if statusQ == "" {
+		s := model.ProjectStatusActive
+		opts.Status = &s
+	} else if strings.ToLower(statusQ) != "all" {
+		if !model.IsValidProjectStatus(statusQ) {
+			c.JSON(http.StatusBadRequest, dto.ErrorResponse{
+				Code:    model.ErrCodeInvalidInput,
+				Message: "status 必須為 active / paused / done / archived / all",
+			})
+			return
+		}
+		s := statusQ
+		opts.Status = &s
+	}
+
+	if v := c.Query("page"); v != "" {
+		n, err := strconv.Atoi(v)
+		if err != nil || n < 1 {
+			c.JSON(http.StatusBadRequest, dto.ErrorResponse{
+				Code:    model.ErrCodeInvalidInput,
+				Message: "page 必須為正整數",
+			})
+			return
+		}
+		opts.Page = n
+	}
+	if v := c.Query("per_page"); v != "" {
+		n, err := strconv.Atoi(v)
+		if err != nil || n < 1 || n > 100 {
+			c.JSON(http.StatusBadRequest, dto.ErrorResponse{
+				Code:    model.ErrCodeInvalidInput,
+				Message: "per_page 必須為 1~100 的整數",
+			})
+			return
+		}
+		opts.PerPage = n
+	}
+	if v := c.Query("sort"); v != "" {
+		switch v {
+		case "updated_at", "created_at", "name", "end_date", "start_date":
+			opts.Sort = v
+		default:
+			c.JSON(http.StatusBadRequest, dto.ErrorResponse{
+				Code:    model.ErrCodeInvalidInput,
+				Message: "sort 必須為 updated_at / created_at / name / end_date / start_date",
+			})
+			return
+		}
+	}
+	if v := c.Query("order"); v != "" {
+		v = strings.ToLower(v)
+		if v != "asc" && v != "desc" {
+			c.JSON(http.StatusBadRequest, dto.ErrorResponse{
+				Code:    model.ErrCodeInvalidInput,
+				Message: "order 必須為 asc / desc",
+			})
+			return
+		}
+		opts.Order = v
+	}
+
+	items, total, err := h.svc.List(c.Request.Context(), opts)
+	if err != nil {
+		writeProjectError(c, err)
+		return
+	}
+	data := make([]dto.ProjectListItem, 0, len(items))
+	for _, p := range items {
+		data = append(data, toProjectListItem(p))
+	}
+
+	totalPages := 0
+	if opts.PerPage > 0 {
+		totalPages = int((total + int64(opts.PerPage) - 1) / int64(opts.PerPage))
+	}
+
+	c.JSON(http.StatusOK, dto.ListProjectsResponse{
+		Data: data,
+		Pagination: dto.PaginationResponse{
+			Page:       opts.Page,
+			PerPage:    opts.PerPage,
+			Total:      int(total),
+			TotalPages: totalPages,
+		},
+	})
+}

--- a/dev/src/handler/project_test.go
+++ b/dev/src/handler/project_test.go
@@ -1,0 +1,411 @@
+package handler
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+	"github.com/gpwork4u/aibo/dto"
+	"github.com/gpwork4u/aibo/model"
+	"github.com/gpwork4u/aibo/repository"
+	"github.com/gpwork4u/aibo/service"
+)
+
+// ─── Fake ProjectRepository（與 service test 形狀一致） ─────────────────────
+
+type fakeProjectRepoH struct {
+	store     map[uuid.UUID]*model.Project
+	createErr error
+	updateErr error
+
+	taskCounts map[uuid.UUID]int
+	taskByStat map[uuid.UUID]map[string]int
+}
+
+func newFakeProjectRepoH() *fakeProjectRepoH {
+	return &fakeProjectRepoH{
+		store:      map[uuid.UUID]*model.Project{},
+		taskCounts: map[uuid.UUID]int{},
+		taskByStat: map[uuid.UUID]map[string]int{},
+	}
+}
+
+func (r *fakeProjectRepoH) Create(_ context.Context, p *model.Project) error {
+	if r.createErr != nil {
+		return r.createErr
+	}
+	if p.ID == uuid.Nil {
+		p.ID = uuid.New()
+	}
+	now := time.Now()
+	p.CreatedAt = now
+	p.UpdatedAt = now
+	if p.Color == "" {
+		p.Color = "#3b82f6"
+	}
+	r.store[p.ID] = p
+	return nil
+}
+func (r *fakeProjectRepoH) FindByID(_ context.Context, id uuid.UUID) (*model.Project, error) {
+	p, ok := r.store[id]
+	if !ok {
+		return nil, model.NewAppError(404, model.ErrCodeProjectNotFound, "專案不存在")
+	}
+	cp := *p
+	return &cp, nil
+}
+func (r *fakeProjectRepoH) List(
+	_ context.Context, opts repository.ProjectListOptions,
+) ([]*model.Project, int64, error) {
+	items := make([]*model.Project, 0)
+	for _, p := range r.store {
+		if opts.Status != nil && p.Status != *opts.Status {
+			continue
+		}
+		cp := *p
+		items = append(items, &cp)
+	}
+	return items, int64(len(items)), nil
+}
+func (r *fakeProjectRepoH) Update(_ context.Context, p *model.Project) error {
+	if r.updateErr != nil {
+		return r.updateErr
+	}
+	if _, ok := r.store[p.ID]; !ok {
+		return model.NewAppError(404, model.ErrCodeProjectNotFound, "專案不存在")
+	}
+	p.UpdatedAt = time.Now()
+	cp := *p
+	r.store[p.ID] = &cp
+	return nil
+}
+func (r *fakeProjectRepoH) Delete(_ context.Context, id uuid.UUID) error {
+	if _, ok := r.store[id]; !ok {
+		return model.NewAppError(404, model.ErrCodeProjectNotFound, "專案不存在")
+	}
+	delete(r.store, id)
+	return nil
+}
+func (r *fakeProjectRepoH) CountTasks(_ context.Context, id uuid.UUID) (int, map[string]int, error) {
+	by := r.taskByStat[id]
+	if by == nil {
+		by = map[string]int{}
+	}
+	return r.taskCounts[id], by, nil
+}
+func (r *fakeProjectRepoH) RecomputeProgress(_ context.Context, _ uuid.UUID) (int, error) {
+	return 0, nil
+}
+
+// ─── Fake TaskRepository ────────────────────────────────────────────────────
+
+type fakeTaskRepoH struct {
+	countByProj map[uuid.UUID]int
+}
+
+func (r *fakeTaskRepoH) Create(_ context.Context, _ *model.Task, _ []model.TaskRef) error {
+	return nil
+}
+func (r *fakeTaskRepoH) FindByID(_ context.Context, _ uuid.UUID) (*model.Task, []model.TaskRef, error) {
+	return nil, nil, nil
+}
+func (r *fakeTaskRepoH) ListByProject(_ context.Context, _ uuid.UUID, _ []string) ([]*model.Task, error) {
+	return nil, nil
+}
+func (r *fakeTaskRepoH) Update(_ context.Context, _ *model.Task) error { return nil }
+func (r *fakeTaskRepoH) ReplaceRefs(_ context.Context, _ uuid.UUID, _ []model.TaskRef) error {
+	return nil
+}
+func (r *fakeTaskRepoH) Delete(_ context.Context, _ uuid.UUID) error { return nil }
+func (r *fakeTaskRepoH) ListUpcoming(_ context.Context, _ int) ([]*model.Task, error) {
+	return nil, nil
+}
+func (r *fakeTaskRepoH) ListOverdue(_ context.Context) ([]*model.Task, error) {
+	return nil, nil
+}
+func (r *fakeTaskRepoH) CountByProject(_ context.Context, id uuid.UUID) (int, error) {
+	return r.countByProj[id], nil
+}
+func (r *fakeTaskRepoH) GetRefs(_ context.Context, _ uuid.UUID) ([]model.TaskRef, error) {
+	return nil, nil
+}
+
+// ─── helper ─────────────────────────────────────────────────────────────────
+
+func newProjectTestRouter(t *testing.T) (*gin.Engine, *fakeProjectRepoH, *fakeTaskRepoH) {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+	pr := newFakeProjectRepoH()
+	tr := &fakeTaskRepoH{countByProj: map[uuid.UUID]int{}}
+	svc := service.NewProjectService(pr, tr)
+	h := NewProjectHandler(svc)
+
+	r := gin.New()
+	g := r.Group("/api/v1/projects")
+	g.GET("", h.List)
+	g.POST("", h.Create)
+	g.GET("/:id", h.GetByID)
+	g.PATCH("/:id", h.Update)
+	g.DELETE("/:id", h.Delete)
+	g.POST("/:id/archive", h.Archive)
+	return r, pr, tr
+}
+
+func doProjReq(r *gin.Engine, method, path string, body any) *httptest.ResponseRecorder {
+	var buf *bytes.Buffer
+	if body != nil {
+		b, _ := json.Marshal(body)
+		buf = bytes.NewBuffer(b)
+	} else {
+		buf = bytes.NewBuffer(nil)
+	}
+	req := httptest.NewRequest(method, path, buf)
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	return w
+}
+
+// ─── Tests ──────────────────────────────────────────────────────────────────
+
+func TestProjectHandler_Create_201(t *testing.T) {
+	r, _, _ := newProjectTestRouter(t)
+	body := dto.CreateProjectRequest{Name: "aibo v2"}
+	w := doProjReq(r, http.MethodPost, "/api/v1/projects", body)
+	if w.Code != http.StatusCreated {
+		t.Fatalf("expected 201, got %d body=%s", w.Code, w.Body.String())
+	}
+	var resp dto.ProjectResponse
+	_ = json.Unmarshal(w.Body.Bytes(), &resp)
+	if resp.Name != "aibo v2" {
+		t.Errorf("name wrong: %s", resp.Name)
+	}
+	if resp.Status != model.ProjectStatusActive {
+		t.Errorf("default status should be active, got %s", resp.Status)
+	}
+	if resp.Progress != 0 {
+		t.Errorf("progress should be 0, got %d", resp.Progress)
+	}
+}
+
+func TestProjectHandler_Create_400_NameEmpty(t *testing.T) {
+	r, _, _ := newProjectTestRouter(t)
+	w := doProjReq(r, http.MethodPost, "/api/v1/projects", map[string]any{"name": ""})
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("expected 400, got %d", w.Code)
+	}
+}
+
+func TestProjectHandler_Create_400_BadStatus(t *testing.T) {
+	r, _, _ := newProjectTestRouter(t)
+	w := doProjReq(r, http.MethodPost, "/api/v1/projects",
+		map[string]any{"name": "x", "status": "weird"})
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("expected 400, got %d", w.Code)
+	}
+}
+
+func TestProjectHandler_Create_409_NameDuplicate(t *testing.T) {
+	r, repo, _ := newProjectTestRouter(t)
+	repo.createErr = model.NewAppError(409, model.ErrCodeProjectNameDuplicate, "已有同名專案")
+	w := doProjReq(r, http.MethodPost, "/api/v1/projects",
+		dto.CreateProjectRequest{Name: "dup"})
+	if w.Code != http.StatusConflict {
+		t.Fatalf("expected 409, got %d", w.Code)
+	}
+	var er dto.ErrorResponse
+	_ = json.Unmarshal(w.Body.Bytes(), &er)
+	if er.Code != model.ErrCodeProjectNameDuplicate {
+		t.Errorf("expected PROJECT_NAME_DUPLICATE, got %s", er.Code)
+	}
+}
+
+func TestProjectHandler_Get_200(t *testing.T) {
+	r, repo, _ := newProjectTestRouter(t)
+	id := uuid.New()
+	repo.store[id] = &model.Project{ID: id, Name: "p", Status: "active"}
+	repo.taskCounts[id] = 2
+	repo.taskByStat[id] = map[string]int{"todo": 2}
+
+	w := doProjReq(r, http.MethodGet, "/api/v1/projects/"+id.String(), nil)
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+	var resp dto.ProjectResponse
+	_ = json.Unmarshal(w.Body.Bytes(), &resp)
+	if resp.TaskCounts == nil || resp.TaskCounts.Total != 2 {
+		t.Errorf("task_counts wrong: %+v", resp.TaskCounts)
+	}
+}
+
+func TestProjectHandler_Get_404(t *testing.T) {
+	r, _, _ := newProjectTestRouter(t)
+	w := doProjReq(r, http.MethodGet, "/api/v1/projects/"+uuid.New().String(), nil)
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("expected 404, got %d", w.Code)
+	}
+	var er dto.ErrorResponse
+	_ = json.Unmarshal(w.Body.Bytes(), &er)
+	if er.Code != model.ErrCodeProjectNotFound {
+		t.Errorf("expected PROJECT_NOT_FOUND, got %s", er.Code)
+	}
+}
+
+func TestProjectHandler_Get_400_BadUUID(t *testing.T) {
+	r, _, _ := newProjectTestRouter(t)
+	w := doProjReq(r, http.MethodGet, "/api/v1/projects/not-a-uuid", nil)
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("expected 400, got %d", w.Code)
+	}
+}
+
+func TestProjectHandler_List_200(t *testing.T) {
+	r, repo, _ := newProjectTestRouter(t)
+	repo.store[uuid.New()] = &model.Project{ID: uuid.New(), Name: "a", Status: "active"}
+	repo.store[uuid.New()] = &model.Project{ID: uuid.New(), Name: "b", Status: "archived"}
+
+	// 預設 status=active
+	w := doProjReq(r, http.MethodGet, "/api/v1/projects", nil)
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+	var resp dto.ListProjectsResponse
+	_ = json.Unmarshal(w.Body.Bytes(), &resp)
+	if len(resp.Data) != 1 {
+		t.Errorf("expected 1 active, got %d", len(resp.Data))
+	}
+}
+
+func TestProjectHandler_List_All(t *testing.T) {
+	r, repo, _ := newProjectTestRouter(t)
+	repo.store[uuid.New()] = &model.Project{ID: uuid.New(), Name: "a", Status: "active"}
+	repo.store[uuid.New()] = &model.Project{ID: uuid.New(), Name: "b", Status: "archived"}
+
+	w := doProjReq(r, http.MethodGet, "/api/v1/projects?status=all", nil)
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+	var resp dto.ListProjectsResponse
+	_ = json.Unmarshal(w.Body.Bytes(), &resp)
+	if len(resp.Data) != 2 {
+		t.Errorf("expected 2, got %d", len(resp.Data))
+	}
+}
+
+func TestProjectHandler_List_400_BadStatus(t *testing.T) {
+	r, _, _ := newProjectTestRouter(t)
+	w := doProjReq(r, http.MethodGet, "/api/v1/projects?status=weird", nil)
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("expected 400, got %d", w.Code)
+	}
+}
+
+func TestProjectHandler_Update_200(t *testing.T) {
+	r, repo, _ := newProjectTestRouter(t)
+	id := uuid.New()
+	repo.store[id] = &model.Project{ID: id, Name: "old", Status: "active"}
+
+	w := doProjReq(r, http.MethodPatch, "/api/v1/projects/"+id.String(),
+		map[string]any{"name": "new"})
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d body=%s", w.Code, w.Body.String())
+	}
+	var resp dto.ProjectResponse
+	_ = json.Unmarshal(w.Body.Bytes(), &resp)
+	if resp.Name != "new" {
+		t.Errorf("name not updated: %s", resp.Name)
+	}
+}
+
+func TestProjectHandler_Update_404(t *testing.T) {
+	r, _, _ := newProjectTestRouter(t)
+	w := doProjReq(r, http.MethodPatch, "/api/v1/projects/"+uuid.New().String(),
+		map[string]any{"name": "x"})
+	if w.Code != http.StatusNotFound {
+		t.Errorf("expected 404, got %d", w.Code)
+	}
+}
+
+func TestProjectHandler_Delete_204(t *testing.T) {
+	r, repo, _ := newProjectTestRouter(t)
+	id := uuid.New()
+	repo.store[id] = &model.Project{ID: id, Name: "p", Status: "active"}
+
+	w := doProjReq(r, http.MethodDelete, "/api/v1/projects/"+id.String(), nil)
+	if w.Code != http.StatusNoContent {
+		t.Fatalf("expected 204, got %d body=%s", w.Code, w.Body.String())
+	}
+	if _, ok := repo.store[id]; ok {
+		t.Error("project should be deleted")
+	}
+}
+
+func TestProjectHandler_Delete_409_HasTasks(t *testing.T) {
+	r, repo, taskRepo := newProjectTestRouter(t)
+	id := uuid.New()
+	repo.store[id] = &model.Project{ID: id, Name: "p", Status: "active"}
+	taskRepo.countByProj[id] = 3
+
+	w := doProjReq(r, http.MethodDelete, "/api/v1/projects/"+id.String(), nil)
+	if w.Code != http.StatusConflict {
+		t.Fatalf("expected 409, got %d body=%s", w.Code, w.Body.String())
+	}
+	var er dto.ErrorResponse
+	_ = json.Unmarshal(w.Body.Bytes(), &er)
+	if er.Code != model.ErrCodeProjectHasTasks {
+		t.Errorf("expected PROJECT_HAS_TASKS, got %s", er.Code)
+	}
+}
+
+func TestProjectHandler_Delete_Force_204(t *testing.T) {
+	r, repo, taskRepo := newProjectTestRouter(t)
+	id := uuid.New()
+	repo.store[id] = &model.Project{ID: id, Name: "p", Status: "active"}
+	taskRepo.countByProj[id] = 5
+
+	w := doProjReq(r, http.MethodDelete, "/api/v1/projects/"+id.String()+"?force=true", nil)
+	if w.Code != http.StatusNoContent {
+		t.Fatalf("expected 204, got %d body=%s", w.Code, w.Body.String())
+	}
+	if _, ok := repo.store[id]; ok {
+		t.Error("project should be deleted with force=true")
+	}
+}
+
+func TestProjectHandler_Delete_404(t *testing.T) {
+	r, _, _ := newProjectTestRouter(t)
+	w := doProjReq(r, http.MethodDelete, "/api/v1/projects/"+uuid.New().String(), nil)
+	if w.Code != http.StatusNotFound {
+		t.Errorf("expected 404, got %d", w.Code)
+	}
+}
+
+func TestProjectHandler_Archive_200(t *testing.T) {
+	r, repo, _ := newProjectTestRouter(t)
+	id := uuid.New()
+	repo.store[id] = &model.Project{ID: id, Name: "p", Status: "active"}
+
+	w := doProjReq(r, http.MethodPost, "/api/v1/projects/"+id.String()+"/archive", nil)
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d body=%s", w.Code, w.Body.String())
+	}
+	var resp dto.ProjectResponse
+	_ = json.Unmarshal(w.Body.Bytes(), &resp)
+	if resp.Status != model.ProjectStatusArchived {
+		t.Errorf("expected status=archived, got %s", resp.Status)
+	}
+}
+
+func TestProjectHandler_Archive_404(t *testing.T) {
+	r, _, _ := newProjectTestRouter(t)
+	w := doProjReq(r, http.MethodPost, "/api/v1/projects/"+uuid.New().String()+"/archive", nil)
+	if w.Code != http.StatusNotFound {
+		t.Errorf("expected 404, got %d", w.Code)
+	}
+}

--- a/dev/src/main.go
+++ b/dev/src/main.go
@@ -140,8 +140,14 @@ func main() {
 	journalDraftSvc := service.NewJournalDraftService(llmSvc, entryRepo, gcalSvc)
 	journalDraftHandler := handler.NewJournalDraftHandler(journalDraftSvc)
 
+	// 初始化專案服務（F-031b：CRUD + archive + force delete）
+	projectRepo := repository.NewProjectRepository(pool)
+	taskRepo := repository.NewTaskRepository(pool)
+	projectSvc := service.NewProjectService(projectRepo, taskRepo)
+	projectHandler := handler.NewProjectHandler(projectSvc)
+
 	// 設定路由
-	r := router.Setup(apiKeySvc, apiKeyHandler, categoryHandler, llmProviderHandler, entryHandler, classifyHandler, searchHandler, gitImportHandler, gcalHandler, confidenceHandler, statsHandler, systemHandler, lifecycleHandler, calendarConvertHandler, calendarHandler, journalHandler, journalDraftHandler)
+	r := router.Setup(apiKeySvc, apiKeyHandler, categoryHandler, llmProviderHandler, entryHandler, classifyHandler, searchHandler, gitImportHandler, gcalHandler, confidenceHandler, statsHandler, systemHandler, lifecycleHandler, calendarConvertHandler, calendarHandler, journalHandler, journalDraftHandler, projectHandler)
 
 	// 啟動 HTTP server（graceful shutdown）
 	srv := &http.Server{

--- a/dev/src/router/router.go
+++ b/dev/src/router/router.go
@@ -10,7 +10,7 @@ import (
 )
 
 // Setup 設定路由
-func Setup(apiKeySvc *service.ApiKeyService, apiKeyHandler *handler.ApiKeyHandler, categoryHandler *handler.CategoryHandler, llmProviderHandler *handler.LlmProviderHandler, entryHandler *handler.EntryHandler, classifyHandler *handler.ClassifyHandler, searchHandler *handler.SearchHandler, gitImportHandler *handler.GitImportHandler, gcalHandler *handler.GcalHandler, confidenceHandler *handler.ConfidenceHandler, statsHandler *handler.StatsHandler, systemHandler *handler.SystemHandler, lifecycleHandler *handler.LifecycleHandler, calendarConvertHandler *handler.CalendarConvertHandler, calendarHandler *handler.CalendarHandler, journalHandler *handler.JournalHandler, journalDraftHandler *handler.JournalDraftHandler) *gin.Engine {
+func Setup(apiKeySvc *service.ApiKeyService, apiKeyHandler *handler.ApiKeyHandler, categoryHandler *handler.CategoryHandler, llmProviderHandler *handler.LlmProviderHandler, entryHandler *handler.EntryHandler, classifyHandler *handler.ClassifyHandler, searchHandler *handler.SearchHandler, gitImportHandler *handler.GitImportHandler, gcalHandler *handler.GcalHandler, confidenceHandler *handler.ConfidenceHandler, statsHandler *handler.StatsHandler, systemHandler *handler.SystemHandler, lifecycleHandler *handler.LifecycleHandler, calendarConvertHandler *handler.CalendarConvertHandler, calendarHandler *handler.CalendarHandler, journalHandler *handler.JournalHandler, journalDraftHandler *handler.JournalDraftHandler, projectHandler *handler.ProjectHandler) *gin.Engine {
 	r := gin.Default()
 
 	// CORS middleware — 允許跨網域（前端 localhost:3000 呼叫 API localhost:8080）
@@ -140,6 +140,17 @@ func Setup(apiKeySvc *service.ApiKeyService, apiKeyHandler *handler.ApiKeyHandle
 			journal.DELETE("/:date", journalHandler.Delete)
 			// F-028c：LLM 草稿（不直接寫入 DB；前端拿 draft 編輯後再 PATCH）
 			journal.POST("/:date/draft", journalDraftHandler.Draft)
+		}
+
+		// 專案（F-031b：CRUD + archive + force delete）
+		projects := v1.Group("/projects")
+		{
+			projects.POST("", projectHandler.Create)
+			projects.GET("", projectHandler.List)
+			projects.GET("/:id", projectHandler.GetByID)
+			projects.PATCH("/:id", projectHandler.Update)
+			projects.DELETE("/:id", projectHandler.Delete)
+			projects.POST("/:id/archive", projectHandler.Archive)
 		}
 	}
 

--- a/dev/src/service/project.go
+++ b/dev/src/service/project.go
@@ -1,0 +1,301 @@
+package service
+
+import (
+	"context"
+	"log/slog"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/gpwork4u/aibo/dto"
+	"github.com/gpwork4u/aibo/model"
+	"github.com/gpwork4u/aibo/repository"
+)
+
+// ProjectService 專案 business logic（F-031b）
+//
+// 職責：
+//   - 欄位驗證（name 1..80、description <= 5000、end_date >= start_date）
+//   - status transition 規則（archived 由 Archive endpoint 設定）
+//   - 對 archived 進行 unarchive 仍透過 PATCH（status=active/paused/done）允許；
+//     反向（active → archived 透過 PATCH archived）也允許。spec §139~140 的「需顯式 unarchive」
+//     在此處解讀為：archive endpoint 只能設成 archived；PATCH 任何 status 皆可，由 client 端
+//     顯式指定。
+//   - delete 預設拒含 task；force=true 時透過 ProjectRepository.Delete（FK CASCADE）。
+//   - PATCH 中 progress 欄位忽略（progress 為自動計算）。
+type ProjectService struct {
+	projectRepo ProjectRepository
+	taskRepo    TaskRepository
+}
+
+// NewProjectService 建立 ProjectService
+func NewProjectService(pr ProjectRepository, tr TaskRepository) *ProjectService {
+	return &ProjectService{projectRepo: pr, taskRepo: tr}
+}
+
+// ProjectListOptions service 層 alias，避免 handler import repository
+type ProjectListOptions = repository.ProjectListOptions
+
+// parseProjectDate 解析 YYYY-MM-DD（以 UTC 表示「該日 00:00」），與 Journal 一致。
+//
+// 空字串視為錯誤，呼叫端應在傳入前判斷是否為 nil。
+func parseProjectDate(s string) (time.Time, error) {
+	t, err := time.Parse("2006-01-02", s)
+	if err != nil {
+		return time.Time{}, model.NewAppError(400, model.ErrCodeInvalidInput,
+			"日期格式錯誤，需 YYYY-MM-DD")
+	}
+	return time.Date(t.Year(), t.Month(), t.Day(), 0, 0, 0, 0, time.UTC), nil
+}
+
+// validateDateRange 若 start/end 都有值，end 必須 >= start
+func validateDateRange(start, end *time.Time) error {
+	if start != nil && end != nil && end.Before(*start) {
+		return model.NewAppError(400, model.ErrCodeInvalidInput,
+			"end_date 不可早於 start_date")
+	}
+	return nil
+}
+
+// Create 建立專案
+//
+// Scenarios:
+//   - 名稱 1..80（DTO binding 已擋）
+//   - end_date >= start_date 否則 400 INVALID_INPUT
+//   - 名稱（CI）重複於非 archived → 409 PROJECT_NAME_DUPLICATE（由 repository PgErr mapping）
+//   - status 預設 active；progress 一律 0
+func (s *ProjectService) Create(
+	ctx context.Context, req *dto.CreateProjectRequest,
+) (*model.Project, error) {
+	if req == nil {
+		return nil, model.NewAppError(400, model.ErrCodeInvalidInput, "request body 為必填")
+	}
+
+	name := strings.TrimSpace(req.Name)
+	if name == "" || len(name) > 80 {
+		return nil, model.NewAppError(400, model.ErrCodeInvalidInput, "name 長度需 1~80")
+	}
+	if req.Description != nil && len(*req.Description) > 5000 {
+		return nil, model.NewAppError(400, model.ErrCodeInvalidInput, "description 長度上限 5000")
+	}
+
+	var startDate, endDate *time.Time
+	if req.StartDate != nil && *req.StartDate != "" {
+		t, err := parseProjectDate(*req.StartDate)
+		if err != nil {
+			return nil, err
+		}
+		startDate = &t
+	}
+	if req.EndDate != nil && *req.EndDate != "" {
+		t, err := parseProjectDate(*req.EndDate)
+		if err != nil {
+			return nil, err
+		}
+		endDate = &t
+	}
+	if err := validateDateRange(startDate, endDate); err != nil {
+		return nil, err
+	}
+
+	status := model.ProjectStatusActive
+	if req.Status != nil && *req.Status != "" {
+		if !model.IsValidProjectStatus(*req.Status) {
+			return nil, model.NewAppError(400, model.ErrCodeInvalidInput, "status 不合法")
+		}
+		status = *req.Status
+	}
+
+	color := ""
+	if req.Color != nil {
+		color = *req.Color
+	}
+
+	p := &model.Project{
+		Name:        name,
+		Description: req.Description,
+		Color:       color,
+		Status:      status,
+		StartDate:   startDate,
+		EndDate:     endDate,
+		Progress:    0,
+	}
+
+	if err := s.projectRepo.Create(ctx, p); err != nil {
+		return nil, err
+	}
+	slog.InfoContext(ctx, "project.create", "id", p.ID, "name", p.Name)
+	return p, nil
+}
+
+// Get 取得專案詳情，附帶 task_counts
+//
+// 不存在 → 404 PROJECT_NOT_FOUND
+func (s *ProjectService) Get(
+	ctx context.Context, id uuid.UUID,
+) (*model.Project, *dto.TaskCountsResponse, error) {
+	p, err := s.projectRepo.FindByID(ctx, id)
+	if err != nil {
+		return nil, nil, err
+	}
+	total, byStatus, err := s.projectRepo.CountTasks(ctx, id)
+	if err != nil {
+		return nil, nil, err
+	}
+	if byStatus == nil {
+		byStatus = map[string]int{}
+	}
+	counts := &dto.TaskCountsResponse{Total: total, ByStatus: byStatus}
+	return p, counts, nil
+}
+
+// List 分頁列表
+func (s *ProjectService) List(
+	ctx context.Context, opts ProjectListOptions,
+) ([]*model.Project, int64, error) {
+	return s.projectRepo.List(ctx, opts)
+}
+
+// Update partial 更新
+//
+// Scenarios:
+//   - name 長度 1..80（若有更新）
+//   - description <= 5000（若有更新）
+//   - end_date >= start_date（合併後）
+//   - 名稱衝突 → 409 PROJECT_NAME_DUPLICATE
+//   - 不存在 → 404 PROJECT_NOT_FOUND
+//
+// 注意：spec §142 progress 由系統計算，PATCH 不接受 progress 欄位（DTO 上沒這個欄位，自然忽略）。
+func (s *ProjectService) Update(
+	ctx context.Context, id uuid.UUID, req *dto.UpdateProjectRequest,
+) (*model.Project, error) {
+	if req == nil {
+		return nil, model.NewAppError(400, model.ErrCodeInvalidInput, "request body 為必填")
+	}
+
+	current, err := s.projectRepo.FindByID(ctx, id)
+	if err != nil {
+		return nil, err
+	}
+
+	// 套用 patch
+	if req.Name != nil {
+		n := strings.TrimSpace(*req.Name)
+		if n == "" || len(n) > 80 {
+			return nil, model.NewAppError(400, model.ErrCodeInvalidInput, "name 長度需 1~80")
+		}
+		current.Name = n
+	}
+	if req.Description != nil {
+		// **string：外層非 nil 代表 client 有送 description 欄位
+		// 內層 nil 代表設為 NULL，否則更新文字
+		if *req.Description == nil {
+			current.Description = nil
+		} else {
+			d := **req.Description
+			if len(d) > 5000 {
+				return nil, model.NewAppError(400, model.ErrCodeInvalidInput, "description 長度上限 5000")
+			}
+			current.Description = &d
+		}
+	}
+	if req.Color != nil {
+		current.Color = *req.Color
+	}
+	if req.Status != nil {
+		if !model.IsValidProjectStatus(*req.Status) {
+			return nil, model.NewAppError(400, model.ErrCodeInvalidInput, "status 不合法")
+		}
+		current.Status = *req.Status
+	}
+	if req.StartDate != nil {
+		if *req.StartDate == nil {
+			current.StartDate = nil
+		} else {
+			d, err := parseProjectDate(**req.StartDate)
+			if err != nil {
+				return nil, err
+			}
+			current.StartDate = &d
+		}
+	}
+	if req.EndDate != nil {
+		if *req.EndDate == nil {
+			current.EndDate = nil
+		} else {
+			d, err := parseProjectDate(**req.EndDate)
+			if err != nil {
+				return nil, err
+			}
+			current.EndDate = &d
+		}
+	}
+	if err := validateDateRange(current.StartDate, current.EndDate); err != nil {
+		return nil, err
+	}
+
+	if err := s.projectRepo.Update(ctx, current); err != nil {
+		return nil, err
+	}
+	slog.InfoContext(ctx, "project.update", "id", id)
+	return current, nil
+}
+
+// Delete 刪除專案
+//
+// Scenarios:
+//   - 預設：若有 task → 409 PROJECT_HAS_TASKS
+//   - force=true → DB FK CASCADE 連帶刪除 tasks（透過 ProjectRepository.Delete）
+//   - 不存在 → 404 PROJECT_NOT_FOUND
+func (s *ProjectService) Delete(ctx context.Context, id uuid.UUID, force bool) error {
+	// 先確認專案存在（一致的 404 行為）
+	if _, err := s.projectRepo.FindByID(ctx, id); err != nil {
+		return err
+	}
+
+	if !force {
+		count, err := s.taskRepo.CountByProject(ctx, id)
+		if err != nil {
+			return err
+		}
+		if count > 0 {
+			return model.NewAppError(409, model.ErrCodeProjectHasTasks,
+				"專案下仍有 task，請改以 ?force=true 強制刪除")
+		}
+	}
+
+	if err := s.projectRepo.Delete(ctx, id); err != nil {
+		return err
+	}
+	slog.InfoContext(ctx, "project.delete", "id", id, "force", force)
+	return nil
+}
+
+// Archive 將專案 status 設為 archived
+//
+// 不存在 → 404 PROJECT_NOT_FOUND
+// 已是 archived → 直接回傳（idempotent）
+func (s *ProjectService) Archive(ctx context.Context, id uuid.UUID) (*model.Project, error) {
+	p, err := s.projectRepo.FindByID(ctx, id)
+	if err != nil {
+		return nil, err
+	}
+	if p.Status == model.ProjectStatusArchived {
+		return p, nil
+	}
+	p.Status = model.ProjectStatusArchived
+	if err := s.projectRepo.Update(ctx, p); err != nil {
+		return nil, err
+	}
+	slog.InfoContext(ctx, "project.archive", "id", id)
+	return p, nil
+}
+
+// RecomputeProgress 給 F-031c task 變動時呼叫，重新計算 progress。
+//
+// 沒有 task 或全部 cancelled → 0。
+func (s *ProjectService) RecomputeProgress(
+	ctx context.Context, projectID uuid.UUID,
+) (int, error) {
+	return s.projectRepo.RecomputeProgress(ctx, projectID)
+}

--- a/dev/src/service/project_test.go
+++ b/dev/src/service/project_test.go
@@ -1,0 +1,524 @@
+package service
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/gpwork4u/aibo/dto"
+	"github.com/gpwork4u/aibo/model"
+	"github.com/gpwork4u/aibo/repository"
+)
+
+// ─── Fake ProjectRepository ────────────────────────────────────────────
+
+type fakeProjectRepo struct {
+	store map[uuid.UUID]*model.Project
+
+	createErr error
+	updateErr error
+	deleteErr error
+
+	taskCounts map[uuid.UUID]int            // for CountTasks total
+	taskByStat map[uuid.UUID]map[string]int // for CountTasks by status
+}
+
+func newFakeProjectRepo() *fakeProjectRepo {
+	return &fakeProjectRepo{
+		store:      map[uuid.UUID]*model.Project{},
+		taskCounts: map[uuid.UUID]int{},
+		taskByStat: map[uuid.UUID]map[string]int{},
+	}
+}
+
+func (r *fakeProjectRepo) Create(ctx context.Context, p *model.Project) error {
+	if r.createErr != nil {
+		return r.createErr
+	}
+	if p.ID == uuid.Nil {
+		p.ID = uuid.New()
+	}
+	now := time.Now()
+	p.CreatedAt = now
+	p.UpdatedAt = now
+	if p.Status == "" {
+		p.Status = model.ProjectStatusActive
+	}
+	if p.Color == "" {
+		p.Color = "#3b82f6"
+	}
+	r.store[p.ID] = p
+	return nil
+}
+
+func (r *fakeProjectRepo) FindByID(ctx context.Context, id uuid.UUID) (*model.Project, error) {
+	p, ok := r.store[id]
+	if !ok {
+		return nil, model.NewAppError(404, model.ErrCodeProjectNotFound, "專案不存在")
+	}
+	cp := *p
+	return &cp, nil
+}
+
+func (r *fakeProjectRepo) List(
+	ctx context.Context, opts repository.ProjectListOptions,
+) ([]*model.Project, int64, error) {
+	items := make([]*model.Project, 0)
+	for _, p := range r.store {
+		if opts.Status != nil && p.Status != *opts.Status {
+			continue
+		}
+		cp := *p
+		items = append(items, &cp)
+	}
+	return items, int64(len(items)), nil
+}
+
+func (r *fakeProjectRepo) Update(ctx context.Context, p *model.Project) error {
+	if r.updateErr != nil {
+		return r.updateErr
+	}
+	if _, ok := r.store[p.ID]; !ok {
+		return model.NewAppError(404, model.ErrCodeProjectNotFound, "專案不存在")
+	}
+	p.UpdatedAt = time.Now()
+	cp := *p
+	r.store[p.ID] = &cp
+	return nil
+}
+
+func (r *fakeProjectRepo) Delete(ctx context.Context, id uuid.UUID) error {
+	if r.deleteErr != nil {
+		return r.deleteErr
+	}
+	if _, ok := r.store[id]; !ok {
+		return model.NewAppError(404, model.ErrCodeProjectNotFound, "專案不存在")
+	}
+	delete(r.store, id)
+	delete(r.taskCounts, id)
+	delete(r.taskByStat, id)
+	return nil
+}
+
+func (r *fakeProjectRepo) CountTasks(
+	ctx context.Context, projectID uuid.UUID,
+) (int, map[string]int, error) {
+	by := r.taskByStat[projectID]
+	if by == nil {
+		by = map[string]int{}
+	}
+	return r.taskCounts[projectID], by, nil
+}
+
+func (r *fakeProjectRepo) RecomputeProgress(
+	ctx context.Context, projectID uuid.UUID,
+) (int, error) {
+	p, ok := r.store[projectID]
+	if !ok {
+		return 0, model.NewAppError(404, model.ErrCodeProjectNotFound, "專案不存在")
+	}
+	by := r.taskByStat[projectID]
+	done := by["done"]
+	total := 0
+	for status, c := range by {
+		if status != "cancelled" {
+			total += c
+		}
+	}
+	prog := 0
+	if total > 0 {
+		prog = (100*done + total/2) / total
+	}
+	p.Progress = prog
+	return prog, nil
+}
+
+// ─── Fake TaskRepository（最小） ─────────────────────────────────────────
+
+type fakeTaskRepoMin struct {
+	countByProj map[uuid.UUID]int
+}
+
+func (r *fakeTaskRepoMin) Create(ctx context.Context, t *model.Task, refs []model.TaskRef) error {
+	return nil
+}
+func (r *fakeTaskRepoMin) FindByID(ctx context.Context, id uuid.UUID) (*model.Task, []model.TaskRef, error) {
+	return nil, nil, nil
+}
+func (r *fakeTaskRepoMin) ListByProject(ctx context.Context, projectID uuid.UUID, statusFilter []string) ([]*model.Task, error) {
+	return nil, nil
+}
+func (r *fakeTaskRepoMin) Update(ctx context.Context, t *model.Task) error          { return nil }
+func (r *fakeTaskRepoMin) ReplaceRefs(ctx context.Context, taskID uuid.UUID, refs []model.TaskRef) error {
+	return nil
+}
+func (r *fakeTaskRepoMin) Delete(ctx context.Context, id uuid.UUID) error           { return nil }
+func (r *fakeTaskRepoMin) ListUpcoming(ctx context.Context, days int) ([]*model.Task, error) {
+	return nil, nil
+}
+func (r *fakeTaskRepoMin) ListOverdue(ctx context.Context) ([]*model.Task, error) {
+	return nil, nil
+}
+func (r *fakeTaskRepoMin) CountByProject(ctx context.Context, projectID uuid.UUID) (int, error) {
+	return r.countByProj[projectID], nil
+}
+func (r *fakeTaskRepoMin) GetRefs(ctx context.Context, taskID uuid.UUID) ([]model.TaskRef, error) {
+	return nil, nil
+}
+
+// ─── Helpers ──────────────────────────────────────────────────────────
+
+func newProjectSvc() (*ProjectService, *fakeProjectRepo, *fakeTaskRepoMin) {
+	pr := newFakeProjectRepo()
+	tr := &fakeTaskRepoMin{countByProj: map[uuid.UUID]int{}}
+	return NewProjectService(pr, tr), pr, tr
+}
+
+func strPtr(s string) *string { return &s }
+
+// ─── Tests ────────────────────────────────────────────────────────────
+
+// Scenario: 建立 project（happy path）
+func TestProjectSvc_Create_HappyPath(t *testing.T) {
+	svc, _, _ := newProjectSvc()
+	req := &dto.CreateProjectRequest{
+		Name:      "aibo v2",
+		StartDate: strPtr("2026-04-01"),
+		EndDate:   strPtr("2026-06-30"),
+	}
+	p, err := svc.Create(context.Background(), req)
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if p.Status != model.ProjectStatusActive {
+		t.Errorf("expected status=active, got %s", p.Status)
+	}
+	if p.Progress != 0 {
+		t.Errorf("expected progress=0, got %d", p.Progress)
+	}
+	if p.StartDate == nil || p.StartDate.Format("2006-01-02") != "2026-04-01" {
+		t.Errorf("start_date wrong: %v", p.StartDate)
+	}
+}
+
+// Scenario: end_date 早於 start_date
+func TestProjectSvc_Create_EndBeforeStart(t *testing.T) {
+	svc, _, _ := newProjectSvc()
+	req := &dto.CreateProjectRequest{
+		Name:      "x",
+		StartDate: strPtr("2026-06-01"),
+		EndDate:   strPtr("2026-04-01"),
+	}
+	_, err := svc.Create(context.Background(), req)
+	appErr, ok := err.(*model.AppError)
+	if !ok {
+		t.Fatalf("expected AppError, got %T", err)
+	}
+	if appErr.Status != 400 || appErr.Code != model.ErrCodeInvalidInput {
+		t.Errorf("expected 400 INVALID_INPUT, got %+v", appErr)
+	}
+}
+
+// Scenario: 重名專案被拒（透過 repo 模擬 PgErr 已轉成 AppError）
+func TestProjectSvc_Create_NameDuplicate(t *testing.T) {
+	svc, repo, _ := newProjectSvc()
+	repo.createErr = model.NewAppError(409, model.ErrCodeProjectNameDuplicate, "已有同名專案")
+	_, err := svc.Create(context.Background(), &dto.CreateProjectRequest{Name: "Aibo V2"})
+	appErr, ok := err.(*model.AppError)
+	if !ok {
+		t.Fatalf("expected AppError, got %T", err)
+	}
+	if appErr.Status != 409 || appErr.Code != model.ErrCodeProjectNameDuplicate {
+		t.Errorf("expected 409 PROJECT_NAME_DUPLICATE, got %+v", appErr)
+	}
+}
+
+// Scenario: name 長度超過 80
+func TestProjectSvc_Create_NameTooLong(t *testing.T) {
+	svc, _, _ := newProjectSvc()
+	long := make([]byte, 81)
+	for i := range long {
+		long[i] = 'a'
+	}
+	_, err := svc.Create(context.Background(), &dto.CreateProjectRequest{Name: string(long)})
+	appErr, ok := err.(*model.AppError)
+	if !ok {
+		t.Fatalf("expected AppError, got %T", err)
+	}
+	if appErr.Code != model.ErrCodeInvalidInput {
+		t.Errorf("expected INVALID_INPUT, got %s", appErr.Code)
+	}
+}
+
+// Scenario: Get 不存在 → 404
+func TestProjectSvc_Get_NotFound(t *testing.T) {
+	svc, _, _ := newProjectSvc()
+	_, _, err := svc.Get(context.Background(), uuid.New())
+	appErr, ok := err.(*model.AppError)
+	if !ok {
+		t.Fatalf("expected AppError, got %T", err)
+	}
+	if appErr.Status != 404 || appErr.Code != model.ErrCodeProjectNotFound {
+		t.Errorf("expected 404 PROJECT_NOT_FOUND, got %+v", appErr)
+	}
+}
+
+// Scenario: Get 包含 task_counts
+func TestProjectSvc_Get_WithTaskCounts(t *testing.T) {
+	svc, repo, _ := newProjectSvc()
+	id := uuid.New()
+	repo.store[id] = &model.Project{ID: id, Name: "x", Status: "active"}
+	repo.taskCounts[id] = 3
+	repo.taskByStat[id] = map[string]int{"todo": 2, "done": 1}
+
+	p, counts, err := svc.Get(context.Background(), id)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if p.ID != id {
+		t.Error("wrong project")
+	}
+	if counts.Total != 3 || counts.ByStatus["done"] != 1 || counts.ByStatus["todo"] != 2 {
+		t.Errorf("counts wrong: %+v", counts)
+	}
+}
+
+// Scenario: List with status filter
+func TestProjectSvc_List_StatusFilter(t *testing.T) {
+	svc, repo, _ := newProjectSvc()
+	repo.store[uuid.New()] = &model.Project{ID: uuid.New(), Name: "a", Status: "active"}
+	repo.store[uuid.New()] = &model.Project{ID: uuid.New(), Name: "b", Status: "active"}
+	repo.store[uuid.New()] = &model.Project{ID: uuid.New(), Name: "c", Status: "archived"}
+
+	active := model.ProjectStatusActive
+	items, total, err := svc.List(context.Background(), repository.ProjectListOptions{
+		Status: &active,
+	})
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if total != 2 || len(items) != 2 {
+		t.Errorf("expected 2 active, got total=%d len=%d", total, len(items))
+	}
+	for _, p := range items {
+		if p.Status != "active" {
+			t.Errorf("got non-active project: %s", p.Status)
+		}
+	}
+}
+
+// Scenario: Update 不存在 → 404
+func TestProjectSvc_Update_NotFound(t *testing.T) {
+	svc, _, _ := newProjectSvc()
+	name := "new name"
+	_, err := svc.Update(context.Background(), uuid.New(), &dto.UpdateProjectRequest{Name: &name})
+	appErr, ok := err.(*model.AppError)
+	if !ok {
+		t.Fatalf("expected AppError, got %T", err)
+	}
+	if appErr.Status != 404 || appErr.Code != model.ErrCodeProjectNotFound {
+		t.Errorf("expected 404, got %+v", appErr)
+	}
+}
+
+// Scenario: Update 修改 name + 日期區間
+func TestProjectSvc_Update_OK(t *testing.T) {
+	svc, repo, _ := newProjectSvc()
+	id := uuid.New()
+	repo.store[id] = &model.Project{ID: id, Name: "old", Status: "active"}
+
+	newName := "new"
+	end := strPtr("2026-12-31")
+	patch := &dto.UpdateProjectRequest{
+		Name:    &newName,
+		EndDate: &end,
+	}
+	p, err := svc.Update(context.Background(), id, patch)
+	if err != nil {
+		t.Fatalf("Update: %v", err)
+	}
+	if p.Name != "new" {
+		t.Errorf("name not updated: %s", p.Name)
+	}
+	if p.EndDate == nil || p.EndDate.Format("2006-01-02") != "2026-12-31" {
+		t.Errorf("end_date not updated: %v", p.EndDate)
+	}
+}
+
+// Scenario: Update 中 end_date 早於 start_date（合併後）→ 400
+func TestProjectSvc_Update_DateRangeInvalid(t *testing.T) {
+	svc, repo, _ := newProjectSvc()
+	id := uuid.New()
+	start := time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC)
+	repo.store[id] = &model.Project{ID: id, Name: "p", Status: "active", StartDate: &start}
+
+	end := strPtr("2026-04-01")
+	patch := &dto.UpdateProjectRequest{EndDate: &end}
+	_, err := svc.Update(context.Background(), id, patch)
+	appErr, ok := err.(*model.AppError)
+	if !ok {
+		t.Fatalf("expected AppError, got %T", err)
+	}
+	if appErr.Status != 400 || appErr.Code != model.ErrCodeInvalidInput {
+		t.Errorf("expected 400 INVALID_INPUT, got %+v", appErr)
+	}
+}
+
+// Scenario: Update description 設為 NULL（**string 內層 nil）
+func TestProjectSvc_Update_DescriptionToNull(t *testing.T) {
+	svc, repo, _ := newProjectSvc()
+	id := uuid.New()
+	desc := "initial"
+	repo.store[id] = &model.Project{ID: id, Name: "p", Status: "active", Description: &desc}
+
+	var nullDesc *string // nil
+	patch := &dto.UpdateProjectRequest{Description: &nullDesc}
+	p, err := svc.Update(context.Background(), id, patch)
+	if err != nil {
+		t.Fatalf("Update: %v", err)
+	}
+	if p.Description != nil {
+		t.Errorf("expected description=nil, got %v", *p.Description)
+	}
+}
+
+// Scenario: 刪除有 task 的專案（無 force）→ 409 PROJECT_HAS_TASKS
+func TestProjectSvc_Delete_HasTasks(t *testing.T) {
+	svc, repo, taskRepo := newProjectSvc()
+	id := uuid.New()
+	repo.store[id] = &model.Project{ID: id, Name: "p", Status: "active"}
+	taskRepo.countByProj[id] = 3
+
+	err := svc.Delete(context.Background(), id, false)
+	appErr, ok := err.(*model.AppError)
+	if !ok {
+		t.Fatalf("expected AppError, got %T", err)
+	}
+	if appErr.Status != 409 || appErr.Code != model.ErrCodeProjectHasTasks {
+		t.Errorf("expected 409 PROJECT_HAS_TASKS, got %+v", appErr)
+	}
+	// 專案不應被刪
+	if _, ok := repo.store[id]; !ok {
+		t.Error("project should not be deleted on 409")
+	}
+}
+
+// Scenario: 強制刪除（force=true）即使有 task
+func TestProjectSvc_Delete_Force(t *testing.T) {
+	svc, repo, taskRepo := newProjectSvc()
+	id := uuid.New()
+	repo.store[id] = &model.Project{ID: id, Name: "p", Status: "active"}
+	taskRepo.countByProj[id] = 5
+
+	if err := svc.Delete(context.Background(), id, true); err != nil {
+		t.Fatalf("Delete force: %v", err)
+	}
+	if _, ok := repo.store[id]; ok {
+		t.Error("project should be deleted with force=true")
+	}
+}
+
+// Scenario: 刪除無 task 的專案
+func TestProjectSvc_Delete_NoTasks(t *testing.T) {
+	svc, repo, _ := newProjectSvc()
+	id := uuid.New()
+	repo.store[id] = &model.Project{ID: id, Name: "p", Status: "active"}
+
+	if err := svc.Delete(context.Background(), id, false); err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+	if _, ok := repo.store[id]; ok {
+		t.Error("project should be deleted")
+	}
+}
+
+// Scenario: Delete 不存在 → 404
+func TestProjectSvc_Delete_NotFound(t *testing.T) {
+	svc, _, _ := newProjectSvc()
+	err := svc.Delete(context.Background(), uuid.New(), false)
+	appErr, ok := err.(*model.AppError)
+	if !ok {
+		t.Fatalf("expected AppError, got %T", err)
+	}
+	if appErr.Status != 404 || appErr.Code != model.ErrCodeProjectNotFound {
+		t.Errorf("expected 404 PROJECT_NOT_FOUND, got %+v", appErr)
+	}
+}
+
+// Scenario: Archive 將 status 設為 archived
+func TestProjectSvc_Archive_OK(t *testing.T) {
+	svc, repo, _ := newProjectSvc()
+	id := uuid.New()
+	repo.store[id] = &model.Project{ID: id, Name: "p", Status: "active"}
+
+	p, err := svc.Archive(context.Background(), id)
+	if err != nil {
+		t.Fatalf("Archive: %v", err)
+	}
+	if p.Status != model.ProjectStatusArchived {
+		t.Errorf("expected status=archived, got %s", p.Status)
+	}
+}
+
+// Scenario: Archive 已是 archived（idempotent）
+func TestProjectSvc_Archive_Idempotent(t *testing.T) {
+	svc, repo, _ := newProjectSvc()
+	id := uuid.New()
+	repo.store[id] = &model.Project{ID: id, Name: "p", Status: "archived"}
+	p, err := svc.Archive(context.Background(), id)
+	if err != nil {
+		t.Fatalf("Archive: %v", err)
+	}
+	if p.Status != model.ProjectStatusArchived {
+		t.Errorf("expected archived, got %s", p.Status)
+	}
+}
+
+// Scenario: Archive 不存在 → 404
+func TestProjectSvc_Archive_NotFound(t *testing.T) {
+	svc, _, _ := newProjectSvc()
+	_, err := svc.Archive(context.Background(), uuid.New())
+	appErr, ok := err.(*model.AppError)
+	if !ok {
+		t.Fatalf("expected AppError, got %T", err)
+	}
+	if appErr.Status != 404 {
+		t.Errorf("expected 404, got %+v", appErr)
+	}
+}
+
+// Edge: 專案下無 task 時 progress = 0
+func TestProjectSvc_Get_NoTasks_ProgressZero(t *testing.T) {
+	svc, repo, _ := newProjectSvc()
+	id := uuid.New()
+	repo.store[id] = &model.Project{ID: id, Name: "p", Status: "active", Progress: 0}
+	// taskCounts/taskByStat 空
+
+	p, counts, err := svc.Get(context.Background(), id)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if p.Progress != 0 {
+		t.Errorf("expected progress=0, got %d", p.Progress)
+	}
+	if counts.Total != 0 {
+		t.Errorf("expected total=0, got %d", counts.Total)
+	}
+}
+
+// Edge: 全部 task 都 cancelled → progress = 0（透過 RecomputeProgress）
+func TestProjectSvc_RecomputeProgress_AllCancelled(t *testing.T) {
+	svc, repo, _ := newProjectSvc()
+	id := uuid.New()
+	repo.store[id] = &model.Project{ID: id, Name: "p", Status: "active"}
+	repo.taskByStat[id] = map[string]int{"cancelled": 3}
+
+	prog, err := svc.RecomputeProgress(context.Background(), id)
+	if err != nil {
+		t.Fatalf("Recompute: %v", err)
+	}
+	if prog != 0 {
+		t.Errorf("expected progress=0, got %d", prog)
+	}
+}


### PR DESCRIPTION
## Summary

- Project CRUD + archive + force delete 的 service / handler / router 接線
- 對齊 `specs/features/f031-projects-tasks.md` Projects 段 API contract
- 38 個 unit tests（service 20 / handler 18）

## 範圍

| File | Lines | 說明 |
|---|---|---|
| `dev/src/service/project.go` | 301 | ProjectService（含 RecomputeProgress 給 F-031c） |
| `dev/src/handler/project.go` | 294 | gin handler，hook DTO 驗證 + AppError |
| `dev/src/service/project_test.go` | 524 | 20 tests |
| `dev/src/handler/project_test.go` | 411 | 18 tests |
| `dev/src/router/router.go` | +12 | /api/v1/projects 路由群組（auth 由 v1.Use 繼承） |
| `dev/src/main.go` | +N | wire ProjectService 到 handler |

## Endpoints

| Method | Path | 200/2xx | 4xx |
|---|---|---|---|
| POST | /api/v1/projects | 201 | 400 INVALID_INPUT, 409 PROJECT_NAME_DUPLICATE |
| GET | /api/v1/projects | 200 | 400 |
| GET | /api/v1/projects/:id | 200 含 task_counts | 404 PROJECT_NOT_FOUND |
| PATCH | /api/v1/projects/:id | 200 | 400 / 404 / 409 |
| DELETE | /api/v1/projects/:id[?force=true] | 204 | 409 PROJECT_HAS_TASKS / 404 |
| POST | /api/v1/projects/:id/archive | 200 | 404 |

## Test plan

- [ ] CI Go test 全綠（本機 Go 版本不符無法跑）
- [ ] code-review 對齊 spec error code 與 Sprint 9 慣例（ConstraintName 結構化判斷）

## Closes

Closes #121

🤖 Generated with [Claude Code](https://claude.com/claude-code)