### PR TITLE
feat(frontend): F-032b ProjectDetail + Kanban + List + Overview

### DIFF
--- a/dev/frontend/app/(dashboard)/projects/[id]/page.tsx
+++ b/dev/frontend/app/(dashboard)/projects/[id]/page.tsx
@@ -2,6 +2,7 @@
 
 import * as React from "react";
 import { useParams, useRouter } from "next/navigation";
+import { useQueryClient } from "@tanstack/react-query";
 import { toast } from "sonner";
 import { ArrowLeft } from "lucide-react";
 import { Button } from "@/components/ui/button";
@@ -13,12 +14,13 @@ import { ProjectOverviewTab } from "@/components/projects/project-overview-tab";
 import { ProjectTaskListTab } from "@/components/projects/project-task-list-tab";
 import { useProject } from "@/lib/hooks/use-projects";
 import {
+  tasksKey,
   useCompleteTask,
   useCreateTask,
   useProjectTasks,
   useUpdateTask,
 } from "@/lib/hooks/use-tasks";
-import type { Task } from "@/lib/api/tasks";
+import type { ListTasksResponse, Task } from "@/lib/api/tasks";
 import { PROJECTS_TESTIDS } from "@/lib/projects/testids";
 
 export default function ProjectDetailPage() {
@@ -26,6 +28,7 @@ export default function ProjectDetailPage() {
   const router = useRouter();
   const projectId = params?.id ?? "";
 
+  const queryClient = useQueryClient();
   const projectQ = useProject(projectId);
   const tasksQ = useProjectTasks(projectId);
   const updateMut = useUpdateTask(projectId);
@@ -65,6 +68,7 @@ export default function ProjectDetailPage() {
       taskId,
       toStatus,
       toIndex,
+      optimisticTasks,
     }: {
       taskId: string;
       fromStatus: KanbanBoardTask["status"];
@@ -72,17 +76,34 @@ export default function ProjectDetailPage() {
       toIndex: number;
       optimisticTasks: KanbanBoardTask[];
     }) => {
+      const key = tasksKey(projectId);
+      const snapshot = queryClient.getQueryData<ListTasksResponse>(key);
+      // 樂觀更新：把 optimisticTasks（已套用拖放結果）寫回快取，立刻反映在 UI
+      if (snapshot) {
+        const byId = new Map<string, KanbanBoardTask>();
+        for (const t of optimisticTasks) byId.set(t.id, t);
+        const next: Task[] = snapshot.data.map((t) => {
+          const o = byId.get(t.id);
+          if (!o) return t;
+          return { ...t, status: o.status, position: o.position };
+        });
+        queryClient.setQueryData<ListTasksResponse>(key, { ...snapshot, data: next });
+      }
       try {
         await updateMut.mutateAsync({
           id: taskId,
           input: { status: toStatus, position: toIndex },
         });
       } catch (err) {
-        toast.error(err instanceof Error ? err.message : "更新失敗");
+        // 失敗回滾到 snapshot
+        if (snapshot) queryClient.setQueryData(key, snapshot);
+        toast.error(err instanceof Error ? err.message : "更新失敗", {
+          id: PROJECTS_TESTIDS.toastDragFailed,
+        });
         throw err;
       }
     },
-    [updateMut],
+    [updateMut, queryClient, projectId],
   );
 
   const handleAddTask = React.useCallback(

--- a/dev/frontend/app/(dashboard)/projects/[id]/page.tsx
+++ b/dev/frontend/app/(dashboard)/projects/[id]/page.tsx
@@ -1,0 +1,207 @@
+"use client";
+
+import * as React from "react";
+import { useParams, useRouter } from "next/navigation";
+import { toast } from "sonner";
+import { ArrowLeft } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { Skeleton } from "@/components/ui/skeleton";
+import { ErrorState } from "@/components/error-state";
+import { KanbanBoard, type KanbanBoardTask } from "@/components/kanban/kanban-board";
+import { ProjectOverviewTab } from "@/components/projects/project-overview-tab";
+import { ProjectTaskListTab } from "@/components/projects/project-task-list-tab";
+import { useProject } from "@/lib/hooks/use-projects";
+import {
+  useCompleteTask,
+  useCreateTask,
+  useProjectTasks,
+  useUpdateTask,
+} from "@/lib/hooks/use-tasks";
+import type { Task } from "@/lib/api/tasks";
+import { PROJECTS_TESTIDS } from "@/lib/projects/testids";
+
+export default function ProjectDetailPage() {
+  const params = useParams<{ id: string }>();
+  const router = useRouter();
+  const projectId = params?.id ?? "";
+
+  const projectQ = useProject(projectId);
+  const tasksQ = useProjectTasks(projectId);
+  const updateMut = useUpdateTask(projectId);
+  const completeMut = useCompleteTask(projectId);
+  const createMut = useCreateTask(projectId);
+
+  const tasks = tasksQ.data?.data ?? [];
+  const kanbanTasks: KanbanBoardTask[] = React.useMemo(
+    () =>
+      tasks.map((t) => ({
+        id: t.id,
+        title: t.title,
+        status: t.status,
+        priority: t.priority,
+        due_date: t.due_date,
+        position: t.position,
+        refs_count: t.refs?.length ?? 0,
+      })),
+    [tasks],
+  );
+
+  const overdueCount = React.useMemo(() => {
+    const today = new Date();
+    today.setHours(0, 0, 0, 0);
+    return tasks.filter((t) => {
+      if (t.status === "done" || t.status === "cancelled") return false;
+      if (!t.due_date) return false;
+      const m = /^(\d{4})-(\d{2})-(\d{2})$/.exec(t.due_date);
+      if (!m) return false;
+      const d = new Date(Number(m[1]), Number(m[2]) - 1, Number(m[3]));
+      return d < today;
+    }).length;
+  }, [tasks]);
+
+  const handleMove = React.useCallback(
+    async ({
+      taskId,
+      toStatus,
+      toIndex,
+    }: {
+      taskId: string;
+      fromStatus: KanbanBoardTask["status"];
+      toStatus: KanbanBoardTask["status"];
+      toIndex: number;
+      optimisticTasks: KanbanBoardTask[];
+    }) => {
+      try {
+        await updateMut.mutateAsync({
+          id: taskId,
+          input: { status: toStatus, position: toIndex },
+        });
+      } catch (err) {
+        toast.error(err instanceof Error ? err.message : "更新失敗");
+        throw err;
+      }
+    },
+    [updateMut],
+  );
+
+  const handleAddTask = React.useCallback(
+    async (status: KanbanBoardTask["status"]) => {
+      const title = window.prompt("任務標題");
+      if (!title?.trim()) return;
+      try {
+        await createMut.mutateAsync({ title: title.trim(), status, priority: "normal" });
+        toast.success("已建立任務");
+      } catch (err) {
+        toast.error(err instanceof Error ? err.message : "建立失敗");
+      }
+    },
+    [createMut],
+  );
+
+  const handleOpenTask = React.useCallback((taskId: string) => {
+    // F-032c TaskSheet 後續實作；此處先 navigate 到 hash 作 placeholder
+    if (typeof window !== "undefined") window.location.hash = `task-${taskId}`;
+  }, []);
+
+  const handleCompleteTask = React.useCallback(
+    async (taskId: string) => {
+      try {
+        await completeMut.mutateAsync(taskId);
+        toast.success("任務已完成");
+      } catch (err) {
+        toast.error(err instanceof Error ? err.message : "標記完成失敗");
+      }
+    },
+    [completeMut],
+  );
+
+  if (projectQ.isLoading) {
+    return (
+      <div className="container mx-auto p-6 space-y-4">
+        <Skeleton className="h-8 w-1/3" />
+        <Skeleton className="h-96 w-full" />
+      </div>
+    );
+  }
+
+  if (projectQ.isError || !projectQ.data) {
+    return (
+      <div className="container mx-auto p-6">
+        <ErrorState
+          message={
+            projectQ.error instanceof Error
+              ? projectQ.error.message
+              : "載入專案失敗，請稍後重試"
+          }
+          onRetry={() => projectQ.refetch()}
+        />
+      </div>
+    );
+  }
+
+  const project = projectQ.data;
+
+  return (
+    <div
+      className="container mx-auto space-y-4 p-6"
+      data-testid={PROJECTS_TESTIDS.detailPage}
+    >
+      <div className="flex items-center gap-3">
+        <Button
+          variant="ghost"
+          size="sm"
+          onClick={() => router.push("/projects")}
+          aria-label="返回專案列表"
+        >
+          <ArrowLeft className="h-4 w-4" />
+        </Button>
+        <h1 className="text-2xl font-semibold">{project.name}</h1>
+      </div>
+
+      <Tabs defaultValue="board" className="w-full">
+        <TabsList data-testid={PROJECTS_TESTIDS.detailTabs}>
+          <TabsTrigger value="board" data-testid={PROJECTS_TESTIDS.detailTabBoard}>
+            Board
+          </TabsTrigger>
+          <TabsTrigger value="list" data-testid={PROJECTS_TESTIDS.detailTabList}>
+            List
+          </TabsTrigger>
+          <TabsTrigger value="overview" data-testid={PROJECTS_TESTIDS.detailTabOverview}>
+            Overview
+          </TabsTrigger>
+        </TabsList>
+
+        <TabsContent value="board" className="mt-4">
+          <KanbanBoard
+            projectId={projectId}
+            tasks={kanbanTasks}
+            isLoading={tasksQ.isLoading}
+            isError={tasksQ.isError}
+            errorMessage={
+              tasksQ.error instanceof Error ? tasksQ.error.message : undefined
+            }
+            onRetry={() => tasksQ.refetch()}
+            onMove={handleMove}
+            onAddTask={handleAddTask}
+            onOpenTask={handleOpenTask}
+            onCompleteTask={handleCompleteTask}
+          />
+        </TabsContent>
+
+        <TabsContent value="list" className="mt-4">
+          <ProjectTaskListTab
+            tasks={tasks}
+            isLoading={tasksQ.isLoading}
+            onOpenTask={handleOpenTask}
+            onCompleteTask={handleCompleteTask}
+          />
+        </TabsContent>
+
+        <TabsContent value="overview" className="mt-4">
+          <ProjectOverviewTab project={project} overdueCount={overdueCount} />
+        </TabsContent>
+      </Tabs>
+    </div>
+  );
+}

--- a/dev/frontend/components/kanban/kanban-board.tsx
+++ b/dev/frontend/components/kanban/kanban-board.tsx
@@ -1,0 +1,339 @@
+"use client";
+
+import * as React from "react";
+import {
+  DndContext,
+  DragOverlay,
+  KeyboardSensor,
+  PointerSensor,
+  closestCorners,
+  useSensor,
+  useSensors,
+  type DragEndEvent,
+  type DragStartEvent,
+  type DragOverEvent,
+} from "@dnd-kit/core";
+import { sortableKeyboardCoordinates } from "@dnd-kit/sortable";
+import { cn } from "@/lib/utils";
+import { ErrorState } from "@/components/error-state";
+import { Skeleton } from "@/components/ui/skeleton";
+import {
+  KANBAN_STATUSES,
+  KANBAN_TESTIDS,
+} from "@/lib/projects/kanban-testids";
+import {
+  KANBAN_STATUS_LIST,
+  applyOptimisticMove,
+  computeNewPosition,
+  groupTasksByStatus,
+  isKanbanStatus,
+  type KanbanStatus,
+} from "@/lib/projects/kanban-utils";
+import { useIsMobile } from "@/lib/hooks/use-is-mobile";
+import { KanbanCard, type KanbanCardData } from "./kanban-card";
+import { KanbanColumn } from "./kanban-column";
+
+export interface KanbanBoardTask extends KanbanCardData {
+  position: number;
+}
+
+interface KanbanBoardProps {
+  projectId: string;
+  tasks: KanbanBoardTask[];
+  isLoading?: boolean;
+  isError?: boolean;
+  errorMessage?: string;
+  onRetry?: () => void;
+  onMove: (input: {
+    taskId: string;
+    fromStatus: KanbanStatus;
+    toStatus: KanbanStatus;
+    toIndex: number;
+    optimisticTasks: KanbanBoardTask[];
+  }) => Promise<void>;
+  onAddTask: (status: KanbanStatus) => void;
+  onOpenTask: (taskId: string) => void;
+  onCompleteTask: (taskId: string) => void;
+}
+
+export function KanbanBoard({
+  tasks,
+  isLoading,
+  isError,
+  errorMessage,
+  onRetry,
+  onMove,
+  onAddTask,
+  onOpenTask,
+  onCompleteTask,
+}: KanbanBoardProps) {
+  const isMobile = useIsMobile();
+  const [mobileStatus, setMobileStatus] = React.useState<KanbanStatus>("todo");
+  const [activeId, setActiveId] = React.useState<string | null>(null);
+  const [overColumn, setOverColumn] = React.useState<KanbanStatus | null>(null);
+  const [liveMessage, setLiveMessage] = React.useState("");
+
+  const sensors = useSensors(
+    useSensor(PointerSensor, { activationConstraint: { distance: 4 } }),
+    useSensor(KeyboardSensor, {
+      coordinateGetter: sortableKeyboardCoordinates,
+    }),
+  );
+
+  const grouped = React.useMemo(() => groupTasksByStatus(tasks), [tasks]);
+  const tasksById = React.useMemo(() => {
+    const m: Record<string, KanbanBoardTask> = {};
+    for (const t of tasks) m[t.id] = t;
+    return m;
+  }, [tasks]);
+
+  const activeTask = activeId ? tasksById[activeId] : null;
+
+  const announcements = React.useMemo(
+    () => ({
+      onDragStart: ({ active }: { active: { id: string | number } }) => {
+        const t = tasksById[String(active.id)];
+        return t ? `已抓起任務「${t.title}」` : "已抓起任務";
+      },
+      onDragOver: ({
+        active,
+        over,
+      }: {
+        active: { id: string | number };
+        over: { id: string | number; data: { current?: Record<string, unknown> } } | null;
+      }) => {
+        if (!over) return "";
+        const t = tasksById[String(active.id)];
+        const overData = (over.data?.current ?? {}) as { columnStatus?: string };
+        const targetCol = KANBAN_STATUSES.find(
+          (c) => c.status === overData.columnStatus,
+        );
+        if (t && targetCol)
+          return `任務「${t.title}」位於 ${targetCol.label} 欄`;
+        return "";
+      },
+      onDragEnd: ({
+        active,
+        over,
+      }: {
+        active: { id: string | number };
+        over: { id: string | number; data: { current?: Record<string, unknown> } } | null;
+      }) => {
+        if (!over) return "已取消拖移";
+        const t = tasksById[String(active.id)];
+        const overData = (over.data?.current ?? {}) as { columnStatus?: string };
+        const targetCol = KANBAN_STATUSES.find(
+          (c) => c.status === overData.columnStatus,
+        );
+        if (t && targetCol)
+          return `任務「${t.title}」已放到 ${targetCol.label} 欄`;
+        return "";
+      },
+      onDragCancel: ({ active }: { active: { id: string | number } }) => {
+        const t = tasksById[String(active.id)];
+        return t ? `已取消移動任務「${t.title}」` : "已取消拖移";
+      },
+    }),
+    [tasksById],
+  );
+
+  const screenReaderInstructions = React.useMemo(
+    () => ({
+      draggable:
+        "請按 Space 或 Enter 開始拖移任務。拖移時，使用方向鍵移動到目標欄位或位置，再按 Space 或 Enter 放下。按 Esc 取消。",
+    }),
+    [],
+  );
+
+  const handleDragStart = (e: DragStartEvent) => {
+    setActiveId(String(e.active.id));
+  };
+
+  const handleDragOver = (e: DragOverEvent) => {
+    const overData = (e.over?.data?.current ?? {}) as { columnStatus?: string };
+    const s = overData.columnStatus;
+    setOverColumn(s && isKanbanStatus(s) ? s : null);
+  };
+
+  const handleDragEnd = async (e: DragEndEvent) => {
+    const activeIdStr = String(e.active.id);
+    setActiveId(null);
+    setOverColumn(null);
+    if (!e.over) return;
+    const overIdStr = String(e.over.id);
+
+    const result = computeNewPosition({
+      activeId: activeIdStr,
+      overId: overIdStr,
+      tasks,
+    });
+    if (!result || !result.changed) return;
+
+    const optimistic = applyOptimisticMove(tasks, result) as KanbanBoardTask[];
+    const t = tasksById[activeIdStr];
+    setLiveMessage(
+      t
+        ? `任務「${t.title}」已從 ${labelOf(result.fromStatus)} 移至 ${labelOf(result.toStatus)} 第 ${result.toIndex + 1} 個位置`
+        : "",
+    );
+
+    try {
+      await onMove({
+        taskId: result.taskId,
+        fromStatus: result.fromStatus,
+        toStatus: result.toStatus,
+        toIndex: result.toIndex,
+        optimisticTasks: optimistic,
+      });
+    } catch {
+      // parent 負責 rollback + toast；這裡只清 live 訊息
+      setLiveMessage("更新失敗，已回復原位置");
+    }
+  };
+
+  const handleDragCancel = () => {
+    setActiveId(null);
+    setOverColumn(null);
+  };
+
+  if (isLoading) {
+    return (
+      <div
+        data-testid={KANBAN_TESTIDS.boardSkeleton}
+        className="grid grid-cols-1 gap-3 md:grid-cols-2 lg:grid-cols-4"
+      >
+        {KANBAN_STATUSES.map((c) => (
+          <div
+            key={c.status}
+            className="space-y-2 rounded-lg bg-muted/40 p-3"
+          >
+            <Skeleton className="h-6 w-24" />
+            {Array.from({ length: 3 }).map((_, i) => (
+              <Skeleton key={i} className="h-20 w-full" />
+            ))}
+          </div>
+        ))}
+      </div>
+    );
+  }
+
+  if (isError) {
+    return (
+      <div data-testid={KANBAN_TESTIDS.boardError}>
+        <ErrorState
+          message={errorMessage ?? "載入任務失敗"}
+          onRetry={onRetry}
+        />
+      </div>
+    );
+  }
+
+  return (
+    <DndContext
+      sensors={sensors}
+      collisionDetection={closestCorners}
+      onDragStart={handleDragStart}
+      onDragOver={handleDragOver}
+      onDragEnd={handleDragEnd}
+      onDragCancel={handleDragCancel}
+      accessibility={{ announcements, screenReaderInstructions }}
+    >
+      {isMobile ? (
+        <div data-testid={KANBAN_TESTIDS.board} className="space-y-3">
+          <div
+            role="tablist"
+            aria-label="切換任務狀態欄位"
+            data-testid={KANBAN_TESTIDS.mobileStatusSwitcher}
+            className="sticky top-0 z-10 flex w-full overflow-x-auto rounded-md border bg-background p-1"
+          >
+            {KANBAN_STATUSES.map((c) => (
+              <button
+                key={c.status}
+                type="button"
+                role="tab"
+                aria-selected={mobileStatus === c.status}
+                data-testid={`${KANBAN_TESTIDS.mobileStatusOption}-${c.status}`}
+                onClick={() => setMobileStatus(c.status)}
+                className={cn(
+                  "flex-1 whitespace-nowrap rounded px-3 py-1.5 text-sm font-medium transition-colors",
+                  mobileStatus === c.status
+                    ? "bg-muted text-foreground"
+                    : "text-muted-foreground hover:bg-muted/50",
+                )}
+              >
+                {c.label}
+                <span className="ml-1.5 rounded bg-muted px-1 text-xs tabular-nums">
+                  {grouped[c.status].length}
+                </span>
+              </button>
+            ))}
+          </div>
+          <KanbanColumn
+            status={mobileStatus}
+            label={KANBAN_STATUSES.find((c) => c.status === mobileStatus)!.label}
+            tasks={grouped[mobileStatus]}
+            onAddTask={onAddTask}
+            onOpenTask={onOpenTask}
+            onCompleteTask={onCompleteTask}
+            isDraggingOver={overColumn === mobileStatus}
+          />
+        </div>
+      ) : (
+        <div
+          data-testid={KANBAN_TESTIDS.board}
+          className="grid grid-cols-1 gap-3 md:grid-cols-2 lg:grid-cols-4"
+        >
+          {KANBAN_STATUS_LIST.map((s) => {
+            const cfg = KANBAN_STATUSES.find((c) => c.status === s)!;
+            return (
+              <KanbanColumn
+                key={s}
+                status={s}
+                label={cfg.label}
+                tasks={grouped[s]}
+                onAddTask={onAddTask}
+                onOpenTask={onOpenTask}
+                onCompleteTask={onCompleteTask}
+                isDraggingOver={overColumn === s}
+              />
+            );
+          })}
+        </div>
+      )}
+
+      <DragOverlay
+        adjustScale={false}
+        dropAnimation={{
+          duration: 200,
+          easing: "cubic-bezier(0.18, 0.67, 0.6, 1.22)",
+        }}
+      >
+        {activeTask ? (
+          <div data-testid={KANBAN_TESTIDS.dragOverlay}>
+            <KanbanCard
+              task={activeTask}
+              isDragOverlay
+              onOpen={() => undefined}
+              onComplete={() => undefined}
+            />
+          </div>
+        ) : null}
+      </DragOverlay>
+
+      <div
+        data-testid={KANBAN_TESTIDS.boardLiveRegion}
+        role="status"
+        aria-live="polite"
+        aria-atomic="true"
+        className="sr-only"
+      >
+        {liveMessage}
+      </div>
+    </DndContext>
+  );
+}
+
+function labelOf(s: KanbanStatus): string {
+  return KANBAN_STATUSES.find((c) => c.status === s)?.label ?? s;
+}
+

--- a/dev/frontend/components/kanban/kanban-card.tsx
+++ b/dev/frontend/components/kanban/kanban-card.tsx
@@ -1,0 +1,194 @@
+"use client";
+
+import * as React from "react";
+import { useSortable } from "@dnd-kit/sortable";
+import { CSS } from "@dnd-kit/utilities";
+import {
+  CalendarIcon,
+  ClockAlertIcon,
+  GripVerticalIcon,
+  PaperclipIcon,
+} from "lucide-react";
+import { cn } from "@/lib/utils";
+import { Badge } from "@/components/ui/badge";
+import { Checkbox } from "@/components/ui/checkbox";
+import {
+  KANBAN_TESTIDS,
+  TASK_PRIORITY_BADGE_CLASS,
+  TASK_PRIORITY_LABEL,
+  TASK_STATUS_DOT_CLASS,
+  type TaskPriority,
+  type TaskStatus,
+} from "@/lib/projects/kanban-testids";
+
+export interface KanbanCardData {
+  id: string;
+  title: string;
+  status: TaskStatus;
+  priority: TaskPriority;
+  due_date: string | null;
+  refs_count: number;
+}
+
+interface KanbanCardProps {
+  task: KanbanCardData;
+  onOpen: () => void;
+  onComplete: () => void;
+  isDragOverlay?: boolean;
+}
+
+function startOfTodayLocal(): Date {
+  const d = new Date();
+  d.setHours(0, 0, 0, 0);
+  return d;
+}
+
+function formatDateShortZh(yyyyMmDd: string): string {
+  // YYYY-MM-DD -> M/D
+  const m = /^(\d{4})-(\d{2})-(\d{2})$/.exec(yyyyMmDd);
+  if (!m) return yyyyMmDd;
+  return `${Number(m[2])}/${Number(m[3])}`;
+}
+
+export function KanbanCard({
+  task,
+  onOpen,
+  onComplete,
+  isDragOverlay,
+}: KanbanCardProps) {
+  const sortable = useSortable({
+    id: task.id,
+    data: { columnStatus: task.status, type: "task" },
+    disabled: isDragOverlay,
+  });
+  const { attributes, listeners, setNodeRef, transform, transition, isDragging } =
+    sortable;
+
+  const isDone = task.status === "done";
+  const dueDate = task.due_date;
+  const isOverdue = !!(
+    dueDate &&
+    !isDone &&
+    new Date(dueDate) < startOfTodayLocal()
+  );
+
+  const style = isDragOverlay
+    ? undefined
+    : { transform: CSS.Transform.toString(transform), transition };
+
+  return (
+    <article
+      ref={isDragOverlay ? undefined : setNodeRef}
+      style={style}
+      data-testid={`${KANBAN_TESTIDS.card}-${task.id}`}
+      className={cn(
+        "group relative rounded-md border bg-card shadow-sm transition-shadow",
+        "hover:shadow-md focus-within:ring-2 focus-within:ring-ring focus-within:ring-offset-1",
+        isDragging && "opacity-40",
+        isDragOverlay && "rotate-[2deg] shadow-2xl ring-2 ring-blue-400",
+        isDone && "opacity-70",
+      )}
+    >
+      <span
+        aria-hidden="true"
+        data-testid={`${KANBAN_TESTIDS.cardStatusDot}-${task.id}`}
+        className={cn(
+          "absolute inset-y-0 left-0 w-1 rounded-l-md",
+          TASK_STATUS_DOT_CLASS[task.status],
+        )}
+      />
+
+      <div className="flex items-start gap-2 p-2.5 pl-3">
+        <button
+          type="button"
+          {...attributes}
+          {...listeners}
+          data-testid={`${KANBAN_TESTIDS.cardDragHandle}-${task.id}`}
+          aria-label={`拖移任務「${task.title}」`}
+          className={cn(
+            "mt-0.5 flex h-6 w-6 shrink-0 cursor-grab touch-none items-center justify-center rounded text-muted-foreground",
+            "hover:bg-muted hover:text-foreground active:cursor-grabbing",
+            "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
+          )}
+        >
+          <GripVerticalIcon className="h-4 w-4" aria-hidden="true" />
+        </button>
+
+        <Checkbox
+          checked={isDone}
+          onCheckedChange={() => onComplete()}
+          data-testid={`${KANBAN_TESTIDS.cardCompleteToggle}-${task.id}`}
+          aria-label={
+            isDone ? `取消完成任務「${task.title}」` : `完成任務「${task.title}」`
+          }
+          className="mt-1"
+        />
+
+        <button
+          type="button"
+          onClick={onOpen}
+          data-testid={`${KANBAN_TESTIDS.cardOpenSheet}-${task.id}`}
+          className="flex-1 text-left focus:outline-none"
+          aria-label={`開啟任務「${task.title}」詳情`}
+        >
+          <div className="mb-1 flex items-start gap-2">
+            <h4
+              data-testid={`${KANBAN_TESTIDS.cardTitle}-${task.id}`}
+              className={cn(
+                "line-clamp-2 flex-1 text-sm font-medium leading-snug",
+                isDone && "line-through text-muted-foreground",
+              )}
+            >
+              {task.title}
+            </h4>
+            {task.priority !== "normal" && (
+              <Badge
+                data-testid={`${KANBAN_TESTIDS.cardPriorityBadge}-${task.id}`}
+                variant="outline"
+                className={cn(
+                  "shrink-0 border text-[10px] leading-tight",
+                  TASK_PRIORITY_BADGE_CLASS[task.priority],
+                )}
+                aria-label={`優先級：${TASK_PRIORITY_LABEL[task.priority]}`}
+              >
+                {TASK_PRIORITY_LABEL[task.priority]}
+              </Badge>
+            )}
+          </div>
+
+          <div className="flex items-center gap-3 text-xs text-muted-foreground">
+            {dueDate && (
+              <span
+                data-testid={`${KANBAN_TESTIDS.cardDueDate}-${task.id}`}
+                className={cn(
+                  "flex items-center gap-1 tabular-nums",
+                  isOverdue && "text-destructive font-medium",
+                )}
+                aria-label={
+                  isOverdue ? `逾期：${dueDate}` : `截止：${dueDate}`
+                }
+              >
+                {isOverdue ? (
+                  <ClockAlertIcon className="h-3.5 w-3.5" aria-hidden="true" />
+                ) : (
+                  <CalendarIcon className="h-3.5 w-3.5" aria-hidden="true" />
+                )}
+                {formatDateShortZh(dueDate)}
+              </span>
+            )}
+            {task.refs_count > 0 && (
+              <span
+                data-testid={`${KANBAN_TESTIDS.cardRefsCount}-${task.id}`}
+                className="flex items-center gap-1"
+                aria-label={`${task.refs_count} 個關聯項目`}
+              >
+                <PaperclipIcon className="h-3.5 w-3.5" aria-hidden="true" />
+                {task.refs_count}
+              </span>
+            )}
+          </div>
+        </button>
+      </div>
+    </article>
+  );
+}

--- a/dev/frontend/components/kanban/kanban-column.tsx
+++ b/dev/frontend/components/kanban/kanban-column.tsx
@@ -1,0 +1,137 @@
+"use client";
+
+import * as React from "react";
+import { useDroppable } from "@dnd-kit/core";
+import {
+  SortableContext,
+  verticalListSortingStrategy,
+} from "@dnd-kit/sortable";
+import { PlusIcon } from "lucide-react";
+import { cn } from "@/lib/utils";
+import { Button } from "@/components/ui/button";
+import {
+  KANBAN_TESTIDS,
+  TASK_STATUS_DOT_CLASS,
+} from "@/lib/projects/kanban-testids";
+import type { KanbanStatus } from "@/lib/projects/kanban-utils";
+import { KanbanCard, type KanbanCardData } from "./kanban-card";
+
+interface KanbanColumnProps {
+  status: KanbanStatus;
+  label: string;
+  tasks: KanbanCardData[];
+  onAddTask: (status: KanbanStatus) => void;
+  onOpenTask: (taskId: string) => void;
+  onCompleteTask: (taskId: string) => void;
+  isDraggingOver?: boolean;
+}
+
+export function KanbanColumn({
+  status,
+  label,
+  tasks,
+  onAddTask,
+  onOpenTask,
+  onCompleteTask,
+  isDraggingOver,
+}: KanbanColumnProps) {
+  const dropId = `col-${status}`;
+  const { setNodeRef, isOver } = useDroppable({
+    id: dropId,
+    data: { columnStatus: status, type: "column" },
+  });
+  const draggingOver = isDraggingOver ?? isOver;
+
+  const itemIds = React.useMemo(() => tasks.map((t) => t.id), [tasks]);
+
+  return (
+    <section
+      data-testid={`${KANBAN_TESTIDS.column}-${status}`}
+      aria-label={`${label} 欄，共 ${tasks.length} 筆任務`}
+      className="flex w-full shrink-0 flex-col rounded-lg bg-muted/40 dark:bg-muted/20 md:w-72"
+    >
+      <header
+        data-testid={`${KANBAN_TESTIDS.columnHeader}-${status}`}
+        className="flex items-center gap-2 border-b px-3 py-2"
+      >
+        <span
+          aria-hidden="true"
+          className={cn(
+            "inline-block h-2 w-2 rounded-full",
+            TASK_STATUS_DOT_CLASS[status],
+          )}
+        />
+        <h3
+          data-testid={`${KANBAN_TESTIDS.columnLabel}-${status}`}
+          className="text-sm font-medium"
+        >
+          {label}
+        </h3>
+        <span
+          data-testid={`${KANBAN_TESTIDS.columnCount}-${status}`}
+          className="rounded bg-muted px-1.5 py-0.5 text-xs font-medium tabular-nums text-muted-foreground"
+          aria-label={`共 ${tasks.length} 筆`}
+        >
+          {tasks.length}
+        </span>
+        <Button
+          variant="ghost"
+          size="icon"
+          className="ml-auto h-7 w-7"
+          onClick={() => onAddTask(status)}
+          data-testid={`${KANBAN_TESTIDS.columnAddTask}-${status}`}
+          aria-label={`在 ${label} 欄新增任務`}
+        >
+          <PlusIcon className="h-4 w-4" aria-hidden="true" />
+        </Button>
+      </header>
+
+      <div
+        ref={setNodeRef}
+        data-testid={`${KANBAN_TESTIDS.columnDropZone}-${status}`}
+        className={cn(
+          "min-h-[120px] flex-1 space-y-2 p-2 transition-colors",
+          draggingOver &&
+            "bg-blue-50 ring-2 ring-blue-400 ring-inset dark:bg-blue-950/30",
+        )}
+      >
+        <SortableContext
+          id={status}
+          items={itemIds}
+          strategy={verticalListSortingStrategy}
+        >
+          <ul
+            data-testid={`${KANBAN_TESTIDS.columnList}-${status}`}
+            className="space-y-2"
+          >
+            {tasks.length === 0 ? (
+              <li
+                data-testid={`${KANBAN_TESTIDS.columnEmpty}-${status}`}
+                className="rounded-md border border-dashed py-6 text-center text-xs text-muted-foreground"
+              >
+                尚無任務
+                <button
+                  type="button"
+                  onClick={() => onAddTask(status)}
+                  className="ml-1 underline underline-offset-2 hover:text-foreground"
+                >
+                  點 + 新增
+                </button>
+              </li>
+            ) : (
+              tasks.map((task) => (
+                <li key={task.id}>
+                  <KanbanCard
+                    task={task}
+                    onOpen={() => onOpenTask(task.id)}
+                    onComplete={() => onCompleteTask(task.id)}
+                  />
+                </li>
+              ))
+            )}
+          </ul>
+        </SortableContext>
+      </div>
+    </section>
+  );
+}

--- a/dev/frontend/components/projects/project-overview-tab.tsx
+++ b/dev/frontend/components/projects/project-overview-tab.tsx
@@ -1,0 +1,239 @@
+"use client";
+
+import * as React from "react";
+import {
+  AlertOctagonIcon,
+  CalendarIcon,
+  CheckCircle2Icon,
+  ClockAlertIcon,
+  ListTodoIcon,
+} from "lucide-react";
+import { cn } from "@/lib/utils";
+import { Card, CardContent } from "@/components/ui/card";
+import { MarkdownViewer } from "@/components/markdown-viewer";
+import {
+  PROJECTS_TESTIDS,
+  PROJECT_STATUS_LABEL,
+} from "@/lib/projects/testids";
+import type { Project } from "@/lib/api/projects";
+
+interface ProjectOverviewTabProps {
+  project: Project;
+  overdueCount: number;
+}
+
+function formatDateZh(value: string): string {
+  // YYYY-MM-DD → 2026/04/25
+  const m = /^(\d{4})-(\d{2})-(\d{2})$/.exec(value);
+  if (!m) return value;
+  return `${m[1]}/${m[2]}/${m[3]}`;
+}
+
+function daysRemaining(endDate: string): number {
+  const m = /^(\d{4})-(\d{2})-(\d{2})$/.exec(endDate);
+  if (!m) return 0;
+  const end = new Date(Number(m[1]), Number(m[2]) - 1, Number(m[3]));
+  const today = new Date();
+  today.setHours(0, 0, 0, 0);
+  const diff = Math.round(
+    (end.getTime() - today.getTime()) / (1000 * 60 * 60 * 24),
+  );
+  return diff;
+}
+
+function StatCard({
+  testid,
+  icon,
+  label,
+  value,
+  highlight,
+}: {
+  testid: string;
+  icon: React.ReactNode;
+  label: string;
+  value: number;
+  highlight?: boolean;
+}) {
+  return (
+    <Card
+      data-testid={testid}
+      className={cn(
+        "transition-colors",
+        highlight &&
+          "border-orange-300 bg-orange-50/60 dark:border-orange-900/60 dark:bg-orange-950/20",
+      )}
+    >
+      <CardContent className="flex flex-col gap-1 p-3">
+        <span className="flex items-center gap-1.5 text-xs text-muted-foreground">
+          {icon}
+          {label}
+        </span>
+        <span className="text-2xl font-semibold tabular-nums">{value}</span>
+      </CardContent>
+    </Card>
+  );
+}
+
+export function ProjectOverviewTab({
+  project,
+  overdueCount,
+}: ProjectOverviewTabProps) {
+  const total = project.task_counts?.total ?? 0;
+  const byStatus = project.task_counts?.by_status ?? {};
+  const doneCount = byStatus.done ?? 0;
+  const blockedCount = byStatus.blocked ?? 0;
+
+  const remaining = project.end_date ? daysRemaining(project.end_date) : null;
+
+  return (
+    <div
+      data-testid={PROJECTS_TESTIDS.detailContentOverview}
+      className="space-y-6 py-4"
+    >
+      {/* Progress block */}
+      <section
+        data-testid={PROJECTS_TESTIDS.overviewProgress}
+        aria-label="專案整體進度"
+      >
+        <div className="mb-2 flex items-baseline justify-between">
+          <h2 className="text-sm font-medium text-muted-foreground">進度</h2>
+          <span className="text-2xl font-semibold tabular-nums">
+            {project.progress}%
+          </span>
+        </div>
+        <div
+          data-testid={PROJECTS_TESTIDS.overviewProgressBar}
+          role="progressbar"
+          aria-valuenow={project.progress}
+          aria-valuemin={0}
+          aria-valuemax={100}
+          aria-label={`進度 ${project.progress}%`}
+          className="h-2.5 overflow-hidden rounded-full bg-muted"
+        >
+          <div
+            className="h-full rounded-full transition-all"
+            style={{
+              width: `${Math.max(0, Math.min(100, project.progress))}%`,
+              backgroundColor: project.color,
+            }}
+          />
+        </div>
+        <p className="mt-1.5 text-xs text-muted-foreground tabular-nums">
+          {doneCount} / {total} 完成（狀態：
+          {PROJECT_STATUS_LABEL[project.status]}）
+        </p>
+      </section>
+
+      {/* Stats */}
+      <section
+        data-testid={PROJECTS_TESTIDS.overviewStats}
+        className="grid grid-cols-2 gap-3 sm:grid-cols-4"
+        aria-label="任務統計"
+      >
+        <StatCard
+          testid={PROJECTS_TESTIDS.overviewStatTotal}
+          icon={<ListTodoIcon className="h-4 w-4" aria-hidden="true" />}
+          label="全部"
+          value={total}
+        />
+        <StatCard
+          testid={PROJECTS_TESTIDS.overviewStatDone}
+          icon={
+            <CheckCircle2Icon
+              className="h-4 w-4 text-green-700 dark:text-green-300"
+              aria-hidden="true"
+            />
+          }
+          label="完成"
+          value={doneCount}
+        />
+        <StatCard
+          testid={PROJECTS_TESTIDS.overviewStatBlocked}
+          icon={
+            <AlertOctagonIcon
+              className="h-4 w-4 text-red-700 dark:text-red-300"
+              aria-hidden="true"
+            />
+          }
+          label="卡住"
+          value={blockedCount}
+        />
+        <StatCard
+          testid={PROJECTS_TESTIDS.overviewStatOverdue}
+          icon={
+            <ClockAlertIcon
+              className="h-4 w-4 text-orange-700 dark:text-orange-300"
+              aria-hidden="true"
+            />
+          }
+          label="逾期"
+          value={overdueCount}
+          highlight={overdueCount > 0}
+        />
+      </section>
+
+      {/* Timeline */}
+      <section
+        data-testid={PROJECTS_TESTIDS.overviewTimeline}
+        aria-label="專案時程"
+      >
+        <h2 className="mb-2 text-sm font-medium text-muted-foreground">時程</h2>
+        <p
+          data-testid={PROJECTS_TESTIDS.overviewDates}
+          className="flex flex-wrap items-center gap-2 text-sm"
+        >
+          <CalendarIcon
+            className="h-4 w-4 text-muted-foreground"
+            aria-hidden="true"
+          />
+          <span>
+            {project.start_date ? formatDateZh(project.start_date) : "未設定"}
+          </span>
+          <span className="text-muted-foreground">→</span>
+          <span>
+            {project.end_date ? formatDateZh(project.end_date) : "未設定"}
+          </span>
+          {remaining !== null && (
+            <span className="text-xs text-muted-foreground">
+              （
+              {remaining > 0
+                ? `剩 ${remaining} 天`
+                : remaining === 0
+                  ? "今天結束"
+                  : `已逾期 ${-remaining} 天`}
+              ）
+            </span>
+          )}
+        </p>
+      </section>
+
+      {/* Description */}
+      {project.description && (
+        <section
+          data-testid={PROJECTS_TESTIDS.overviewDescription}
+          aria-label="專案描述"
+        >
+          <h2 className="mb-2 text-sm font-medium text-muted-foreground">
+            描述
+          </h2>
+          <article className="rounded-md border bg-card p-4">
+            <MarkdownViewer content={project.description} />
+          </article>
+        </section>
+      )}
+
+      {/* Activity placeholder（後端尚未提供 activity feed，預留 hook） */}
+      <section
+        data-testid={PROJECTS_TESTIDS.overviewActivity}
+        aria-label="最近活動"
+      >
+        <h2 className="mb-2 text-sm font-medium text-muted-foreground">
+          最近活動
+        </h2>
+        <p className="text-sm italic text-muted-foreground">
+          尚無活動紀錄
+        </p>
+      </section>
+    </div>
+  );
+}

--- a/dev/frontend/components/projects/project-task-list-tab.tsx
+++ b/dev/frontend/components/projects/project-task-list-tab.tsx
@@ -1,0 +1,136 @@
+"use client";
+
+import * as React from "react";
+import { Check, ExternalLink } from "lucide-react";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Skeleton } from "@/components/ui/skeleton";
+import {
+  TASK_PRIORITY_BADGE_CLASS,
+  TASK_PRIORITY_LABEL,
+  TASK_STATUS_BADGE_CLASS,
+  TASK_STATUS_LABEL,
+} from "@/lib/projects/kanban-testids";
+import type { Task } from "@/lib/api/tasks";
+import { PROJECTS_TESTIDS } from "@/lib/projects/testids";
+import { cn } from "@/lib/utils";
+
+interface ProjectTaskListTabProps {
+  tasks: Task[];
+  isLoading?: boolean;
+  onOpenTask: (id: string) => void;
+  onCompleteTask: (id: string) => void;
+}
+
+function isOverdue(t: Task): boolean {
+  if (t.status === "done" || t.status === "cancelled") return false;
+  if (!t.due_date) return false;
+  const m = /^(\d{4})-(\d{2})-(\d{2})$/.exec(t.due_date);
+  if (!m) return false;
+  const today = new Date();
+  today.setHours(0, 0, 0, 0);
+  return new Date(Number(m[1]), Number(m[2]) - 1, Number(m[3])) < today;
+}
+
+export function ProjectTaskListTab({
+  tasks,
+  isLoading,
+  onOpenTask,
+  onCompleteTask,
+}: ProjectTaskListTabProps) {
+  if (isLoading) {
+    return (
+      <div className="space-y-2">
+        {Array.from({ length: 5 }).map((_, i) => (
+          <Skeleton key={i} className="h-12 w-full" />
+        ))}
+      </div>
+    );
+  }
+
+  if (tasks.length === 0) {
+    return (
+      <div
+        className="rounded-md border border-dashed p-8 text-center text-sm text-muted-foreground"
+        data-testid={PROJECTS_TESTIDS.taskListEmpty}
+      >
+        尚無任務
+      </div>
+    );
+  }
+
+  return (
+    <div
+      className="overflow-hidden rounded-md border"
+      data-testid={PROJECTS_TESTIDS.taskListTable}
+    >
+      <table className="w-full text-sm">
+        <thead className="bg-muted/40 text-left">
+          <tr>
+            <th className="px-3 py-2 font-medium">標題</th>
+            <th className="px-3 py-2 font-medium">狀態</th>
+            <th className="px-3 py-2 font-medium">優先級</th>
+            <th className="px-3 py-2 font-medium">到期日</th>
+            <th className="px-3 py-2"></th>
+          </tr>
+        </thead>
+        <tbody>
+          {tasks.map((t) => (
+            <tr
+              key={t.id}
+              className="border-t hover:bg-muted/20"
+              data-testid={PROJECTS_TESTIDS.taskListRow(t.id)}
+            >
+              <td className="px-3 py-2">
+                <button
+                  type="button"
+                  className="text-left underline-offset-2 hover:underline"
+                  onClick={() => onOpenTask(t.id)}
+                >
+                  {t.title}
+                </button>
+              </td>
+              <td className="px-3 py-2">
+                <Badge className={cn("border", TASK_STATUS_BADGE_CLASS[t.status])}>
+                  {TASK_STATUS_LABEL[t.status]}
+                </Badge>
+              </td>
+              <td className="px-3 py-2">
+                <Badge className={cn("border", TASK_PRIORITY_BADGE_CLASS[t.priority])}>
+                  {TASK_PRIORITY_LABEL[t.priority]}
+                </Badge>
+              </td>
+              <td className={cn("px-3 py-2", isOverdue(t) && "text-destructive")}>
+                {t.due_date ?? "—"}
+              </td>
+              <td className="px-3 py-2">
+                <div className="flex justify-end gap-1">
+                  {t.status !== "done" && (
+                    <Button
+                      type="button"
+                      variant="ghost"
+                      size="sm"
+                      aria-label="標記完成"
+                      onClick={() => onCompleteTask(t.id)}
+                    >
+                      <Check className="h-4 w-4" />
+                    </Button>
+                  )}
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="sm"
+                    aria-label="開啟任務"
+                    onClick={() => onOpenTask(t.id)}
+                  >
+                    <ExternalLink className="h-4 w-4" />
+                  </Button>
+                </div>
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/dev/frontend/lib/api/tasks.ts
+++ b/dev/frontend/lib/api/tasks.ts
@@ -1,0 +1,126 @@
+import { apiClient } from "./client";
+import type {
+  TaskPriority,
+  TaskStatus,
+} from "@/lib/projects/kanban-testids";
+
+export type { TaskPriority, TaskStatus };
+
+export interface TaskRef {
+  ref_type: "entry" | "journal" | "gcal_event";
+  ref_id: string;
+  exists?: boolean;
+}
+
+export interface Task {
+  id: string;
+  project_id: string;
+  title: string;
+  description: string | null;
+  status: TaskStatus;
+  priority: TaskPriority;
+  due_date: string | null;
+  position: number;
+  refs: TaskRef[];
+  created_at: string;
+  updated_at: string;
+  completed_at: string | null;
+}
+
+export interface ListTasksResponse {
+  data: Task[];
+}
+
+export interface CreateTaskInput {
+  title: string;
+  description?: string | null;
+  status?: TaskStatus;
+  priority?: TaskPriority;
+  due_date?: string | null;
+  position?: number;
+  refs?: TaskRef[];
+}
+
+/**
+ * UpdateTaskInput
+ *
+ * 後端使用 `**string` 區分「不更動」與「更新為 null」。
+ * 前端：欄位省略 = 不更動；明確帶 null = 清空為 NULL。
+ */
+export interface UpdateTaskInput {
+  title?: string;
+  description?: string | null;
+  status?: TaskStatus;
+  priority?: TaskPriority;
+  due_date?: string | null;
+  position?: number;
+  refs?: TaskRef[];
+}
+
+export async function listTasksByProject(
+  projectId: string,
+): Promise<ListTasksResponse> {
+  return apiClient.get<ListTasksResponse>(
+    `/api/v1/projects/${encodeURIComponent(projectId)}/tasks`,
+  );
+}
+
+export async function createTask(
+  projectId: string,
+  input: CreateTaskInput,
+): Promise<Task> {
+  return apiClient.post<Task>(
+    `/api/v1/projects/${encodeURIComponent(projectId)}/tasks`,
+    input,
+  );
+}
+
+export async function getTask(id: string): Promise<Task> {
+  return apiClient.get<Task>(`/api/v1/tasks/${encodeURIComponent(id)}`);
+}
+
+export async function updateTask(
+  id: string,
+  input: UpdateTaskInput,
+): Promise<Task> {
+  return apiClient.patch<Task>(
+    `/api/v1/tasks/${encodeURIComponent(id)}`,
+    input,
+  );
+}
+
+export async function completeTask(id: string): Promise<Task> {
+  return apiClient.post<Task>(
+    `/api/v1/tasks/${encodeURIComponent(id)}/complete`,
+  );
+}
+
+export async function deleteTask(id: string): Promise<void> {
+  await apiClient.delete(`/api/v1/tasks/${encodeURIComponent(id)}`);
+}
+
+export interface UpcomingTaskItem {
+  id: string;
+  project_id: string;
+  project_name: string;
+  title: string;
+  status: TaskStatus;
+  priority: TaskPriority;
+  due_date: string | null;
+  updated_at: string;
+  completed_at: string | null;
+}
+
+export interface UpcomingTasksResponse {
+  data: UpcomingTaskItem[];
+}
+
+export async function listUpcomingTasks(
+  days = 7,
+): Promise<UpcomingTasksResponse> {
+  const sp = new URLSearchParams();
+  sp.set("days", String(days));
+  return apiClient.get<UpcomingTasksResponse>(
+    `/api/v1/tasks/upcoming?${sp.toString()}`,
+  );
+}

--- a/dev/frontend/lib/hooks/use-tasks.ts
+++ b/dev/frontend/lib/hooks/use-tasks.ts
@@ -1,0 +1,95 @@
+"use client";
+
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import {
+  CreateTaskInput,
+  ListTasksResponse,
+  Task,
+  UpdateTaskInput,
+  UpcomingTasksResponse,
+  completeTask,
+  createTask,
+  deleteTask,
+  getTask,
+  listTasksByProject,
+  listUpcomingTasks,
+  updateTask,
+} from "@/lib/api/tasks";
+import { projectKey, PROJECTS_QUERY_KEY } from "@/lib/hooks/use-projects";
+
+export const tasksKey = (projectId: string) =>
+  ["tasks", projectId] as const;
+export const taskKey = (id: string) => ["task", id] as const;
+export const UPCOMING_TASKS_KEY = ["tasks", "upcoming"] as const;
+
+export function useProjectTasks(projectId: string | null | undefined) {
+  return useQuery<ListTasksResponse>({
+    queryKey: tasksKey(projectId ?? ""),
+    queryFn: () => listTasksByProject(projectId as string),
+    enabled: !!projectId,
+  });
+}
+
+export function useTask(id: string | null | undefined) {
+  return useQuery<Task>({
+    queryKey: taskKey(id ?? ""),
+    queryFn: () => getTask(id as string),
+    enabled: !!id,
+  });
+}
+
+function invalidateTaskQueries(
+  qc: ReturnType<typeof useQueryClient>,
+  projectId: string,
+) {
+  qc.invalidateQueries({ queryKey: tasksKey(projectId) });
+  qc.invalidateQueries({ queryKey: projectKey(projectId) });
+  qc.invalidateQueries({ queryKey: PROJECTS_QUERY_KEY });
+  qc.invalidateQueries({ queryKey: UPCOMING_TASKS_KEY });
+}
+
+export function useCreateTask(projectId: string) {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (input: CreateTaskInput) => createTask(projectId, input),
+    onSuccess: () => invalidateTaskQueries(qc, projectId),
+  });
+}
+
+export function useUpdateTask(projectId: string) {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: ({ id, input }: { id: string; input: UpdateTaskInput }) =>
+      updateTask(id, input),
+    onSettled: (_data, _err, vars) => {
+      invalidateTaskQueries(qc, projectId);
+      if (vars?.id) qc.invalidateQueries({ queryKey: taskKey(vars.id) });
+    },
+  });
+}
+
+export function useCompleteTask(projectId: string) {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (id: string) => completeTask(id),
+    onSettled: (_data, _err, id) => {
+      invalidateTaskQueries(qc, projectId);
+      if (id) qc.invalidateQueries({ queryKey: taskKey(id) });
+    },
+  });
+}
+
+export function useDeleteTask(projectId: string) {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (id: string) => deleteTask(id),
+    onSuccess: () => invalidateTaskQueries(qc, projectId),
+  });
+}
+
+export function useUpcomingTasks(days = 7) {
+  return useQuery<UpcomingTasksResponse>({
+    queryKey: [...UPCOMING_TASKS_KEY, days],
+    queryFn: () => listUpcomingTasks(days),
+  });
+}

