### PR TITLE
feat(backend): F-031c Task CRUD + complete + upcoming/overdue

### DIFF
--- a/dev/src/handler/task.go
+++ b/dev/src/handler/task.go
@@ -1,0 +1,278 @@
+package handler
+
+import (
+	"net/http"
+	"strconv"
+	"strings"
+
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+	"github.com/gpwork4u/aibo/dto"
+	"github.com/gpwork4u/aibo/model"
+	"github.com/gpwork4u/aibo/service"
+)
+
+// TaskHandler 任務 HTTP handlers（F-031c）
+type TaskHandler struct {
+	svc            *service.TaskService
+	projectService *service.ProjectService // 用來查 project name 給 upcoming/overdue
+}
+
+// NewTaskHandler 建立 TaskHandler
+func NewTaskHandler(svc *service.TaskService, projectSvc *service.ProjectService) *TaskHandler {
+	return &TaskHandler{svc: svc, projectService: projectSvc}
+}
+
+// formatTaskDate 將 *time.Time 轉成 *string YYYY-MM-DD
+func formatTaskDate(t *model.Task) *string {
+	if t.DueDate == nil {
+		return nil
+	}
+	s := t.DueDate.UTC().Format("2006-01-02")
+	return &s
+}
+
+// toTaskResponse 將 model + refs 組成 dto.TaskResponse
+func toTaskResponse(t *model.Task, refs []model.TaskRef) dto.TaskResponse {
+	refsDTO := make([]dto.TaskRefDTO, 0, len(refs))
+	for _, r := range refs {
+		refsDTO = append(refsDTO, dto.TaskRefDTO{
+			RefType: r.RefType,
+			RefID:   r.RefID,
+		})
+	}
+	return dto.TaskResponse{
+		ID:          t.ID,
+		ProjectID:   t.ProjectID,
+		Title:       t.Title,
+		Description: t.Description,
+		Status:      t.Status,
+		Priority:    t.Priority,
+		DueDate:     formatTaskDate(t),
+		Position:    t.Position,
+		Refs:        refsDTO,
+		CreatedAt:   t.CreatedAt,
+		UpdatedAt:   t.UpdatedAt,
+		CompletedAt: t.CompletedAt,
+	}
+}
+
+// writeTaskError 統一輸出 AppError
+func writeTaskError(c *gin.Context, err error) {
+	if appErr, ok := err.(*model.AppError); ok {
+		c.JSON(appErr.Status, dto.ErrorResponse{Code: appErr.Code, Message: appErr.Message})
+		return
+	}
+	c.JSON(http.StatusInternalServerError, dto.ErrorResponse{
+		Code:    "INTERNAL_ERROR",
+		Message: "伺服器內部錯誤",
+	})
+}
+
+// parseTaskUUIDParam 從 :id / :project_id 取出 uuid.UUID
+func parseTaskUUIDParam(c *gin.Context, key string) (uuid.UUID, bool) {
+	id, err := uuid.Parse(c.Param(key))
+	if err != nil {
+		c.JSON(http.StatusBadRequest, dto.ErrorResponse{
+			Code:    model.ErrCodeInvalidInput,
+			Message: key + " 必須為合法的 UUID",
+		})
+		return uuid.Nil, false
+	}
+	return id, true
+}
+
+// CreateInProject POST /api/v1/projects/:id/tasks
+func (h *TaskHandler) CreateInProject(c *gin.Context) {
+	projectID, ok := parseTaskUUIDParam(c, "id")
+	if !ok {
+		return
+	}
+	var req dto.CreateTaskRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, dto.ErrorResponse{
+			Code:    model.ErrCodeInvalidInput,
+			Message: err.Error(),
+		})
+		return
+	}
+	t, refs, err := h.svc.Create(c.Request.Context(), projectID, &req)
+	if err != nil {
+		writeTaskError(c, err)
+		return
+	}
+	c.JSON(http.StatusCreated, toTaskResponse(t, refs))
+}
+
+// ListByProject GET /api/v1/projects/:id/tasks?status=todo,in_progress
+func (h *TaskHandler) ListByProject(c *gin.Context) {
+	projectID, ok := parseTaskUUIDParam(c, "id")
+	if !ok {
+		return
+	}
+	var statusFilter []string
+	if v := c.Query("status"); v != "" {
+		raw := strings.Split(v, ",")
+		for _, s := range raw {
+			s = strings.TrimSpace(s)
+			if s == "" {
+				continue
+			}
+			if !model.IsValidTaskStatus(s) {
+				c.JSON(http.StatusBadRequest, dto.ErrorResponse{
+					Code:    model.ErrCodeInvalidInput,
+					Message: "status 必須為 todo / in_progress / blocked / done / cancelled",
+				})
+				return
+			}
+			statusFilter = append(statusFilter, s)
+		}
+	}
+
+	items, err := h.svc.ListByProject(c.Request.Context(), projectID, statusFilter)
+	if err != nil {
+		writeTaskError(c, err)
+		return
+	}
+
+	data := make([]dto.TaskResponse, 0, len(items))
+	for _, t := range items {
+		// 列表不展開 refs（避免 N+1）
+		data = append(data, toTaskResponse(t, nil))
+	}
+	c.JSON(http.StatusOK, dto.ListTasksResponse{Data: data})
+}
+
+// GetByID GET /api/v1/tasks/:id
+func (h *TaskHandler) GetByID(c *gin.Context) {
+	id, ok := parseTaskUUIDParam(c, "id")
+	if !ok {
+		return
+	}
+	t, refs, err := h.svc.Get(c.Request.Context(), id)
+	if err != nil {
+		writeTaskError(c, err)
+		return
+	}
+	c.JSON(http.StatusOK, toTaskResponse(t, refs))
+}
+
+// Update PATCH /api/v1/tasks/:id
+func (h *TaskHandler) Update(c *gin.Context) {
+	id, ok := parseTaskUUIDParam(c, "id")
+	if !ok {
+		return
+	}
+	var req dto.UpdateTaskRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, dto.ErrorResponse{
+			Code:    model.ErrCodeInvalidInput,
+			Message: err.Error(),
+		})
+		return
+	}
+	t, refs, err := h.svc.Update(c.Request.Context(), id, &req)
+	if err != nil {
+		writeTaskError(c, err)
+		return
+	}
+	c.JSON(http.StatusOK, toTaskResponse(t, refs))
+}
+
+// Complete POST /api/v1/tasks/:id/complete
+func (h *TaskHandler) Complete(c *gin.Context) {
+	id, ok := parseTaskUUIDParam(c, "id")
+	if !ok {
+		return
+	}
+	t, err := h.svc.Complete(c.Request.Context(), id)
+	if err != nil {
+		writeTaskError(c, err)
+		return
+	}
+	// 重新撈 refs 一致回傳
+	_, refs, err := h.svc.Get(c.Request.Context(), id)
+	if err != nil {
+		writeTaskError(c, err)
+		return
+	}
+	c.JSON(http.StatusOK, toTaskResponse(t, refs))
+}
+
+// Delete DELETE /api/v1/tasks/:id
+func (h *TaskHandler) Delete(c *gin.Context) {
+	id, ok := parseTaskUUIDParam(c, "id")
+	if !ok {
+		return
+	}
+	if err := h.svc.Delete(c.Request.Context(), id); err != nil {
+		writeTaskError(c, err)
+		return
+	}
+	c.Status(http.StatusNoContent)
+}
+
+// Upcoming GET /api/v1/tasks/upcoming?days=7
+func (h *TaskHandler) Upcoming(c *gin.Context) {
+	days := 7
+	if v := c.Query("days"); v != "" {
+		n, err := strconv.Atoi(v)
+		if err != nil {
+			c.JSON(http.StatusBadRequest, dto.ErrorResponse{
+				Code:    model.ErrCodeInvalidInput,
+				Message: "days 必須為整數",
+			})
+			return
+		}
+		days = n
+	}
+	items, err := h.svc.ListUpcoming(c.Request.Context(), days)
+	if err != nil {
+		writeTaskError(c, err)
+		return
+	}
+	c.JSON(http.StatusOK, dto.UpcomingTasksResponse{
+		Data: h.toUpcomingItems(c, items),
+	})
+}
+
+// Overdue GET /api/v1/tasks/overdue
+func (h *TaskHandler) Overdue(c *gin.Context) {
+	items, err := h.svc.ListOverdue(c.Request.Context())
+	if err != nil {
+		writeTaskError(c, err)
+		return
+	}
+	c.JSON(http.StatusOK, dto.UpcomingTasksResponse{
+		Data: h.toUpcomingItems(c, items),
+	})
+}
+
+// toUpcomingItems 為 upcoming/overdue 補 project_name（小數量；naive cache）
+func (h *TaskHandler) toUpcomingItems(c *gin.Context, items []*model.Task) []dto.UpcomingTaskItem {
+	out := make([]dto.UpcomingTaskItem, 0, len(items))
+	cache := map[uuid.UUID]string{}
+	for _, t := range items {
+		name, ok := cache[t.ProjectID]
+		if !ok {
+			if h.projectService != nil {
+				if p, _, err := h.projectService.Get(c.Request.Context(), t.ProjectID); err == nil && p != nil {
+					name = p.Name
+				}
+			}
+			cache[t.ProjectID] = name
+		}
+		out = append(out, dto.UpcomingTaskItem{
+			ID:          t.ID,
+			ProjectID:   t.ProjectID,
+			ProjectName: name,
+			Title:       t.Title,
+			Status:      t.Status,
+			Priority:    t.Priority,
+			DueDate:     formatTaskDate(t),
+			UpdatedAt:   t.UpdatedAt,
+			CompletedAt: t.CompletedAt,
+		})
+	}
+	return out
+}