--- a/dev/frontend/lib/projects/kanban-testids.ts
+++ b/dev/frontend/lib/projects/kanban-testids.ts
@@ -1,0 +1,106 @@
+/**
+ * Kanban 元件 data-testid 命名表（F-032b）。
+ *
+ * 必須與 `design/components/kanban/testids.md` 與
+ * QA fixture 保持完全一致。
+ */
+export const KANBAN_TESTIDS = {
+  // Board container
+  board: "kanban-board",
+  boardScroll: "kanban-board-scroll",
+  boardSkeleton: "kanban-board-skeleton",
+  boardError: "kanban-board-error",
+  boardLiveRegion: "kanban-board-live-region",
+
+  // Mobile single-column switcher (< 768px)
+  mobileStatusSwitcher: "kanban-mobile-status-switcher",
+  mobileStatusOption: "kanban-mobile-status-option",
+
+  // Column
+  column: "kanban-column",
+  columnHeader: "kanban-column-header",
+  columnLabel: "kanban-column-label",
+  columnCount: "kanban-column-count",
+  columnAddTask: "kanban-column-add-task",
+  columnEmpty: "kanban-column-empty",
+  columnDropZone: "kanban-column-drop-zone",
+  columnList: "kanban-column-list",
+
+  // Card
+  card: "kanban-card",
+  cardDragHandle: "kanban-card-drag-handle",
+  cardTitle: "kanban-card-title",
+  cardPriorityBadge: "kanban-card-priority",
+  cardStatusDot: "kanban-card-status-dot",
+  cardDueDate: "kanban-card-due-date",
+  cardRefsCount: "kanban-card-refs-count",
+  cardCompleteToggle: "kanban-card-complete-toggle",
+  cardOpenSheet: "kanban-card-open-sheet",
+
+  // Drag overlay
+  dragOverlay: "kanban-drag-overlay",
+  dragOverlayCard: "kanban-drag-overlay-card",
+} as const;
+
+export type TaskStatus =
+  | "todo"
+  | "in_progress"
+  | "blocked"
+  | "done"
+  | "cancelled";
+
+export type TaskPriority = "low" | "normal" | "high" | "urgent";
+
+export const KANBAN_STATUSES: ReadonlyArray<{
+  status: Exclude<TaskStatus, "cancelled">;
+  label: string;
+}> = [
+  { status: "todo", label: "待辦" },
+  { status: "in_progress", label: "進行中" },
+  { status: "blocked", label: "卡住" },
+  { status: "done", label: "完成" },
+];
+
+export const TASK_STATUS_LABEL: Record<TaskStatus, string> = {
+  todo: "待辦",
+  in_progress: "進行中",
+  blocked: "卡住",
+  done: "完成",
+  cancelled: "取消",
+};
+
+export const TASK_PRIORITY_LABEL: Record<TaskPriority, string> = {
+  low: "低",
+  normal: "一般",
+  high: "高",
+  urgent: "急迫",
+};
+
+export const TASK_STATUS_DOT_CLASS: Record<TaskStatus, string> = {
+  todo: "bg-zinc-400",
+  in_progress: "bg-blue-500",
+  blocked: "bg-red-500",
+  done: "bg-green-500",
+  cancelled: "bg-zinc-300",
+};
+
+export const TASK_STATUS_BADGE_CLASS: Record<TaskStatus, string> = {
+  todo:
+    "border-zinc-300 bg-zinc-100 text-zinc-700 dark:bg-zinc-900/60 dark:text-zinc-300",
+  in_progress:
+    "border-blue-300 bg-blue-100 text-blue-900 dark:bg-blue-950/40 dark:text-blue-200",
+  blocked:
+    "border-red-300 bg-red-100 text-red-900 dark:bg-red-950/40 dark:text-red-200",
+  done: "border-green-300 bg-green-100 text-green-900 dark:bg-green-950/40 dark:text-green-200",
+  cancelled:
+    "border-zinc-300 bg-zinc-100 text-zinc-500 dark:bg-zinc-900/60 dark:text-zinc-400",
+};
+
+export const TASK_PRIORITY_BADGE_CLASS: Record<TaskPriority, string> = {
+  low: "border-zinc-300 bg-zinc-100 text-zinc-700 dark:bg-zinc-900/60 dark:text-zinc-300",
+  normal:
+    "border-blue-300 bg-blue-100 text-blue-900 dark:bg-blue-950/40 dark:text-blue-200",
+  high: "border-orange-300 bg-orange-100 text-orange-900 dark:bg-orange-950/40 dark:text-orange-200",
+  urgent:
+    "border-red-300 bg-red-100 text-red-900 dark:bg-red-950/40 dark:text-red-200",
+};

--- a/dev/frontend/lib/projects/kanban-utils.ts
+++ b/dev/frontend/lib/projects/kanban-utils.ts
@@ -1,0 +1,175 @@
+/**
+ * Kanban 純函式工具：負責「拖放後計算新分組與位置」的邏輯，
+ * 不碰 React 狀態，方便 vitest 單測。
+ */
+import type { Task } from "@/lib/api/tasks";
+import type { TaskStatus } from "@/lib/projects/kanban-testids";
+
+export type KanbanStatus = Exclude<TaskStatus, "cancelled">;
+export const KANBAN_STATUS_LIST: ReadonlyArray<KanbanStatus> = [
+  "todo",
+  "in_progress",
+  "blocked",
+  "done",
+];
+
+export function isKanbanStatus(s: string): s is KanbanStatus {
+  return (KANBAN_STATUS_LIST as ReadonlyArray<string>).includes(s);
+}
+
+export interface KanbanTaskLike {
+  id: string;
+  status: TaskStatus;
+  position: number;
+  due_date?: string | null;
+  priority?: string;
+  title?: string;
+  refs?: unknown[];
+}
+
+/** 將 tasks 依 status 分組並排序（cancelled 不顯示在 board）。 */
+export function groupTasksByStatus<T extends KanbanTaskLike>(
+  tasks: T[],
+): Record<KanbanStatus, T[]> {
+  const out: Record<KanbanStatus, T[]> = {
+    todo: [],
+    in_progress: [],
+    blocked: [],
+    done: [],
+  };
+  for (const t of tasks) {
+    if (isKanbanStatus(t.status)) out[t.status].push(t);
+  }
+  for (const s of KANBAN_STATUS_LIST) {
+    out[s].sort((a, b) => a.position - b.position);
+  }
+  return out;
+}
+
+export interface ComputeNewPositionInput {
+  /** 拖移中的 task id */
+  activeId: string;
+  /** drop 目標 id：可能是另一張 card.id，或 column drop zone id `col-{status}` */
+  overId: string;
+  /** 全部 tasks（會在內部依 status 分組） */
+  tasks: KanbanTaskLike[];
+}
+
+export interface ComputeNewPositionResult {
+  taskId: string;
+  fromStatus: KanbanStatus;
+  toStatus: KanbanStatus;
+  /** 0-based 在目標欄的新位置（已扣除自己原本佔的格） */
+  toIndex: number;
+  /** 是否真的有變動（同欄同位則 false） */
+  changed: boolean;
+}
+
+/**
+ * 計算拖放後的新分組與位置。
+ *
+ * - overId 為 `col-{status}` 形式 → drop 在該欄末端
+ * - overId 為另一個 task.id → 插入在該卡片之前
+ * - 跨欄移動：自己被視為從來源欄移除後再插入
+ * - 同欄移動：插入位置會自動補償自己原本佔的位置
+ */
+export function computeNewPosition(
+  input: ComputeNewPositionInput,
+): ComputeNewPositionResult | null {
+  const { activeId, overId, tasks } = input;
+  const active = tasks.find((t) => t.id === activeId);
+  if (!active || !isKanbanStatus(active.status)) return null;
+
+  const fromStatus = active.status;
+
+  // 解析目標欄
+  let toStatus: KanbanStatus | null = null;
+  if (overId.startsWith("col-")) {
+    const s = overId.slice(4);
+    if (isKanbanStatus(s)) toStatus = s;
+  } else {
+    const overTask = tasks.find((t) => t.id === overId);
+    if (overTask && isKanbanStatus(overTask.status)) {
+      toStatus = overTask.status;
+    }
+  }
+  if (!toStatus) return null;
+
+  const grouped = groupTasksByStatus(tasks);
+  const targetList = grouped[toStatus];
+
+  let toIndex: number;
+  if (overId.startsWith("col-")) {
+    // drop 在欄末端
+    toIndex =
+      fromStatus === toStatus ? targetList.length - 1 : targetList.length;
+    if (toIndex < 0) toIndex = 0;
+  } else {
+    const overIdx = targetList.findIndex((t) => t.id === overId);
+    if (overIdx === -1) {
+      toIndex = targetList.length;
+    } else if (fromStatus === toStatus) {
+      const fromIdx = targetList.findIndex((t) => t.id === activeId);
+      // 同欄拖移：若往下拖過自己，目的索引不需 +1
+      toIndex = overIdx;
+      if (fromIdx !== -1 && fromIdx < overIdx) {
+        toIndex = overIdx; // arrayMove semantics with @dnd-kit closestCorners
+      }
+    } else {
+      toIndex = overIdx;
+    }
+  }
+
+  const fromIdx = grouped[fromStatus].findIndex((t) => t.id === activeId);
+  const changed = !(fromStatus === toStatus && fromIdx === toIndex);
+
+  return { taskId: activeId, fromStatus, toStatus, toIndex, changed };
+}
+
+/**
+ * 將樂觀更新套用到 tasks（回傳新陣列，不改原物件）。
+ *
+ * 為了讓 UI 立即反映，我們在這裡同時：
+ * 1. 把目標 task 的 status 設為 toStatus
+ * 2. 重新指派 position（依新順序 0,1,2,...）
+ */
+export function applyOptimisticMove<T extends KanbanTaskLike>(
+  tasks: T[],
+  result: ComputeNewPositionResult,
+): T[] {
+  const { taskId, fromStatus, toStatus, toIndex } = result;
+  const grouped = groupTasksByStatus(tasks);
+
+  // 從來源欄移除
+  const sourceList = grouped[fromStatus].filter((t) => t.id !== taskId);
+  // 找到 active task
+  const active = tasks.find((t) => t.id === taskId);
+  if (!active) return tasks;
+
+  if (fromStatus === toStatus) {
+    const insertIdx = Math.max(0, Math.min(toIndex, sourceList.length));
+    sourceList.splice(insertIdx, 0, { ...active, status: toStatus } as T);
+    grouped[fromStatus] = sourceList;
+  } else {
+    grouped[fromStatus] = sourceList;
+    const targetList = [...grouped[toStatus]];
+    const insertIdx = Math.max(0, Math.min(toIndex, targetList.length));
+    targetList.splice(insertIdx, 0, { ...active, status: toStatus } as T);
+    grouped[toStatus] = targetList;
+  }
+
+  // 重編 position（每個欄獨立）
+  const out: T[] = [];
+  // 保留 cancelled 等不在 board 的 status 原樣
+  const kanbanIdSet = new Set<string>();
+  for (const s of KANBAN_STATUS_LIST) {
+    grouped[s].forEach((t, i) => {
+      out.push({ ...t, status: s, position: i } as T);
+      kanbanIdSet.add(t.id);
+    });
+  }
+  for (const t of tasks) {
+    if (!kanbanIdSet.has(t.id)) out.push(t);
+  }
+  return out;
+}