--- a/dev/src/handler/task_test.go
+++ b/dev/src/handler/task_test.go
@@ -1,0 +1,497 @@
+package handler
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+	"github.com/gpwork4u/aibo/dto"
+	"github.com/gpwork4u/aibo/model"
+	"github.com/gpwork4u/aibo/service"
+)
+
+// ─── Fakes ─────────────────────────────────────────────────────────────
+
+type fakeTaskRepoFull struct {
+	tasks    map[uuid.UUID]*model.Task
+	refs     map[uuid.UUID][]model.TaskRef
+	upcoming []*model.Task
+	overdue  []*model.Task
+}
+
+func newFakeTaskRepoFull() *fakeTaskRepoFull {
+	return &fakeTaskRepoFull{
+		tasks: map[uuid.UUID]*model.Task{},
+		refs:  map[uuid.UUID][]model.TaskRef{},
+	}
+}
+
+func (r *fakeTaskRepoFull) Create(_ context.Context, t *model.Task, refs []model.TaskRef) error {
+	if t.ID == uuid.Nil {
+		t.ID = uuid.New()
+	}
+	now := time.Now()
+	t.CreatedAt = now
+	t.UpdatedAt = now
+	if t.Status == "" {
+		t.Status = model.TaskStatusTodo
+	}
+	if t.Priority == "" {
+		t.Priority = model.TaskPriorityNormal
+	}
+	cp := *t
+	r.tasks[t.ID] = &cp
+	if len(refs) > 0 {
+		stored := make([]model.TaskRef, len(refs))
+		for i, ref := range refs {
+			stored[i] = model.TaskRef{TaskID: t.ID, RefType: ref.RefType, RefID: ref.RefID}
+		}
+		r.refs[t.ID] = stored
+	}
+	return nil
+}
+func (r *fakeTaskRepoFull) FindByID(_ context.Context, id uuid.UUID) (*model.Task, []model.TaskRef, error) {
+	t, ok := r.tasks[id]
+	if !ok {
+		return nil, nil, model.NewAppError(404, model.ErrCodeTaskNotFound, "任務不存在")
+	}
+	cp := *t
+	refs := append([]model.TaskRef(nil), r.refs[id]...)
+	return &cp, refs, nil
+}
+func (r *fakeTaskRepoFull) ListByProject(_ context.Context, projectID uuid.UUID, statusFilter []string) ([]*model.Task, error) {
+	out := make([]*model.Task, 0)
+	for _, t := range r.tasks {
+		if t.ProjectID != projectID {
+			continue
+		}
+		if len(statusFilter) > 0 {
+			match := false
+			for _, s := range statusFilter {
+				if t.Status == s {
+					match = true
+					break
+				}
+			}
+			if !match {
+				continue
+			}
+		}
+		cp := *t
+		out = append(out, &cp)
+	}
+	return out, nil
+}
+func (r *fakeTaskRepoFull) Update(_ context.Context, t *model.Task) error {
+	if _, ok := r.tasks[t.ID]; !ok {
+		return model.NewAppError(404, model.ErrCodeTaskNotFound, "任務不存在")
+	}
+	t.UpdatedAt = time.Now()
+	cp := *t
+	r.tasks[t.ID] = &cp
+	return nil
+}
+func (r *fakeTaskRepoFull) ReplaceRefs(_ context.Context, taskID uuid.UUID, refs []model.TaskRef) error {
+	if len(refs) == 0 {
+		delete(r.refs, taskID)
+		return nil
+	}
+	stored := make([]model.TaskRef, len(refs))
+	for i, ref := range refs {
+		stored[i] = model.TaskRef{TaskID: taskID, RefType: ref.RefType, RefID: ref.RefID}
+	}
+	r.refs[taskID] = stored
+	return nil
+}
+func (r *fakeTaskRepoFull) Delete(_ context.Context, id uuid.UUID) error {
+	if _, ok := r.tasks[id]; !ok {
+		return model.NewAppError(404, model.ErrCodeTaskNotFound, "任務不存在")
+	}
+	delete(r.tasks, id)
+	delete(r.refs, id)
+	return nil
+}
+func (r *fakeTaskRepoFull) ListUpcoming(_ context.Context, _ int) ([]*model.Task, error) {
+	return r.upcoming, nil
+}
+func (r *fakeTaskRepoFull) ListOverdue(_ context.Context) ([]*model.Task, error) {
+	return r.overdue, nil
+}
+func (r *fakeTaskRepoFull) CountByProject(_ context.Context, projectID uuid.UUID) (int, error) {
+	c := 0
+	for _, t := range r.tasks {
+		if t.ProjectID == projectID {
+			c++
+		}
+	}
+	return c, nil
+}
+func (r *fakeTaskRepoFull) GetRefs(_ context.Context, taskID uuid.UUID) ([]model.TaskRef, error) {
+	return append([]model.TaskRef(nil), r.refs[taskID]...), nil
+}
+
+type fakeRefValidatorH struct {
+	entries map[uuid.UUID]bool
+}
+
+func (v *fakeRefValidatorH) EntryExists(_ context.Context, id uuid.UUID) (bool, error) {
+	return v.entries[id], nil
+}
+func (v *fakeRefValidatorH) JournalExistsByDate(_ context.Context, _ time.Time) (bool, error) {
+	return false, nil
+}
+
+// ─── Helper：建 router with task handler ────────────────────────────────
+
+func newTaskTestRouter(t *testing.T) (
+	*gin.Engine,
+	*fakeProjectRepoH,
+	*fakeTaskRepoFull,
+	*fakeRefValidatorH,
+) {
+	t.Helper()
+	gin.SetMode(gin.TestMode)
+	pr := newFakeProjectRepoH()
+	tr := newFakeTaskRepoFull()
+	rv := &fakeRefValidatorH{entries: map[uuid.UUID]bool{}}
+
+	psvc := service.NewProjectService(pr, tr)
+	tsvc := service.NewTaskServiceWithValidator(tr, pr, rv, psvc)
+	th := NewTaskHandler(tsvc, psvc)
+
+	r := gin.New()
+	v1 := r.Group("/api/v1")
+	{
+		projects := v1.Group("/projects")
+		projects.POST("/:id/tasks", th.CreateInProject)
+		projects.GET("/:id/tasks", th.ListByProject)
+
+		tasks := v1.Group("/tasks")
+		tasks.GET("/upcoming", th.Upcoming)
+		tasks.GET("/overdue", th.Overdue)
+		tasks.GET("/:id", th.GetByID)
+		tasks.PATCH("/:id", th.Update)
+		tasks.POST("/:id/complete", th.Complete)
+		tasks.DELETE("/:id", th.Delete)
+	}
+	return r, pr, tr, rv
+}
+
+func doTaskReq(r *gin.Engine, method, path string, body any) *httptest.ResponseRecorder {
+	var buf *bytes.Buffer
+	if body != nil {
+		b, _ := json.Marshal(body)
+		buf = bytes.NewBuffer(b)
+	} else {
+		buf = bytes.NewBuffer(nil)
+	}
+	req := httptest.NewRequest(method, path, buf)
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	return w
+}
+
+func seedProject(pr *fakeProjectRepoH, status string) *model.Project {
+	id := uuid.New()
+	p := &model.Project{ID: id, Name: "P", Status: status}
+	pr.store[id] = p
+	return p
+}
+
+// ─── Tests ─────────────────────────────────────────────────────────────
+
+// 1. POST /projects/:id/tasks → 201
+func TestTaskHandler_Create_201(t *testing.T) {
+	r, pr, _, _ := newTaskTestRouter(t)
+	p := seedProject(pr, model.ProjectStatusActive)
+	w := doTaskReq(r, "POST", "/api/v1/projects/"+p.ID.String()+"/tasks",
+		dto.CreateTaskRequest{Title: "設計"})
+	if w.Code != http.StatusCreated {
+		t.Fatalf("expected 201, got %d body=%s", w.Code, w.Body.String())
+	}
+	var resp dto.TaskResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if resp.Title != "設計" || resp.Status != model.TaskStatusTodo {
+		t.Errorf("unexpected: %+v", resp)
+	}
+}
+
+// 2. POST 不合法 project id → 400
+func TestTaskHandler_Create_BadProjectID(t *testing.T) {
+	r, _, _, _ := newTaskTestRouter(t)
+	w := doTaskReq(r, "POST", "/api/v1/projects/not-a-uuid/tasks",
+		dto.CreateTaskRequest{Title: "x"})
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("expected 400, got %d", w.Code)
+	}
+}
+
+// 3. POST archived project → 400 PROJECT_ARCHIVED
+func TestTaskHandler_Create_Archived(t *testing.T) {
+	r, pr, _, _ := newTaskTestRouter(t)
+	p := seedProject(pr, model.ProjectStatusArchived)
+	w := doTaskReq(r, "POST", "/api/v1/projects/"+p.ID.String()+"/tasks",
+		dto.CreateTaskRequest{Title: "x"})
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d body=%s", w.Code, w.Body.String())
+	}
+	var er dto.ErrorResponse
+	_ = json.Unmarshal(w.Body.Bytes(), &er)
+	if er.Code != model.ErrCodeProjectArchived {
+		t.Errorf("expected PROJECT_ARCHIVED, got %s", er.Code)
+	}
+}
+
+// 4. POST project 不存在 → 404
+func TestTaskHandler_Create_ProjectNotFound(t *testing.T) {
+	r, _, _, _ := newTaskTestRouter(t)
+	w := doTaskReq(r, "POST", "/api/v1/projects/"+uuid.New().String()+"/tasks",
+		dto.CreateTaskRequest{Title: "x"})
+	if w.Code != http.StatusNotFound {
+		t.Errorf("expected 404, got %d", w.Code)
+	}
+}
+
+// 5. POST 缺 title → 400
+func TestTaskHandler_Create_MissingTitle(t *testing.T) {
+	r, pr, _, _ := newTaskTestRouter(t)
+	p := seedProject(pr, model.ProjectStatusActive)
+	w := doTaskReq(r, "POST", "/api/v1/projects/"+p.ID.String()+"/tasks",
+		map[string]any{})
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("expected 400, got %d", w.Code)
+	}
+}
+
+// 6. GET /projects/:id/tasks 列表
+func TestTaskHandler_ListByProject(t *testing.T) {
+	r, pr, tr, _ := newTaskTestRouter(t)
+	p := seedProject(pr, model.ProjectStatusActive)
+	tr.tasks[uuid.New()] = &model.Task{
+		ID: uuid.New(), ProjectID: p.ID, Title: "a",
+		Status: model.TaskStatusTodo, Priority: model.TaskPriorityNormal,
+	}
+	tr.tasks[uuid.New()] = &model.Task{
+		ID: uuid.New(), ProjectID: p.ID, Title: "b",
+		Status: model.TaskStatusInProgress, Priority: model.TaskPriorityNormal,
+	}
+	w := doTaskReq(r, "GET", "/api/v1/projects/"+p.ID.String()+"/tasks", nil)
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+	var resp dto.ListTasksResponse
+	_ = json.Unmarshal(w.Body.Bytes(), &resp)
+	if len(resp.Data) != 2 {
+		t.Errorf("expected 2 items, got %d", len(resp.Data))
+	}
+}
+
+// 7. GET 列表 status filter
+func TestTaskHandler_ListByProject_StatusFilter(t *testing.T) {
+	r, pr, tr, _ := newTaskTestRouter(t)
+	p := seedProject(pr, model.ProjectStatusActive)
+	tr.tasks[uuid.New()] = &model.Task{
+		ID: uuid.New(), ProjectID: p.ID, Title: "a",
+		Status: model.TaskStatusTodo, Priority: model.TaskPriorityNormal,
+	}
+	tr.tasks[uuid.New()] = &model.Task{
+		ID: uuid.New(), ProjectID: p.ID, Title: "b",
+		Status: model.TaskStatusDone, Priority: model.TaskPriorityNormal,
+	}
+	w := doTaskReq(r, "GET", "/api/v1/projects/"+p.ID.String()+"/tasks?status=todo", nil)
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+	var resp dto.ListTasksResponse
+	_ = json.Unmarshal(w.Body.Bytes(), &resp)
+	if len(resp.Data) != 1 || resp.Data[0].Status != "todo" {
+		t.Errorf("expected 1 todo, got %+v", resp.Data)
+	}
+}
+
+// 8. GET 列表 status filter 含非法值 → 400
+func TestTaskHandler_ListByProject_BadStatus(t *testing.T) {
+	r, pr, _, _ := newTaskTestRouter(t)
+	p := seedProject(pr, model.ProjectStatusActive)
+	w := doTaskReq(r, "GET", "/api/v1/projects/"+p.ID.String()+"/tasks?status=wrong", nil)
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("expected 400, got %d", w.Code)
+	}
+}
+
+// 9. GET /tasks/:id → 200
+func TestTaskHandler_GetByID(t *testing.T) {
+	r, pr, tr, _ := newTaskTestRouter(t)
+	p := seedProject(pr, model.ProjectStatusActive)
+	id := uuid.New()
+	tr.tasks[id] = &model.Task{
+		ID: id, ProjectID: p.ID, Title: "x",
+		Status: model.TaskStatusTodo, Priority: model.TaskPriorityNormal,
+	}
+	w := doTaskReq(r, "GET", "/api/v1/tasks/"+id.String(), nil)
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+}
+
+// 10. GET /tasks/:id 不存在 → 404
+func TestTaskHandler_GetByID_NotFound(t *testing.T) {
+	r, _, _, _ := newTaskTestRouter(t)
+	w := doTaskReq(r, "GET", "/api/v1/tasks/"+uuid.New().String(), nil)
+	if w.Code != http.StatusNotFound {
+		t.Errorf("expected 404, got %d", w.Code)
+	}
+}
+
+// 11. PATCH /tasks/:id → 200
+func TestTaskHandler_Update(t *testing.T) {
+	r, pr, tr, _ := newTaskTestRouter(t)
+	p := seedProject(pr, model.ProjectStatusActive)
+	id := uuid.New()
+	tr.tasks[id] = &model.Task{
+		ID: id, ProjectID: p.ID, Title: "old",
+		Status: model.TaskStatusTodo, Priority: model.TaskPriorityNormal,
+	}
+	newTitle := "new"
+	w := doTaskReq(r, "PATCH", "/api/v1/tasks/"+id.String(),
+		dto.UpdateTaskRequest{Title: &newTitle})
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d body=%s", w.Code, w.Body.String())
+	}
+	var resp dto.TaskResponse
+	_ = json.Unmarshal(w.Body.Bytes(), &resp)
+	if resp.Title != "new" {
+		t.Errorf("title not updated: %s", resp.Title)
+	}
+}
+
+// 12. POST /tasks/:id/complete → 200 + status=done
+func TestTaskHandler_Complete(t *testing.T) {
+	r, pr, tr, _ := newTaskTestRouter(t)
+	p := seedProject(pr, model.ProjectStatusActive)
+	id := uuid.New()
+	tr.tasks[id] = &model.Task{
+		ID: id, ProjectID: p.ID, Title: "x",
+		Status: model.TaskStatusTodo, Priority: model.TaskPriorityNormal,
+	}
+	w := doTaskReq(r, "POST", "/api/v1/tasks/"+id.String()+"/complete", nil)
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+	var resp dto.TaskResponse
+	_ = json.Unmarshal(w.Body.Bytes(), &resp)
+	if resp.Status != model.TaskStatusDone || resp.CompletedAt == nil {
+		t.Errorf("expected done with completed_at, got %+v", resp)
+	}
+}
+
+// 13. DELETE /tasks/:id → 204
+func TestTaskHandler_Delete(t *testing.T) {
+	r, pr, tr, _ := newTaskTestRouter(t)
+	p := seedProject(pr, model.ProjectStatusActive)
+	id := uuid.New()
+	tr.tasks[id] = &model.Task{
+		ID: id, ProjectID: p.ID, Title: "x",
+		Status: model.TaskStatusTodo, Priority: model.TaskPriorityNormal,
+	}
+	w := doTaskReq(r, "DELETE", "/api/v1/tasks/"+id.String(), nil)
+	if w.Code != http.StatusNoContent {
+		t.Errorf("expected 204, got %d", w.Code)
+	}
+	if _, ok := tr.tasks[id]; ok {
+		t.Errorf("task should be deleted")
+	}
+}
+
+// 14. GET /tasks/upcoming → 200
+func TestTaskHandler_Upcoming(t *testing.T) {
+	r, pr, tr, _ := newTaskTestRouter(t)
+	p := seedProject(pr, model.ProjectStatusActive)
+	now := time.Now()
+	tr.upcoming = []*model.Task{
+		{ID: uuid.New(), ProjectID: p.ID, Title: "a", Status: "todo", Priority: "normal", DueDate: &now},
+	}
+	w := doTaskReq(r, "GET", "/api/v1/tasks/upcoming?days=7", nil)
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+	var resp dto.UpcomingTasksResponse
+	_ = json.Unmarshal(w.Body.Bytes(), &resp)
+	if len(resp.Data) != 1 {
+		t.Errorf("expected 1 item, got %d", len(resp.Data))
+	}
+	if resp.Data[0].ProjectName != "P" {
+		t.Errorf("expected project_name=P, got %s", resp.Data[0].ProjectName)
+	}
+}
+
+// 15. GET /tasks/upcoming bad days → 400
+func TestTaskHandler_Upcoming_BadDays(t *testing.T) {
+	r, _, _, _ := newTaskTestRouter(t)
+	w := doTaskReq(r, "GET", "/api/v1/tasks/upcoming?days=abc", nil)
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("expected 400, got %d", w.Code)
+	}
+}
+
+// 16. GET /tasks/overdue
+func TestTaskHandler_Overdue(t *testing.T) {
+	r, pr, tr, _ := newTaskTestRouter(t)
+	p := seedProject(pr, model.ProjectStatusActive)
+	yesterday := time.Now().AddDate(0, 0, -1)
+	tr.overdue = []*model.Task{
+		{ID: uuid.New(), ProjectID: p.ID, Title: "old", Status: "todo", Priority: "high", DueDate: &yesterday},
+	}
+	w := doTaskReq(r, "GET", "/api/v1/tasks/overdue", nil)
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+	var resp dto.UpcomingTasksResponse
+	_ = json.Unmarshal(w.Body.Bytes(), &resp)
+	if len(resp.Data) != 1 {
+		t.Errorf("expected 1, got %d", len(resp.Data))
+	}
+}
+
+// 17. /tasks/upcoming 不會被 /tasks/:id 攔截（路由順序驗證）
+func TestTaskHandler_RoutingOrder(t *testing.T) {
+	r, _, _, _ := newTaskTestRouter(t)
+	w := doTaskReq(r, "GET", "/api/v1/tasks/upcoming", nil)
+	if w.Code != http.StatusOK {
+		t.Errorf("expected 200 (routed to upcoming, not :id), got %d body=%s",
+			w.Code, w.Body.String())
+	}
+}
+
+// 18. PATCH /tasks/:id with refs replace
+func TestTaskHandler_Update_RefsReplace(t *testing.T) {
+	r, pr, tr, rv := newTaskTestRouter(t)
+	p := seedProject(pr, model.ProjectStatusActive)
+	entryID := uuid.New()
+	rv.entries[entryID] = true
+	id := uuid.New()
+	tr.tasks[id] = &model.Task{
+		ID: id, ProjectID: p.ID, Title: "x",
+		Status: model.TaskStatusTodo, Priority: model.TaskPriorityNormal,
+	}
+	refs := []dto.TaskRefDTO{{RefType: "entry", RefID: entryID.String()}}
+	w := doTaskReq(r, "PATCH", "/api/v1/tasks/"+id.String(),
+		dto.UpdateTaskRequest{Refs: &refs})
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d body=%s", w.Code, w.Body.String())
+	}
+	var resp dto.TaskResponse
+	_ = json.Unmarshal(w.Body.Bytes(), &resp)
+	if len(resp.Refs) != 1 || resp.Refs[0].RefType != "entry" {
+		t.Errorf("refs not replaced: %+v", resp.Refs)
+	}
+}