--- a/dev/frontend/lib/projects/testids.ts
+++ b/dev/frontend/lib/projects/testids.ts
@@ -69,6 +69,48 @@ export const PROJECTS_TESTIDS = {
   toastUpdated: "projects-toast-updated",
   toastDeleted: "projects-toast-deleted",
   toastArchived: "projects-toast-archived",
+  toastDragFailed: "project-toast-drag-failed",
+  toastTaskCompleted: "project-toast-task-completed",
+
+  // Detail page (F-032b)
+  detailPage: "project-detail-page",
+  detailHeader: "project-detail-header",
+  detailHeaderName: "project-detail-header-name",
+  detailHeaderEdit: "project-detail-header-edit",
+  detailNewTask: "project-detail-new-task",
+  detailLoading: "project-detail-loading",
+  detailError: "project-detail-error",
+  detailNotFound: "project-detail-not-found",
+  detailTabs: "project-detail-tabs",
+  detailTabBoard: "project-detail-tab-board",
+  detailTabList: "project-detail-tab-list",
+  detailTabOverview: "project-detail-tab-overview",
+  detailContentBoard: "project-detail-content-board",
+  detailContentList: "project-detail-content-list",
+  detailContentOverview: "project-detail-content-overview",
+
+  // Overview tab
+  overviewProgress: "project-overview-progress",
+  overviewProgressBar: "project-overview-progress-bar",
+  overviewStats: "project-overview-stats",
+  overviewStatTotal: "project-overview-stat-total",
+  overviewStatDone: "project-overview-stat-done",
+  overviewStatBlocked: "project-overview-stat-blocked",
+  overviewStatOverdue: "project-overview-stat-overdue",
+  overviewTimeline: "project-overview-timeline",
+  overviewDates: "project-overview-dates",
+  overviewDescription: "project-overview-description",
+  overviewActivity: "project-overview-activity",
+  overviewActivityItem: "project-overview-activity-item",
+
+  // Task list tab
+  taskListSearch: "task-list-search",
+  taskListFilterStatus: "task-list-filter-status",
+  taskListFilterPriority: "task-list-filter-priority",
+  taskListTable: "project-task-list-table",
+  taskListEmpty: "project-task-list-empty",
+  taskListRow: (id: string) => `task-list-row-${id}`,
+  taskListRowCheck: (id: string) => `task-list-row-${id}-check`,
 } as const;
 
 /** Project color palette（與 design/tokens/projects.json `project-color-palette` 對齊） */

--- a/dev/frontend/lib/schemas/task.ts
+++ b/dev/frontend/lib/schemas/task.ts
@@ -1,0 +1,36 @@
+import { z } from "zod";
+
+export const taskRefSchema = z.object({
+  ref_type: z.enum(["entry", "journal", "gcal_event"]),
+  ref_id: z.string().min(1),
+});
+
+const dateOrEmpty = z
+  .string()
+  .trim()
+  .regex(/^\d{4}-\d{2}-\d{2}$/, "日期格式應為 YYYY-MM-DD")
+  .optional()
+  .or(z.literal(""));
+
+export const taskFormSchema = z.object({
+  title: z
+    .string()
+    .trim()
+    .min(1, "標題必填")
+    .max(200, "標題最多 200 個字元"),
+  description: z
+    .string()
+    .trim()
+    .max(5000, "描述最多 5000 個字元")
+    .optional()
+    .or(z.literal("")),
+  status: z
+    .enum(["todo", "in_progress", "blocked", "done", "cancelled"])
+    .optional(),
+  priority: z.enum(["low", "normal", "high", "urgent"]).optional(),
+  due_date: dateOrEmpty,
+  refs: z.array(taskRefSchema).optional(),
+});
+
+export type TaskFormValues = z.infer<typeof taskFormSchema>;
+export type TaskRefInput = z.infer<typeof taskRefSchema>;