--- a/dev/src/main.go
+++ b/dev/src/main.go
@@ -146,8 +146,12 @@ func main() {
 	projectSvc := service.NewProjectService(projectRepo, taskRepo)
 	projectHandler := handler.NewProjectHandler(projectSvc)
 
+	// 初始化任務服務（F-031c：CRUD + complete + upcoming/overdue）
+	taskSvc := service.NewTaskService(taskRepo, projectRepo, entryRepo, journalRepo, projectSvc)
+	taskHandler := handler.NewTaskHandler(taskSvc, projectSvc)
+
 	// 設定路由
-	r := router.Setup(apiKeySvc, apiKeyHandler, categoryHandler, llmProviderHandler, entryHandler, classifyHandler, searchHandler, gitImportHandler, gcalHandler, confidenceHandler, statsHandler, systemHandler, lifecycleHandler, calendarConvertHandler, calendarHandler, journalHandler, journalDraftHandler, projectHandler)
+	r := router.Setup(apiKeySvc, apiKeyHandler, categoryHandler, llmProviderHandler, entryHandler, classifyHandler, searchHandler, gitImportHandler, gcalHandler, confidenceHandler, statsHandler, systemHandler, lifecycleHandler, calendarConvertHandler, calendarHandler, journalHandler, journalDraftHandler, projectHandler, taskHandler)
 
 	// 啟動 HTTP server（graceful shutdown）
 	srv := &http.Server{

--- a/dev/src/model/error.go
+++ b/dev/src/model/error.go
@@ -29,6 +29,8 @@ const (
 	ErrCodeInvalidStatusTransition = "INVALID_STATUS_TRANSITION"
 	ErrCodeProjectNotFound         = "PROJECT_NOT_FOUND"
 	ErrCodeTaskNotFound            = "TASK_NOT_FOUND"
+	ErrCodeProjectArchived         = "PROJECT_ARCHIVED"
+	ErrCodeInvalidRefType          = "INVALID_REF_TYPE"
 )
 
 // AppError 應用程式錯誤

--- a/dev/src/router/router.go
+++ b/dev/src/router/router.go
@@ -10,7 +10,7 @@ import (
 )
 
 // Setup 設定路由
-func Setup(apiKeySvc *service.ApiKeyService, apiKeyHandler *handler.ApiKeyHandler, categoryHandler *handler.CategoryHandler, llmProviderHandler *handler.LlmProviderHandler, entryHandler *handler.EntryHandler, classifyHandler *handler.ClassifyHandler, searchHandler *handler.SearchHandler, gitImportHandler *handler.GitImportHandler, gcalHandler *handler.GcalHandler, confidenceHandler *handler.ConfidenceHandler, statsHandler *handler.StatsHandler, systemHandler *handler.SystemHandler, lifecycleHandler *handler.LifecycleHandler, calendarConvertHandler *handler.CalendarConvertHandler, calendarHandler *handler.CalendarHandler, journalHandler *handler.JournalHandler, journalDraftHandler *handler.JournalDraftHandler, projectHandler *handler.ProjectHandler) *gin.Engine {
+func Setup(apiKeySvc *service.ApiKeyService, apiKeyHandler *handler.ApiKeyHandler, categoryHandler *handler.CategoryHandler, llmProviderHandler *handler.LlmProviderHandler, entryHandler *handler.EntryHandler, classifyHandler *handler.ClassifyHandler, searchHandler *handler.SearchHandler, gitImportHandler *handler.GitImportHandler, gcalHandler *handler.GcalHandler, confidenceHandler *handler.ConfidenceHandler, statsHandler *handler.StatsHandler, systemHandler *handler.SystemHandler, lifecycleHandler *handler.LifecycleHandler, calendarConvertHandler *handler.CalendarConvertHandler, calendarHandler *handler.CalendarHandler, journalHandler *handler.JournalHandler, journalDraftHandler *handler.JournalDraftHandler, projectHandler *handler.ProjectHandler, taskHandler *handler.TaskHandler) *gin.Engine {
 	r := gin.Default()
 
 	// CORS middleware — 允許跨網域（前端 localhost:3000 呼叫 API localhost:8080）
@@ -151,6 +151,22 @@ func Setup(apiKeySvc *service.ApiKeyService, apiKeyHandler *handler.ApiKeyHandle
 			projects.PATCH("/:id", projectHandler.Update)
 			projects.DELETE("/:id", projectHandler.Delete)
 			projects.POST("/:id/archive", projectHandler.Archive)
+
+			// 巢狀 task：建立 / 列表（F-031c）
+			projects.POST("/:id/tasks", taskHandler.CreateInProject)
+			projects.GET("/:id/tasks", taskHandler.ListByProject)
+		}
+
+		// 任務（F-031c：詳情 / 更新 / 完成 / 刪除 / upcoming / overdue）
+		// 注意：/upcoming /overdue 必須在 /:id 之前以避免誤匹配
+		tasks := v1.Group("/tasks")
+		{
+			tasks.GET("/upcoming", taskHandler.Upcoming)
+			tasks.GET("/overdue", taskHandler.Overdue)
+			tasks.GET("/:id", taskHandler.GetByID)
+			tasks.PATCH("/:id", taskHandler.Update)
+			tasks.POST("/:id/complete", taskHandler.Complete)
+			tasks.DELETE("/:id", taskHandler.Delete)
 		}
 	}
 

--- a/dev/src/service/task.go
+++ b/dev/src/service/task.go
@@ -1,0 +1,466 @@
+package service
+
+import (
+	"context"
+	"log/slog"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/gpwork4u/aibo/dto"
+	"github.com/gpwork4u/aibo/model"
+)
+
+// TaskRefValidator 對 task_refs 做存在性驗證的最小介面
+//
+// 拆出獨立介面避免 TaskService 直接綁 EntryRepository / JournalRepository 的整套
+// API，以利 unit test。
+type TaskRefValidator interface {
+	EntryExists(ctx context.Context, id uuid.UUID) (bool, error)
+	JournalExistsByDate(ctx context.Context, date time.Time) (bool, error)
+}
+
+// EntryFinder 包一層 EntryRepository.FindByID
+type EntryFinder interface {
+	FindByID(ctx context.Context, id uuid.UUID) (*model.Entry, error)
+}
+
+// JournalDateFinder 包一層 JournalRepository.GetByDate
+type JournalDateFinder interface {
+	GetByDate(ctx context.Context, date time.Time) (*model.Journal, []model.JournalSourceRef, error)
+}
+
+// taskRefValidatorAdapter 將 EntryRepository / JournalRepository 串成 TaskRefValidator
+type taskRefValidatorAdapter struct {
+	entryRepo   EntryFinder
+	journalRepo JournalDateFinder
+}
+
+func (a *taskRefValidatorAdapter) EntryExists(ctx context.Context, id uuid.UUID) (bool, error) {
+	e, err := a.entryRepo.FindByID(ctx, id)
+	if err != nil {
+		// 統一將底層錯誤回傳；service 層會包裝
+		return false, err
+	}
+	return e != nil, nil
+}
+
+func (a *taskRefValidatorAdapter) JournalExistsByDate(ctx context.Context, date time.Time) (bool, error) {
+	j, _, err := a.journalRepo.GetByDate(ctx, date)
+	if err != nil {
+		// JournalRepository.GetByDate 不存在會回 AppError 404，需轉成 (false, nil)
+		if appErr, ok := err.(*model.AppError); ok && appErr.Status == 404 {
+			return false, nil
+		}
+		return false, err
+	}
+	return j != nil, nil
+}
+
+// TaskService 任務 business logic（F-031c）
+//
+// 職責：
+//   - title 1..200 / description <= 5000 / due_date 格式驗證
+//   - status / priority enum 驗證；done → 其他 自動清 completed_at
+//   - refs 驗證：entry 用 EntryRepository / journal 用 JournalRepository.GetByDate(YYYY-MM-DD)
+//   - Create/Update/Complete/Delete 後呼叫 ProjectService.RecomputeProgress
+//   - archived project 不可新增 task → 400 PROJECT_ARCHIVED
+type TaskService struct {
+	taskRepo       TaskRepository
+	projectRepo    ProjectRepository
+	refValidator   TaskRefValidator
+	projectService *ProjectService
+}
+
+// NewTaskService 由 main 注入完整 dependencies
+func NewTaskService(
+	taskRepo TaskRepository,
+	projectRepo ProjectRepository,
+	entryRepo EntryFinder,
+	journalRepo JournalDateFinder,
+	projectService *ProjectService,
+) *TaskService {
+	return &TaskService{
+		taskRepo:    taskRepo,
+		projectRepo: projectRepo,
+		refValidator: &taskRefValidatorAdapter{
+			entryRepo:   entryRepo,
+			journalRepo: journalRepo,
+		},
+		projectService: projectService,
+	}
+}
+
+// NewTaskServiceWithValidator 測試用注入點
+func NewTaskServiceWithValidator(
+	taskRepo TaskRepository,
+	projectRepo ProjectRepository,
+	validator TaskRefValidator,
+	projectService *ProjectService,
+) *TaskService {
+	return &TaskService{
+		taskRepo:       taskRepo,
+		projectRepo:    projectRepo,
+		refValidator:   validator,
+		projectService: projectService,
+	}
+}
+
+// parseTaskDueDate 將 YYYY-MM-DD 轉成 UTC date（00:00），空字串視為錯誤
+func parseTaskDueDate(s string) (time.Time, error) {
+	t, err := time.Parse("2006-01-02", s)
+	if err != nil {
+		return time.Time{}, model.NewAppError(400, model.ErrCodeInvalidInput,
+			"due_date 格式錯誤，需 YYYY-MM-DD")
+	}
+	return time.Date(t.Year(), t.Month(), t.Day(), 0, 0, 0, 0, time.UTC), nil
+}
+
+// validateAndConvertRefs 驗證 task_refs（entry / journal / gcal_event）
+func (s *TaskService) validateAndConvertRefs(
+	ctx context.Context, refs []dto.TaskRefDTO,
+) ([]model.TaskRef, error) {
+	out := make([]model.TaskRef, 0, len(refs))
+	for _, r := range refs {
+		switch r.RefType {
+		case model.TaskRefTypeEntry:
+			id, err := uuid.Parse(r.RefID)
+			if err != nil {
+				return nil, model.NewAppError(400, model.ErrCodeInvalidInput,
+					"task ref entry id 格式錯誤")
+			}
+			ok, err := s.refValidator.EntryExists(ctx, id)
+			if err != nil {
+				return nil, err
+			}
+			if !ok {
+				return nil, model.NewAppError(400, model.ErrCodeInvalidInput,
+					"task ref entry not found")
+			}
+		case model.TaskRefTypeJournal:
+			d, err := time.Parse("2006-01-02", r.RefID)
+			if err != nil {
+				return nil, model.NewAppError(400, model.ErrCodeInvalidInput,
+					"task ref journal id 需為 YYYY-MM-DD")
+			}
+			date := time.Date(d.Year(), d.Month(), d.Day(), 0, 0, 0, 0, time.UTC)
+			ok, err := s.refValidator.JournalExistsByDate(ctx, date)
+			if err != nil {
+				return nil, err
+			}
+			if !ok {
+				return nil, model.NewAppError(400, model.ErrCodeInvalidInput,
+					"task ref journal not found")
+			}
+		case model.TaskRefTypeGcalEvent:
+			if strings.TrimSpace(r.RefID) == "" {
+				return nil, model.NewAppError(400, model.ErrCodeInvalidInput,
+					"gcal_event ref_id 不可為空")
+			}
+		default:
+			return nil, model.NewAppError(400, model.ErrCodeInvalidRefType,
+				"ref_type 必須為 entry / journal / gcal_event")
+		}
+		out = append(out, model.TaskRef{RefType: r.RefType, RefID: r.RefID})
+	}
+	return out, nil
+}
+
+// validateCreate 共用欄位檢查（Create 用）
+func validateTaskTitle(title string) (string, error) {
+	t := strings.TrimSpace(title)
+	if t == "" || len(t) > 200 {
+		return "", model.NewAppError(400, model.ErrCodeInvalidInput, "title 長度需 1~200")
+	}
+	return t, nil
+}
+
+// Create 建立 task
+//
+// Scenarios:
+//   - title 1..200、description <= 5000
+//   - status 預設 todo、priority 預設 normal
+//   - due_date 若有需 YYYY-MM-DD
+//   - archived project 不可新增 task → 400 PROJECT_ARCHIVED
+//   - project 不存在 → 404 PROJECT_NOT_FOUND
+//   - refs 驗證（entry/journal）
+//   - 建立後 RecomputeProgress
+func (s *TaskService) Create(
+	ctx context.Context, projectID uuid.UUID, req *dto.CreateTaskRequest,
+) (*model.Task, []model.TaskRef, error) {
+	if req == nil {
+		return nil, nil, model.NewAppError(400, model.ErrCodeInvalidInput, "request body 為必填")
+	}
+
+	// 確認 project 存在 + 非 archived
+	p, err := s.projectRepo.FindByID(ctx, projectID)
+	if err != nil {
+		return nil, nil, err
+	}
+	if p.Status == model.ProjectStatusArchived {
+		return nil, nil, model.NewAppError(400, model.ErrCodeProjectArchived,
+			"已封存的專案不可新增任務")
+	}
+
+	title, err := validateTaskTitle(req.Title)
+	if err != nil {
+		return nil, nil, err
+	}
+	if req.Description != nil && len(*req.Description) > 5000 {
+		return nil, nil, model.NewAppError(400, model.ErrCodeInvalidInput, "description 長度上限 5000")
+	}
+
+	status := model.TaskStatusTodo
+	if req.Status != nil && *req.Status != "" {
+		if !model.IsValidTaskStatus(*req.Status) {
+			return nil, nil, model.NewAppError(400, model.ErrCodeInvalidInput, "status 不合法")
+		}
+		status = *req.Status
+	}
+	priority := model.TaskPriorityNormal
+	if req.Priority != nil && *req.Priority != "" {
+		if !model.IsValidTaskPriority(*req.Priority) {
+			return nil, nil, model.NewAppError(400, model.ErrCodeInvalidInput, "priority 不合法")
+		}
+		priority = *req.Priority
+	}
+
+	var dueDate *time.Time
+	if req.DueDate != nil && *req.DueDate != "" {
+		d, err := parseTaskDueDate(*req.DueDate)
+		if err != nil {
+			return nil, nil, err
+		}
+		dueDate = &d
+	}
+
+	pos := 0
+	if req.Position != nil {
+		pos = *req.Position
+	}
+
+	refs, err := s.validateAndConvertRefs(ctx, req.Refs)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	t := &model.Task{
+		ProjectID:   projectID,
+		Title:       title,
+		Description: req.Description,
+		Status:      status,
+		Priority:    priority,
+		DueDate:     dueDate,
+		Position:    pos,
+	}
+	// 若 client 直接以 status=done 建立，自動補 completed_at
+	if status == model.TaskStatusDone {
+		now := time.Now().UTC()
+		t.CompletedAt = &now
+	}
+
+	if err := s.taskRepo.Create(ctx, t, refs); err != nil {
+		return nil, nil, err
+	}
+
+	if _, err := s.projectService.RecomputeProgress(ctx, projectID); err != nil {
+		slog.WarnContext(ctx, "task.create.recompute_progress_failed",
+			"project_id", projectID, "err", err)
+	}
+
+	slog.InfoContext(ctx, "task.create",
+		"id", t.ID, "project_id", projectID, "refs", len(refs))
+	return t, refs, nil
+}
+
+// Get 取得 task 詳情含 refs
+//
+// 不存在 → 404 TASK_NOT_FOUND
+func (s *TaskService) Get(
+	ctx context.Context, id uuid.UUID,
+) (*model.Task, []model.TaskRef, error) {
+	return s.taskRepo.FindByID(ctx, id)
+}
+
+// ListByProject 列表（依 project，無分頁）
+//
+// 超過 500 → 400 TOO_MANY_TASKS（由 repository 直接擋）
+func (s *TaskService) ListByProject(
+	ctx context.Context, projectID uuid.UUID, statusFilter []string,
+) ([]*model.Task, error) {
+	// 確認專案存在以一致 404 行為
+	if _, err := s.projectRepo.FindByID(ctx, projectID); err != nil {
+		return nil, err
+	}
+	return s.taskRepo.ListByProject(ctx, projectID, statusFilter)
+}
+
+// Update partial 更新
+//
+// Scenarios:
+//   - title 長度 1..200（若有更新）
+//   - description <= 5000
+//   - status/priority enum
+//   - done → 其他 → 自動清 completed_at；其他 → done → 自動補 completed_at
+//   - refs 為非 nil 則整批覆寫
+//   - 不存在 → 404 TASK_NOT_FOUND
+//   - 變動後 RecomputeProgress
+func (s *TaskService) Update(
+	ctx context.Context, id uuid.UUID, req *dto.UpdateTaskRequest,
+) (*model.Task, []model.TaskRef, error) {
+	if req == nil {
+		return nil, nil, model.NewAppError(400, model.ErrCodeInvalidInput, "request body 為必填")
+	}
+
+	current, _, err := s.taskRepo.FindByID(ctx, id)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	prevStatus := current.Status
+
+	if req.Title != nil {
+		t, err := validateTaskTitle(*req.Title)
+		if err != nil {
+			return nil, nil, err
+		}
+		current.Title = t
+	}
+	if req.Description != nil {
+		if *req.Description == nil {
+			current.Description = nil
+		} else {
+			d := **req.Description
+			if len(d) > 5000 {
+				return nil, nil, model.NewAppError(400, model.ErrCodeInvalidInput, "description 長度上限 5000")
+			}
+			current.Description = &d
+		}
+	}
+	if req.Status != nil {
+		if !model.IsValidTaskStatus(*req.Status) {
+			return nil, nil, model.NewAppError(400, model.ErrCodeInvalidInput, "status 不合法")
+		}
+		current.Status = *req.Status
+	}
+	if req.Priority != nil {
+		if !model.IsValidTaskPriority(*req.Priority) {
+			return nil, nil, model.NewAppError(400, model.ErrCodeInvalidInput, "priority 不合法")
+		}
+		current.Priority = *req.Priority
+	}
+	if req.DueDate != nil {
+		if *req.DueDate == nil {
+			current.DueDate = nil
+		} else {
+			d, err := parseTaskDueDate(**req.DueDate)
+			if err != nil {
+				return nil, nil, err
+			}
+			current.DueDate = &d
+		}
+	}
+	if req.Position != nil {
+		current.Position = *req.Position
+	}
+
+	// status transition：done → 其他 清 completed_at；其他 → done 補 completed_at
+	if prevStatus == model.TaskStatusDone && current.Status != model.TaskStatusDone {
+		current.CompletedAt = nil
+	}
+	if prevStatus != model.TaskStatusDone && current.Status == model.TaskStatusDone {
+		now := time.Now().UTC()
+		current.CompletedAt = &now
+	}
+
+	if err := s.taskRepo.Update(ctx, current); err != nil {
+		return nil, nil, err
+	}
+
+	// refs 整批覆寫（含 nil 不動 / 空陣列 = 全清）
+	var newRefs []model.TaskRef
+	if req.Refs != nil {
+		converted, err := s.validateAndConvertRefs(ctx, *req.Refs)
+		if err != nil {
+			return nil, nil, err
+		}
+		if err := s.taskRepo.ReplaceRefs(ctx, current.ID, converted); err != nil {
+			return nil, nil, err
+		}
+		newRefs = converted
+	} else {
+		got, err := s.taskRepo.GetRefs(ctx, current.ID)
+		if err != nil {
+			return nil, nil, err
+		}
+		newRefs = got
+	}
+
+	if _, err := s.projectService.RecomputeProgress(ctx, current.ProjectID); err != nil {
+		slog.WarnContext(ctx, "task.update.recompute_progress_failed",
+			"project_id", current.ProjectID, "err", err)
+	}
+	slog.InfoContext(ctx, "task.update", "id", id)
+	return current, newRefs, nil
+}
+
+// Complete 將 task 標記 done + 補 completed_at + RecomputeProgress
+//
+// 不存在 → 404 TASK_NOT_FOUND
+func (s *TaskService) Complete(ctx context.Context, id uuid.UUID) (*model.Task, error) {
+	t, _, err := s.taskRepo.FindByID(ctx, id)
+	if err != nil {
+		return nil, err
+	}
+	if t.Status != model.TaskStatusDone {
+		now := time.Now().UTC()
+		t.Status = model.TaskStatusDone
+		t.CompletedAt = &now
+		if err := s.taskRepo.Update(ctx, t); err != nil {
+			return nil, err
+		}
+	}
+	if _, err := s.projectService.RecomputeProgress(ctx, t.ProjectID); err != nil {
+		slog.WarnContext(ctx, "task.complete.recompute_progress_failed",
+			"project_id", t.ProjectID, "err", err)
+	}
+	slog.InfoContext(ctx, "task.complete", "id", id)
+	return t, nil
+}
+
+// Delete 刪除 task；之後 RecomputeProgress
+//
+// 不存在 → 404 TASK_NOT_FOUND
+func (s *TaskService) Delete(ctx context.Context, id uuid.UUID) error {
+	t, _, err := s.taskRepo.FindByID(ctx, id)
+	if err != nil {
+		return err
+	}
+	if err := s.taskRepo.Delete(ctx, id); err != nil {
+		return err
+	}
+	if _, err := s.projectService.RecomputeProgress(ctx, t.ProjectID); err != nil {
+		slog.WarnContext(ctx, "task.delete.recompute_progress_failed",
+			"project_id", t.ProjectID, "err", err)
+	}
+	slog.InfoContext(ctx, "task.delete", "id", id)
+	return nil
+}
+
+// ListUpcoming 跨專案：未完成且 due_date <= today + days
+//
+// days 預設 7、最大 365
+func (s *TaskService) ListUpcoming(ctx context.Context, days int) ([]*model.Task, error) {
+	if days < 0 {
+		return nil, model.NewAppError(400, model.ErrCodeInvalidInput, "days 不可為負數")
+	}
+	if days > 365 {
+		return nil, model.NewAppError(400, model.ErrCodeInvalidInput, "days 上限 365")
+	}
+	return s.taskRepo.ListUpcoming(ctx, days)
+}
+
+// ListOverdue 跨專案：未完成且 due_date < today
+func (s *TaskService) ListOverdue(ctx context.Context) ([]*model.Task, error) {
+	return s.taskRepo.ListOverdue(ctx)
+}

--- a/dev/src/service/task_test.go
+++ b/dev/src/service/task_test.go
@@ -1,0 +1,692 @@
+package service
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/gpwork4u/aibo/dto"
+	"github.com/gpwork4u/aibo/model"
+)
+
+// ─── Fake TaskRepository（service test 用） ──────────────────────────────
+
+type fakeTaskRepo struct {
+	tasks    map[uuid.UUID]*model.Task
+	refs     map[uuid.UUID][]model.TaskRef
+	createErr error
+	updateErr error
+	deleteErr error
+
+	// ListByProject 排序後直接吐回（不過濾）
+	listByProjErr error
+
+	upcoming []*model.Task
+	overdue  []*model.Task
+}
+
+func newFakeTaskRepo() *fakeTaskRepo {
+	return &fakeTaskRepo{
+		tasks: map[uuid.UUID]*model.Task{},
+		refs:  map[uuid.UUID][]model.TaskRef{},
+	}
+}
+
+func (r *fakeTaskRepo) Create(ctx context.Context, t *model.Task, refs []model.TaskRef) error {
+	if r.createErr != nil {
+		return r.createErr
+	}
+	if t.ID == uuid.Nil {
+		t.ID = uuid.New()
+	}
+	now := time.Now()
+	t.CreatedAt = now
+	t.UpdatedAt = now
+	if t.Status == "" {
+		t.Status = model.TaskStatusTodo
+	}
+	if t.Priority == "" {
+		t.Priority = model.TaskPriorityNormal
+	}
+	cp := *t
+	r.tasks[t.ID] = &cp
+	if len(refs) > 0 {
+		stored := make([]model.TaskRef, len(refs))
+		for i, ref := range refs {
+			stored[i] = model.TaskRef{TaskID: t.ID, RefType: ref.RefType, RefID: ref.RefID}
+		}
+		r.refs[t.ID] = stored
+	}
+	return nil
+}
+
+func (r *fakeTaskRepo) FindByID(ctx context.Context, id uuid.UUID) (*model.Task, []model.TaskRef, error) {
+	t, ok := r.tasks[id]
+	if !ok {
+		return nil, nil, model.NewAppError(404, model.ErrCodeTaskNotFound, "任務不存在")
+	}
+	cp := *t
+	refs := append([]model.TaskRef(nil), r.refs[id]...)
+	return &cp, refs, nil
+}
+
+func (r *fakeTaskRepo) ListByProject(ctx context.Context, projectID uuid.UUID, statusFilter []string) ([]*model.Task, error) {
+	if r.listByProjErr != nil {
+		return nil, r.listByProjErr
+	}
+	out := make([]*model.Task, 0)
+	for _, t := range r.tasks {
+		if t.ProjectID != projectID {
+			continue
+		}
+		if len(statusFilter) > 0 {
+			match := false
+			for _, s := range statusFilter {
+				if t.Status == s {
+					match = true
+					break
+				}
+			}
+			if !match {
+				continue
+			}
+		}
+		cp := *t
+		out = append(out, &cp)
+	}
+	return out, nil
+}
+
+func (r *fakeTaskRepo) Update(ctx context.Context, t *model.Task) error {
+	if r.updateErr != nil {
+		return r.updateErr
+	}
+	if _, ok := r.tasks[t.ID]; !ok {
+		return model.NewAppError(404, model.ErrCodeTaskNotFound, "任務不存在")
+	}
+	t.UpdatedAt = time.Now()
+	cp := *t
+	r.tasks[t.ID] = &cp
+	return nil
+}
+
+func (r *fakeTaskRepo) ReplaceRefs(ctx context.Context, taskID uuid.UUID, refs []model.TaskRef) error {
+	if len(refs) == 0 {
+		delete(r.refs, taskID)
+		return nil
+	}
+	stored := make([]model.TaskRef, len(refs))
+	for i, ref := range refs {
+		stored[i] = model.TaskRef{TaskID: taskID, RefType: ref.RefType, RefID: ref.RefID}
+	}
+	r.refs[taskID] = stored
+	return nil
+}
+
+func (r *fakeTaskRepo) Delete(ctx context.Context, id uuid.UUID) error {
+	if r.deleteErr != nil {
+		return r.deleteErr
+	}
+	if _, ok := r.tasks[id]; !ok {
+		return model.NewAppError(404, model.ErrCodeTaskNotFound, "任務不存在")
+	}
+	delete(r.tasks, id)
+	delete(r.refs, id)
+	return nil
+}
+
+func (r *fakeTaskRepo) ListUpcoming(ctx context.Context, days int) ([]*model.Task, error) {
+	return r.upcoming, nil
+}
+
+func (r *fakeTaskRepo) ListOverdue(ctx context.Context) ([]*model.Task, error) {
+	return r.overdue, nil
+}
+
+func (r *fakeTaskRepo) CountByProject(ctx context.Context, projectID uuid.UUID) (int, error) {
+	c := 0
+	for _, t := range r.tasks {
+		if t.ProjectID == projectID {
+			c++
+		}
+	}
+	return c, nil
+}
+
+func (r *fakeTaskRepo) GetRefs(ctx context.Context, taskID uuid.UUID) ([]model.TaskRef, error) {
+	return append([]model.TaskRef(nil), r.refs[taskID]...), nil
+}
+
+// ─── Fake TaskRefValidator ──────────────────────────────────────────────
+
+type fakeRefValidator struct {
+	entries  map[uuid.UUID]bool
+	journals map[string]bool // YYYY-MM-DD
+}
+
+func newFakeRefValidator() *fakeRefValidator {
+	return &fakeRefValidator{
+		entries:  map[uuid.UUID]bool{},
+		journals: map[string]bool{},
+	}
+}
+
+func (v *fakeRefValidator) EntryExists(ctx context.Context, id uuid.UUID) (bool, error) {
+	return v.entries[id], nil
+}
+func (v *fakeRefValidator) JournalExistsByDate(ctx context.Context, date time.Time) (bool, error) {
+	return v.journals[date.UTC().Format("2006-01-02")], nil
+}
+
+// ─── Helpers ─────────────────────────────────────────────────────────────
+
+func newTaskSvc(t *testing.T) (
+	*TaskService,
+	*fakeTaskRepo,
+	*fakeProjectRepo,
+	*fakeRefValidator,
+	*ProjectService,
+) {
+	t.Helper()
+	tr := newFakeTaskRepo()
+	pr := newFakeProjectRepo()
+	rv := newFakeRefValidator()
+	psvc := NewProjectService(pr, tr)
+	svc := NewTaskServiceWithValidator(tr, pr, rv, psvc)
+	return svc, tr, pr, rv, psvc
+}
+
+func seedActiveProject(pr *fakeProjectRepo) *model.Project {
+	id := uuid.New()
+	p := &model.Project{ID: id, Name: "P", Status: model.ProjectStatusActive}
+	pr.store[id] = p
+	return p
+}
+
+// ─── Tests ──────────────────────────────────────────────────────────────
+
+// 1. Create happy path 預設 status=todo / priority=normal
+func TestTaskSvc_Create_HappyPath(t *testing.T) {
+	svc, _, pr, _, _ := newTaskSvc(t)
+	p := seedActiveProject(pr)
+	req := &dto.CreateTaskRequest{Title: "設計 schema"}
+	got, refs, err := svc.Create(context.Background(), p.ID, req)
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if got.Status != model.TaskStatusTodo {
+		t.Errorf("status default expected todo, got %s", got.Status)
+	}
+	if got.Priority != model.TaskPriorityNormal {
+		t.Errorf("priority default expected normal, got %s", got.Priority)
+	}
+	if len(refs) != 0 {
+		t.Errorf("expected 0 refs, got %d", len(refs))
+	}
+}
+
+// 2. Create 帶 entry ref（成功）
+func TestTaskSvc_Create_WithEntryRef(t *testing.T) {
+	svc, _, pr, rv, _ := newTaskSvc(t)
+	p := seedActiveProject(pr)
+	entryID := uuid.New()
+	rv.entries[entryID] = true
+
+	req := &dto.CreateTaskRequest{
+		Title: "設計 schema",
+		Refs: []dto.TaskRefDTO{
+			{RefType: "entry", RefID: entryID.String()},
+		},
+	}
+	_, refs, err := svc.Create(context.Background(), p.ID, req)
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if len(refs) != 1 || refs[0].RefID != entryID.String() {
+		t.Errorf("expected 1 entry ref, got %+v", refs)
+	}
+}
+
+// 3. Create entry ref 不存在 → 400 INVALID_INPUT
+func TestTaskSvc_Create_EntryRefNotFound(t *testing.T) {
+	svc, _, pr, _, _ := newTaskSvc(t)
+	p := seedActiveProject(pr)
+	req := &dto.CreateTaskRequest{
+		Title: "x",
+		Refs:  []dto.TaskRefDTO{{RefType: "entry", RefID: uuid.New().String()}},
+	}
+	_, _, err := svc.Create(context.Background(), p.ID, req)
+	appErr, ok := err.(*model.AppError)
+	if !ok || appErr.Status != 400 || appErr.Code != model.ErrCodeInvalidInput {
+		t.Fatalf("expected 400 INVALID_INPUT, got %v", err)
+	}
+}
+
+// 4. Create journal ref 不存在 → 400
+func TestTaskSvc_Create_JournalRefNotFound(t *testing.T) {
+	svc, _, pr, _, _ := newTaskSvc(t)
+	p := seedActiveProject(pr)
+	req := &dto.CreateTaskRequest{
+		Title: "x",
+		Refs:  []dto.TaskRefDTO{{RefType: "journal", RefID: "2026-04-25"}},
+	}
+	_, _, err := svc.Create(context.Background(), p.ID, req)
+	appErr, ok := err.(*model.AppError)
+	if !ok || appErr.Status != 400 || appErr.Code != model.ErrCodeInvalidInput {
+		t.Fatalf("expected 400, got %v", err)
+	}
+}
+
+// 5. Create journal ref id 格式錯
+func TestTaskSvc_Create_JournalRefBadFormat(t *testing.T) {
+	svc, _, pr, _, _ := newTaskSvc(t)
+	p := seedActiveProject(pr)
+	req := &dto.CreateTaskRequest{
+		Title: "x",
+		Refs:  []dto.TaskRefDTO{{RefType: "journal", RefID: "not-a-date"}},
+	}
+	_, _, err := svc.Create(context.Background(), p.ID, req)
+	appErr, ok := err.(*model.AppError)
+	if !ok || appErr.Code != model.ErrCodeInvalidInput {
+		t.Fatalf("expected INVALID_INPUT, got %v", err)
+	}
+}
+
+// 6. Create gcal_event ref 空字串
+func TestTaskSvc_Create_GcalRefEmpty(t *testing.T) {
+	svc, _, pr, _, _ := newTaskSvc(t)
+	p := seedActiveProject(pr)
+	req := &dto.CreateTaskRequest{
+		Title: "x",
+		Refs:  []dto.TaskRefDTO{{RefType: "gcal_event", RefID: ""}},
+	}
+	_, _, err := svc.Create(context.Background(), p.ID, req)
+	appErr, ok := err.(*model.AppError)
+	if !ok || appErr.Code != model.ErrCodeInvalidInput {
+		t.Fatalf("expected INVALID_INPUT, got %v", err)
+	}
+}
+
+// 7. Create 對 archived 專案 → 400 PROJECT_ARCHIVED
+func TestTaskSvc_Create_ProjectArchived(t *testing.T) {
+	svc, _, pr, _, _ := newTaskSvc(t)
+	id := uuid.New()
+	pr.store[id] = &model.Project{ID: id, Name: "old", Status: model.ProjectStatusArchived}
+	_, _, err := svc.Create(context.Background(), id, &dto.CreateTaskRequest{Title: "x"})
+	appErr, ok := err.(*model.AppError)
+	if !ok || appErr.Status != 400 || appErr.Code != model.ErrCodeProjectArchived {
+		t.Fatalf("expected 400 PROJECT_ARCHIVED, got %v", err)
+	}
+}
+
+// 8. Create project 不存在 → 404
+func TestTaskSvc_Create_ProjectNotFound(t *testing.T) {
+	svc, _, _, _, _ := newTaskSvc(t)
+	_, _, err := svc.Create(context.Background(), uuid.New(), &dto.CreateTaskRequest{Title: "x"})
+	appErr, ok := err.(*model.AppError)
+	if !ok || appErr.Status != 404 || appErr.Code != model.ErrCodeProjectNotFound {
+		t.Fatalf("expected 404 PROJECT_NOT_FOUND, got %v", err)
+	}
+}
+
+// 9. Create title 過長 → 400
+func TestTaskSvc_Create_TitleTooLong(t *testing.T) {
+	svc, _, pr, _, _ := newTaskSvc(t)
+	p := seedActiveProject(pr)
+	long := make([]byte, 201)
+	for i := range long {
+		long[i] = 'a'
+	}
+	_, _, err := svc.Create(context.Background(), p.ID, &dto.CreateTaskRequest{Title: string(long)})
+	appErr, ok := err.(*model.AppError)
+	if !ok || appErr.Code != model.ErrCodeInvalidInput {
+		t.Fatalf("expected INVALID_INPUT, got %v", err)
+	}
+}
+
+// 10. Create due_date 格式錯
+func TestTaskSvc_Create_DueDateBadFormat(t *testing.T) {
+	svc, _, pr, _, _ := newTaskSvc(t)
+	p := seedActiveProject(pr)
+	bad := "2026/04/25"
+	_, _, err := svc.Create(context.Background(), p.ID, &dto.CreateTaskRequest{
+		Title: "x", DueDate: &bad,
+	})
+	appErr, ok := err.(*model.AppError)
+	if !ok || appErr.Code != model.ErrCodeInvalidInput {
+		t.Fatalf("expected INVALID_INPUT, got %v", err)
+	}
+}
+
+// 11. Get 不存在 → 404
+func TestTaskSvc_Get_NotFound(t *testing.T) {
+	svc, _, _, _, _ := newTaskSvc(t)
+	_, _, err := svc.Get(context.Background(), uuid.New())
+	appErr, ok := err.(*model.AppError)
+	if !ok || appErr.Status != 404 || appErr.Code != model.ErrCodeTaskNotFound {
+		t.Fatalf("expected 404 TASK_NOT_FOUND, got %v", err)
+	}
+}
+
+// 12. Update 不存在 → 404
+func TestTaskSvc_Update_NotFound(t *testing.T) {
+	svc, _, _, _, _ := newTaskSvc(t)
+	tt := "x"
+	_, _, err := svc.Update(context.Background(), uuid.New(), &dto.UpdateTaskRequest{Title: &tt})
+	appErr, ok := err.(*model.AppError)
+	if !ok || appErr.Status != 404 || appErr.Code != model.ErrCodeTaskNotFound {
+		t.Fatalf("expected 404, got %v", err)
+	}
+}
+
+// 13. Update done → todo 清 completed_at
+func TestTaskSvc_Update_DoneToTodoClearsCompletedAt(t *testing.T) {
+	svc, tr, pr, _, _ := newTaskSvc(t)
+	p := seedActiveProject(pr)
+	now := time.Now()
+	id := uuid.New()
+	tr.tasks[id] = &model.Task{
+		ID: id, ProjectID: p.ID, Title: "t",
+		Status: model.TaskStatusDone, Priority: model.TaskPriorityNormal,
+		CompletedAt: &now,
+	}
+
+	todo := model.TaskStatusTodo
+	got, _, err := svc.Update(context.Background(), id, &dto.UpdateTaskRequest{Status: &todo})
+	if err != nil {
+		t.Fatalf("Update: %v", err)
+	}
+	if got.CompletedAt != nil {
+		t.Errorf("expected completed_at cleared, got %v", got.CompletedAt)
+	}
+	if got.Status != model.TaskStatusTodo {
+		t.Errorf("status not updated, got %s", got.Status)
+	}
+}
+
+// 14. Update todo → done 自動補 completed_at
+func TestTaskSvc_Update_TodoToDoneSetsCompletedAt(t *testing.T) {
+	svc, tr, pr, _, _ := newTaskSvc(t)
+	p := seedActiveProject(pr)
+	id := uuid.New()
+	tr.tasks[id] = &model.Task{
+		ID: id, ProjectID: p.ID, Title: "t",
+		Status: model.TaskStatusTodo, Priority: model.TaskPriorityNormal,
+	}
+	done := model.TaskStatusDone
+	got, _, err := svc.Update(context.Background(), id, &dto.UpdateTaskRequest{Status: &done})
+	if err != nil {
+		t.Fatalf("Update: %v", err)
+	}
+	if got.CompletedAt == nil {
+		t.Errorf("expected completed_at set")
+	}
+}
+
+// 15. Update refs 整批覆寫
+func TestTaskSvc_Update_RefsReplace(t *testing.T) {
+	svc, tr, pr, rv, _ := newTaskSvc(t)
+	p := seedActiveProject(pr)
+	entryID := uuid.New()
+	rv.entries[entryID] = true
+
+	id := uuid.New()
+	tr.tasks[id] = &model.Task{
+		ID: id, ProjectID: p.ID, Title: "t",
+		Status: model.TaskStatusTodo, Priority: model.TaskPriorityNormal,
+	}
+	tr.refs[id] = []model.TaskRef{
+		{TaskID: id, RefType: "gcal_event", RefID: "old-event"},
+	}
+
+	newRefs := []dto.TaskRefDTO{{RefType: "entry", RefID: entryID.String()}}
+	_, refs, err := svc.Update(context.Background(), id, &dto.UpdateTaskRequest{Refs: &newRefs})
+	if err != nil {
+		t.Fatalf("Update: %v", err)
+	}
+	if len(refs) != 1 || refs[0].RefType != "entry" {
+		t.Errorf("expected 1 entry ref, got %+v", refs)
+	}
+}
+
+// 16. Update refs 空陣列 → 全清
+func TestTaskSvc_Update_RefsEmptyClears(t *testing.T) {
+	svc, tr, pr, _, _ := newTaskSvc(t)
+	p := seedActiveProject(pr)
+	id := uuid.New()
+	tr.tasks[id] = &model.Task{
+		ID: id, ProjectID: p.ID, Title: "t",
+		Status: model.TaskStatusTodo, Priority: model.TaskPriorityNormal,
+	}
+	tr.refs[id] = []model.TaskRef{
+		{TaskID: id, RefType: "gcal_event", RefID: "x"},
+	}
+	empty := []dto.TaskRefDTO{}
+	_, refs, err := svc.Update(context.Background(), id, &dto.UpdateTaskRequest{Refs: &empty})
+	if err != nil {
+		t.Fatalf("Update: %v", err)
+	}
+	if len(refs) != 0 {
+		t.Errorf("expected refs cleared, got %d", len(refs))
+	}
+}
+
+// 17. Update position（拖放更新）
+func TestTaskSvc_Update_Position(t *testing.T) {
+	svc, tr, pr, _, _ := newTaskSvc(t)
+	p := seedActiveProject(pr)
+	id := uuid.New()
+	tr.tasks[id] = &model.Task{
+		ID: id, ProjectID: p.ID, Title: "t",
+		Status: model.TaskStatusTodo, Priority: model.TaskPriorityNormal,
+		Position: 0,
+	}
+	pos := 2
+	inProg := model.TaskStatusInProgress
+	got, _, err := svc.Update(context.Background(), id, &dto.UpdateTaskRequest{
+		Status: &inProg, Position: &pos,
+	})
+	if err != nil {
+		t.Fatalf("Update: %v", err)
+	}
+	if got.Position != 2 || got.Status != model.TaskStatusInProgress {
+		t.Errorf("expected pos=2 status=in_progress, got pos=%d status=%s", got.Position, got.Status)
+	}
+}
+
+// 18. Complete 觸發 RecomputeProgress（4 tasks，1 done → complete 第 2 → 50）
+func TestTaskSvc_Complete_RecomputesProgress(t *testing.T) {
+	svc, tr, pr, _, _ := newTaskSvc(t)
+	p := seedActiveProject(pr)
+	// 模擬已有 4 tasks（service test 直接餵到 fakeProjectRepo.taskByStat）
+	pr.taskByStat[p.ID] = map[string]int{"todo": 3, "done": 1}
+
+	// 我們要 complete 第 2 個 task：先建一個 todo task，之後 complete
+	id := uuid.New()
+	tr.tasks[id] = &model.Task{
+		ID: id, ProjectID: p.ID, Title: "t2",
+		Status: model.TaskStatusTodo, Priority: model.TaskPriorityNormal,
+	}
+	// Complete 之後 byStat 改為 todo:2 done:2 → progress=50
+	originalProgress := pr.store[p.ID].Progress
+	_ = originalProgress
+
+	// hook 進 fake：complete 後我們手動改 byStat（service 呼叫 RecomputeProgress 時會用此計算）
+	// 但 fake 的 RecomputeProgress 直接讀 byStat；我們改成先把 byStat 改成終態，
+	// 然後驗證 RecomputeProgress 被呼叫（即 progress 被更新成期望值）
+	pr.taskByStat[p.ID] = map[string]int{"todo": 2, "done": 2}
+
+	got, err := svc.Complete(context.Background(), id)
+	if err != nil {
+		t.Fatalf("Complete: %v", err)
+	}
+	if got.Status != model.TaskStatusDone || got.CompletedAt == nil {
+		t.Errorf("expected status=done with completed_at, got %+v", got)
+	}
+	if pr.store[p.ID].Progress != 50 {
+		t.Errorf("expected project.progress=50, got %d", pr.store[p.ID].Progress)
+	}
+}
+
+// 19. Complete 已是 done 的 task 不重複設 completed_at（idempotent-ish）
+func TestTaskSvc_Complete_AlreadyDone(t *testing.T) {
+	svc, tr, pr, _, _ := newTaskSvc(t)
+	p := seedActiveProject(pr)
+	old := time.Now().Add(-time.Hour)
+	id := uuid.New()
+	tr.tasks[id] = &model.Task{
+		ID: id, ProjectID: p.ID, Title: "t",
+		Status: model.TaskStatusDone, Priority: model.TaskPriorityNormal,
+		CompletedAt: &old,
+	}
+	got, err := svc.Complete(context.Background(), id)
+	if err != nil {
+		t.Fatalf("Complete: %v", err)
+	}
+	// completedAt 不被覆蓋（保持原始值）
+	if !got.CompletedAt.Equal(old) {
+		t.Errorf("expected completed_at unchanged when already done, got %v vs %v", got.CompletedAt, old)
+	}
+}
+
+// 20. Complete on archived project 仍可執行（Edge：archived 後完成 task 仍 recompute progress）
+func TestTaskSvc_Complete_OnArchivedProject(t *testing.T) {
+	svc, tr, pr, _, _ := newTaskSvc(t)
+	id := uuid.New()
+	pid := uuid.New()
+	pr.store[pid] = &model.Project{ID: pid, Name: "old", Status: model.ProjectStatusArchived}
+	pr.taskByStat[pid] = map[string]int{"done": 1}
+	tr.tasks[id] = &model.Task{
+		ID: id, ProjectID: pid, Title: "t",
+		Status: model.TaskStatusTodo, Priority: model.TaskPriorityNormal,
+	}
+	if _, err := svc.Complete(context.Background(), id); err != nil {
+		t.Fatalf("Complete on archived should succeed, got %v", err)
+	}
+	if pr.store[pid].Progress != 100 {
+		t.Errorf("expected progress=100 (1/1 done), got %d", pr.store[pid].Progress)
+	}
+}
+
+// 21. Delete 不存在 → 404
+func TestTaskSvc_Delete_NotFound(t *testing.T) {
+	svc, _, _, _, _ := newTaskSvc(t)
+	err := svc.Delete(context.Background(), uuid.New())
+	appErr, ok := err.(*model.AppError)
+	if !ok || appErr.Status != 404 {
+		t.Fatalf("expected 404, got %v", err)
+	}
+}
+
+// 22. Delete 後 RecomputeProgress 被呼叫
+func TestTaskSvc_Delete_RecomputesProgress(t *testing.T) {
+	svc, tr, pr, _, _ := newTaskSvc(t)
+	p := seedActiveProject(pr)
+	id := uuid.New()
+	tr.tasks[id] = &model.Task{
+		ID: id, ProjectID: p.ID, Title: "t",
+		Status: model.TaskStatusTodo, Priority: model.TaskPriorityNormal,
+	}
+	pr.taskByStat[p.ID] = map[string]int{"todo": 1, "done": 1}
+	// 假設 Delete 後 byStat 改成
+	pr.taskByStat[p.ID] = map[string]int{"done": 1}
+	if err := svc.Delete(context.Background(), id); err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+	if pr.store[p.ID].Progress != 100 {
+		t.Errorf("expected progress=100, got %d", pr.store[p.ID].Progress)
+	}
+}
+
+// 23. ListByProject project 不存在 → 404
+func TestTaskSvc_List_ProjectNotFound(t *testing.T) {
+	svc, _, _, _, _ := newTaskSvc(t)
+	_, err := svc.ListByProject(context.Background(), uuid.New(), nil)
+	appErr, ok := err.(*model.AppError)
+	if !ok || appErr.Status != 404 {
+		t.Fatalf("expected 404, got %v", err)
+	}
+}
+
+// 24. ListUpcoming days < 0 → 400
+func TestTaskSvc_Upcoming_NegativeDays(t *testing.T) {
+	svc, _, _, _, _ := newTaskSvc(t)
+	_, err := svc.ListUpcoming(context.Background(), -1)
+	appErr, ok := err.(*model.AppError)
+	if !ok || appErr.Code != model.ErrCodeInvalidInput {
+		t.Fatalf("expected INVALID_INPUT, got %v", err)
+	}
+}
+
+// 25. ListUpcoming days > 365 → 400
+func TestTaskSvc_Upcoming_DaysTooLarge(t *testing.T) {
+	svc, _, _, _, _ := newTaskSvc(t)
+	_, err := svc.ListUpcoming(context.Background(), 9999)
+	appErr, ok := err.(*model.AppError)
+	if !ok || appErr.Code != model.ErrCodeInvalidInput {
+		t.Fatalf("expected INVALID_INPUT, got %v", err)
+	}
+}
+
+// 26. ListUpcoming 回傳 repo 結果
+func TestTaskSvc_Upcoming_Pass(t *testing.T) {
+	svc, tr, _, _, _ := newTaskSvc(t)
+	now := time.Now()
+	tr.upcoming = []*model.Task{
+		{ID: uuid.New(), Title: "a", DueDate: &now},
+		{ID: uuid.New(), Title: "b", DueDate: &now},
+		{ID: uuid.New(), Title: "c", DueDate: &now},
+	}
+	got, err := svc.ListUpcoming(context.Background(), 7)
+	if err != nil {
+		t.Fatalf("ListUpcoming: %v", err)
+	}
+	if len(got) != 3 {
+		t.Errorf("expected 3, got %d", len(got))
+	}
+}
+
+// 27. ListOverdue 回傳 repo 結果
+func TestTaskSvc_Overdue_Pass(t *testing.T) {
+	svc, tr, _, _, _ := newTaskSvc(t)
+	tr.overdue = []*model.Task{{ID: uuid.New(), Title: "old"}}
+	got, err := svc.ListOverdue(context.Background())
+	if err != nil {
+		t.Fatalf("ListOverdue: %v", err)
+	}
+	if len(got) != 1 {
+		t.Errorf("expected 1, got %d", len(got))
+	}
+}
+
+// 28. Create status 不合法
+func TestTaskSvc_Create_BadStatus(t *testing.T) {
+	svc, _, pr, _, _ := newTaskSvc(t)
+	p := seedActiveProject(pr)
+	bad := "wrong"
+	_, _, err := svc.Create(context.Background(), p.ID, &dto.CreateTaskRequest{
+		Title: "x", Status: &bad,
+	})
+	appErr, ok := err.(*model.AppError)
+	if !ok || appErr.Code != model.ErrCodeInvalidInput {
+		t.Fatalf("expected INVALID_INPUT, got %v", err)
+	}
+}
+
+// 29. Update bad status
+func TestTaskSvc_Update_BadStatus(t *testing.T) {
+	svc, tr, pr, _, _ := newTaskSvc(t)
+	p := seedActiveProject(pr)
+	id := uuid.New()
+	tr.tasks[id] = &model.Task{
+		ID: id, ProjectID: p.ID, Title: "t",
+		Status: model.TaskStatusTodo, Priority: model.TaskPriorityNormal,
+	}
+	bad := "wrong"
+	_, _, err := svc.Update(context.Background(), id, &dto.UpdateTaskRequest{Status: &bad})
+	appErr, ok := err.(*model.AppError)
+	if !ok || appErr.Code != model.ErrCodeInvalidInput {
+		t.Fatalf("expected INVALID_INPUT, got %v", err)
+	}
+}


### PR DESCRIPTION
## Summary

- Task CRUD + complete（觸發專案進度重算）+ upcoming/overdue 聚合
- 對齊 specs/features/f031-projects-tasks.md Tasks 段
- 7 endpoints，1957 lines，35+ unit tests

## 範圍

| File | Lines |
|---|---|
| dev/src/service/task.go | 466 |
| dev/src/service/task_test.go | 692 |
| dev/src/handler/task.go | 278 |
| dev/src/handler/task_test.go | 497 |
| dev/src/router/router.go | +18 |
| dev/src/main.go | +6 |
| dev/src/model/error.go | +2 |

## Endpoints

| Method | Path |
|---|---|
| POST | /api/v1/projects/:project_id/tasks |
| GET | /api/v1/projects/:project_id/tasks |
| GET | /api/v1/tasks/:id |
| PATCH | /api/v1/tasks/:id |
| DELETE | /api/v1/tasks/:id |
| POST | /api/v1/tasks/:id/complete |
| GET | /api/v1/tasks/upcoming?days=7 |
| GET | /api/v1/tasks/overdue |

## Note

由於 F-031c agent 與 F-032a agent 在同一 worktree 撞檔，本 PR 由 orchestrator 手動拆分後建立。所有實作由 engineer agent 完成，commit 時間/內容未經編輯。

## Closes

Closes #122

🤖 Generated with [Claude Code](https://claude.com/claude-code)