--- a/dev/frontend/package-lock.json
+++ b/dev/frontend/package-lock.json
@@ -8,6 +8,10 @@
       "name": "aibo-frontend",
       "version": "0.1.0",
       "dependencies": {
+        "@dnd-kit/accessibility": "^3.1.1",
+        "@dnd-kit/core": "^6.3.1",
+        "@dnd-kit/sortable": "^8.0.0",
+        "@dnd-kit/utilities": "^3.2.2",
         "@hookform/resolvers": "^3.9.1",
         "@radix-ui/react-alert-dialog": "^1.1.4",
         "@radix-ui/react-checkbox": "^1.1.3",
@@ -241,6 +245,59 @@
       "license": "MIT",
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/@dnd-kit/accessibility": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/accessibility/-/accessibility-3.1.1.tgz",
+      "integrity": "sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/core": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/core/-/core-6.3.1.tgz",
+      "integrity": "sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/accessibility": "^3.1.1",
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/sortable": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/sortable/-/sortable-8.0.0.tgz",
+      "integrity": "sha512-U3jk5ebVXe1Lr7c2wU7SBZjcWdQP+j7peHJfCspnA81enlu88Mgd7CC8Q+pub9ubP7eKVETzJW+IBAhsqbSu/g==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "@dnd-kit/core": "^6.1.0",
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/utilities": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/utilities/-/utilities-3.2.2.tgz",
+      "integrity": "sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
       }
     },
     "node_modules/@emnapi/core": {

--- a/dev/frontend/package.json
+++ b/dev/frontend/package.json
@@ -11,6 +11,10 @@
     "test:watch": "vitest"
   },
   "dependencies": {
+    "@dnd-kit/accessibility": "^3.1.1",
+    "@dnd-kit/core": "^6.3.1",
+    "@dnd-kit/sortable": "^8.0.0",
+    "@dnd-kit/utilities": "^3.2.2",
     "@hookform/resolvers": "^3.9.1",
     "@radix-ui/react-alert-dialog": "^1.1.4",
     "@radix-ui/react-checkbox": "^1.1.3",


### PR DESCRIPTION
## Summary

- ProjectDetailPage（Tabs：Board / List / Overview）
- KanbanBoard 用 @dnd-kit/sortable，含 mobile 單欄 + status switcher、drag handle a11y label
- ProjectOverviewTab（進度 / 統計 / 時程 / 描述）+ ProjectTaskListTab（表格）
- TanStack Query：updateTask / completeTask / createTask 後 invalidate 同步 kanban + project

## 範圍

15 檔，+1894 行：
- app/(dashboard)/projects/[id]/page.tsx
- components/kanban/{kanban-board,kanban-column,kanban-card}.tsx
- components/projects/{project-overview-tab,project-task-list-tab}.tsx
- lib/api/tasks.ts + lib/hooks/use-tasks.ts + lib/schemas/task.ts
- lib/projects/{kanban-utils,kanban-testids}.ts + testids.ts +detail/overview/list 區塊
- 新增 deps：@dnd-kit/core, @dnd-kit/sortable, @dnd-kit/utilities

## Note

由 engineer agent 實作 KanbanBoard / Overview / lib 主體（~1130 行），orchestrator 補 page.tsx 整合 + ProjectTaskListTab（task add 用 prompt() placeholder，task open 留 hash placeholder 給 F-032c TaskSheet）。

## Closes

Closes #124

🤖 Generated with [Claude Code](https://claude.com/claude-code)