### PR TITLE
feat(frontend): F-032c TaskSheet + RefsPicker + UpcomingTasksWidget

### DIFF
--- a/dev/frontend/app/(dashboard)/projects/[id]/page.tsx
+++ b/dev/frontend/app/(dashboard)/projects/[id]/page.tsx
@@ -12,6 +12,7 @@ import { ErrorState } from "@/components/error-state";
 import { KanbanBoard, type KanbanBoardTask } from "@/components/kanban/kanban-board";
 import { ProjectOverviewTab } from "@/components/projects/project-overview-tab";
 import { ProjectTaskListTab } from "@/components/projects/project-task-list-tab";
+import { TaskSheet } from "@/components/task/task-sheet";
 import { useProject } from "@/lib/hooks/use-projects";
 import {
   tasksKey,
@@ -29,6 +30,8 @@ export default function ProjectDetailPage() {
   const projectId = params?.id ?? "";
 
   const queryClient = useQueryClient();
+  const [activeTaskId, setActiveTaskId] = React.useState<string | null>(null);
+  const [sheetOpen, setSheetOpen] = React.useState(false);
   const projectQ = useProject(projectId);
   const tasksQ = useProjectTasks(projectId);
   const updateMut = useUpdateTask(projectId);
@@ -121,8 +124,8 @@ export default function ProjectDetailPage() {
   );
 
   const handleOpenTask = React.useCallback((taskId: string) => {
-    // F-032c TaskSheet 後續實作；此處先 navigate 到 hash 作 placeholder
-    if (typeof window !== "undefined") window.location.hash = `task-${taskId}`;
+    setActiveTaskId(taskId);
+    setSheetOpen(true);
   }, []);
 
   const handleCompleteTask = React.useCallback(
@@ -223,6 +226,16 @@ export default function ProjectDetailPage() {
           <ProjectOverviewTab project={project} overdueCount={overdueCount} />
         </TabsContent>
       </Tabs>
+
+      <TaskSheet
+        taskId={activeTaskId}
+        projectId={projectId}
+        open={sheetOpen}
+        onOpenChange={(o) => {
+          setSheetOpen(o);
+          if (!o) setActiveTaskId(null);
+        }}
+      />
     </div>
   );
 }

--- a/dev/frontend/components/app-sidebar.tsx
+++ b/dev/frontend/components/app-sidebar.tsx
@@ -17,6 +17,7 @@ import {
 import { cn } from "@/lib/utils";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
+import { UpcomingTasksWidget } from "@/components/task/upcoming-tasks-widget";
 
 type NavItem = {
   label: string;
@@ -90,7 +91,8 @@ export function AppSidebar({ inboxCount = 0, open, onClose }: AppSidebarProps) {
           <NavGroup title="設定" items={settings} pathname={pathname} />
         </nav>
 
-        <div className="border-t border-sidebar-border p-4">
+        <div className="border-t border-sidebar-border p-3 space-y-3">
+          <UpcomingTasksWidget />
           <p className="text-xs text-muted-foreground">aibo v1.0.0</p>
         </div>
       </aside>

--- a/dev/frontend/components/task/refs-picker.tsx
+++ b/dev/frontend/components/task/refs-picker.tsx
@@ -1,0 +1,133 @@
+"use client";
+
+import * as React from "react";
+import { X } from "lucide-react";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Tabs, TabsList, TabsTrigger, TabsContent } from "@/components/ui/tabs";
+import type { TaskRef } from "@/lib/api/tasks";
+import { PROJECTS_TESTIDS } from "@/lib/projects/testids";
+
+type RefKind = TaskRef["ref_type"];
+
+interface RefsPickerProps {
+  value: TaskRef[];
+  onChange: (next: TaskRef[]) => void;
+}
+
+/**
+ * RefsPicker：F-032c 基礎版本。
+ *
+ * 提供 Entry / Journal / Gcal 三個 tab，搜尋輸入框與已選 chips 區塊。
+ * 搜尋實際串接後端會在後續 PR 完成；本版本以「直接輸入 ID + label」方式新增 ref，
+ * 確保資料流（onChange）正確並不阻擋 TaskSheet 整合。
+ */
+export function RefsPicker({ value, onChange }: RefsPickerProps) {
+  const [kind, setKind] = React.useState<RefKind>("entry");
+  const [refId, setRefId] = React.useState("");
+
+  const handleAdd = () => {
+    const id = refId.trim();
+    if (!id) return;
+    if (value.some((r) => r.ref_type === kind && r.ref_id === id)) return;
+    onChange([...value, { ref_type: kind, ref_id: id }]);
+    setRefId("");
+  };
+
+  const handleRemove = (target: TaskRef) => {
+    onChange(
+      value.filter(
+        (r) => !(r.ref_type === target.ref_type && r.ref_id === target.ref_id),
+      ),
+    );
+  };
+
+  return (
+    <div className="space-y-3" data-testid={PROJECTS_TESTIDS.refsPicker}>
+      <Tabs value={kind} onValueChange={(v) => setKind(v as RefKind)}>
+        <TabsList>
+          <TabsTrigger
+            value="entry"
+            data-testid={PROJECTS_TESTIDS.refsPickerTab("entry")}
+          >
+            知識條目
+          </TabsTrigger>
+          <TabsTrigger
+            value="journal"
+            data-testid={PROJECTS_TESTIDS.refsPickerTab("journal")}
+          >
+            日記
+          </TabsTrigger>
+          <TabsTrigger
+            value="gcal_event"
+            data-testid={PROJECTS_TESTIDS.refsPickerTab("gcal")}
+          >
+            Google Calendar
+          </TabsTrigger>
+        </TabsList>
+
+        <TabsContent value={kind} className="mt-3 space-y-2">
+          <div className="flex gap-2">
+            <Input
+              value={refId}
+              onChange={(e) => setRefId(e.target.value)}
+              placeholder={
+                kind === "entry"
+                  ? "輸入條目 ID 或關鍵字"
+                  : kind === "journal"
+                    ? "輸入日記日期 (YYYY-MM-DD)"
+                    : "輸入 Google Calendar 事件 ID"
+              }
+              data-testid={PROJECTS_TESTIDS.refsPickerSearch}
+              onKeyDown={(e) => {
+                if (e.key === "Enter") {
+                  e.preventDefault();
+                  handleAdd();
+                }
+              }}
+            />
+            <Button type="button" onClick={handleAdd}>
+              新增
+            </Button>
+          </div>
+          <p className="text-xs text-muted-foreground">
+            （搜尋串接後端的版本將於後續 PR 上線；目前可直接輸入 ID 建立關聯。）
+          </p>
+        </TabsContent>
+      </Tabs>
+
+      {value.length === 0 ? (
+        <div
+          className="rounded-md border border-dashed p-3 text-center text-xs text-muted-foreground"
+          data-testid={PROJECTS_TESTIDS.refsPickerEmpty}
+        >
+          尚未關聯任何來源
+        </div>
+      ) : (
+        <div className="flex flex-wrap gap-2">
+          {value.map((r) => (
+            <Badge
+              key={`${r.ref_type}:${r.ref_id}`}
+              variant="secondary"
+              className="gap-1 pr-1"
+              data-testid={PROJECTS_TESTIDS.refsPickerChip(r.ref_id)}
+            >
+              <span className="font-medium uppercase opacity-70">{r.ref_type}</span>
+              <span className="truncate max-w-[140px]">{r.ref_id}</span>
+              <button
+                type="button"
+                aria-label="移除來源"
+                className="ml-1 rounded p-0.5 hover:bg-muted"
+                onClick={() => handleRemove(r)}
+                data-testid={PROJECTS_TESTIDS.refsPickerChipRemove(r.ref_id)}
+              >
+                <X className="h-3 w-3" />
+              </button>
+            </Badge>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/dev/frontend/components/task/task-sheet.tsx
+++ b/dev/frontend/components/task/task-sheet.tsx
@@ -1,0 +1,321 @@
+"use client";
+
+import * as React from "react";
+import { toast } from "sonner";
+import { Check, Loader2, Trash2 } from "lucide-react";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import {
+  Sheet,
+  SheetContent,
+  SheetDescription,
+  SheetFooter,
+  SheetHeader,
+  SheetTitle,
+} from "@/components/ui/sheet";
+import { Skeleton } from "@/components/ui/skeleton";
+import { Textarea } from "@/components/ui/textarea";
+import { RefsPicker } from "@/components/task/refs-picker";
+import {
+  useCompleteTask,
+  useDeleteTask,
+  useTask,
+  useUpdateTask,
+} from "@/lib/hooks/use-tasks";
+import type { TaskPriority, TaskRef, TaskStatus } from "@/lib/api/tasks";
+import { PROJECTS_TESTIDS } from "@/lib/projects/testids";
+
+interface TaskSheetProps {
+  taskId: string | null;
+  projectId: string;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+const STATUS_OPTIONS: TaskStatus[] = [
+  "todo",
+  "in_progress",
+  "blocked",
+  "done",
+  "cancelled",
+];
+const PRIORITY_OPTIONS: TaskPriority[] = ["low", "normal", "high", "urgent"];
+
+const STATUS_LABEL: Record<TaskStatus, string> = {
+  todo: "待辦",
+  in_progress: "進行中",
+  blocked: "受阻",
+  done: "已完成",
+  cancelled: "取消",
+};
+const PRIORITY_LABEL: Record<TaskPriority, string> = {
+  low: "低",
+  normal: "中",
+  high: "高",
+  urgent: "緊急",
+};
+
+export function TaskSheet({ taskId, projectId, open, onOpenChange }: TaskSheetProps) {
+  const taskQ = useTask(open ? taskId : null);
+  const updateMut = useUpdateTask(projectId);
+  const completeMut = useCompleteTask(projectId);
+  const deleteMut = useDeleteTask(projectId);
+
+  const [title, setTitle] = React.useState("");
+  const [description, setDescription] = React.useState("");
+  const [status, setStatus] = React.useState<TaskStatus>("todo");
+  const [priority, setPriority] = React.useState<TaskPriority>("normal");
+  const [dueDate, setDueDate] = React.useState("");
+  const [refs, setRefs] = React.useState<TaskRef[]>([]);
+  const [confirmDelete, setConfirmDelete] = React.useState(false);
+
+  React.useEffect(() => {
+    if (taskQ.data) {
+      setTitle(taskQ.data.title);
+      setDescription(taskQ.data.description ?? "");
+      setStatus(taskQ.data.status);
+      setPriority(taskQ.data.priority);
+      setDueDate(taskQ.data.due_date ?? "");
+      setRefs(taskQ.data.refs ?? []);
+    }
+  }, [taskQ.data]);
+
+  const handleSave = async () => {
+    if (!taskId) return;
+    if (!title.trim()) {
+      toast.error("標題不可為空");
+      return;
+    }
+    try {
+      await updateMut.mutateAsync({
+        id: taskId,
+        input: {
+          title: title.trim(),
+          description: description.trim() ? description : null,
+          status,
+          priority,
+          due_date: dueDate || null,
+          refs,
+        },
+      });
+      toast.success("已儲存");
+      onOpenChange(false);
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : "儲存失敗");
+    }
+  };
+
+  const handleComplete = async () => {
+    if (!taskId) return;
+    try {
+      await completeMut.mutateAsync(taskId);
+      toast.success("任務已完成");
+      onOpenChange(false);
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : "標記完成失敗");
+    }
+  };
+
+  const handleDelete = async () => {
+    if (!taskId) return;
+    try {
+      await deleteMut.mutateAsync(taskId);
+      toast.success("已刪除");
+      setConfirmDelete(false);
+      onOpenChange(false);
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : "刪除失敗");
+    }
+  };
+
+  return (
+    <>
+      <Sheet open={open} onOpenChange={onOpenChange}>
+        <SheetContent
+          side="right"
+          className="w-full overflow-y-auto sm:max-w-md"
+          data-testid={PROJECTS_TESTIDS.taskSheet}
+        >
+          <SheetHeader>
+            <SheetTitle>編輯任務</SheetTitle>
+            <SheetDescription>修改標題、狀態、優先級、到期日與關聯來源</SheetDescription>
+          </SheetHeader>
+
+          {taskQ.isLoading ? (
+            <div className="mt-4 space-y-3">
+              <Skeleton className="h-9 w-full" />
+              <Skeleton className="h-24 w-full" />
+              <Skeleton className="h-9 w-full" />
+            </div>
+          ) : taskQ.isError ? (
+            <p className="mt-4 text-sm text-destructive">
+              {taskQ.error instanceof Error ? taskQ.error.message : "載入失敗"}
+            </p>
+          ) : (
+            <div className="mt-4 space-y-4">
+              <div className="space-y-1">
+                <Label htmlFor="task-title">標題</Label>
+                <Input
+                  id="task-title"
+                  value={title}
+                  onChange={(e) => setTitle(e.target.value)}
+                  data-testid={PROJECTS_TESTIDS.taskSheetTitle}
+                />
+              </div>
+
+              <div className="space-y-1">
+                <Label htmlFor="task-description">描述</Label>
+                <Textarea
+                  id="task-description"
+                  value={description}
+                  onChange={(e) => setDescription(e.target.value)}
+                  rows={4}
+                  data-testid={PROJECTS_TESTIDS.taskSheetDescription}
+                />
+              </div>
+
+              <div className="grid grid-cols-2 gap-3">
+                <div className="space-y-1">
+                  <Label>狀態</Label>
+                  <Select
+                    value={status}
+                    onValueChange={(v) => setStatus(v as TaskStatus)}
+                  >
+                    <SelectTrigger data-testid={PROJECTS_TESTIDS.taskSheetStatus}>
+                      <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {STATUS_OPTIONS.map((s) => (
+                        <SelectItem key={s} value={s}>
+                          {STATUS_LABEL[s]}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                </div>
+
+                <div className="space-y-1">
+                  <Label>優先級</Label>
+                  <Select
+                    value={priority}
+                    onValueChange={(v) => setPriority(v as TaskPriority)}
+                  >
+                    <SelectTrigger data-testid={PROJECTS_TESTIDS.taskSheetPriority}>
+                      <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {PRIORITY_OPTIONS.map((p) => (
+                        <SelectItem key={p} value={p}>
+                          {PRIORITY_LABEL[p]}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                </div>
+              </div>
+
+              <div className="space-y-1">
+                <Label htmlFor="task-due">到期日</Label>
+                <Input
+                  id="task-due"
+                  type="date"
+                  value={dueDate}
+                  onChange={(e) => setDueDate(e.target.value)}
+                  data-testid={PROJECTS_TESTIDS.taskSheetDueDate}
+                />
+              </div>
+
+              <div className="space-y-1" data-testid={PROJECTS_TESTIDS.taskSheetRefs}>
+                <Label>關聯來源</Label>
+                <RefsPicker value={refs} onChange={setRefs} />
+              </div>
+            </div>
+          )}
+
+          <SheetFooter className="mt-6 flex-row flex-wrap justify-between gap-2">
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              onClick={() => setConfirmDelete(true)}
+              disabled={!taskId || deleteMut.isPending}
+              data-testid={PROJECTS_TESTIDS.taskSheetDelete}
+            >
+              <Trash2 className="mr-1 h-4 w-4" />
+              刪除
+            </Button>
+            <div className="flex gap-2">
+              {status !== "done" && (
+                <Button
+                  type="button"
+                  variant="secondary"
+                  size="sm"
+                  onClick={handleComplete}
+                  disabled={!taskId || completeMut.isPending}
+                  data-testid={PROJECTS_TESTIDS.taskSheetComplete}
+                >
+                  {completeMut.isPending ? (
+                    <Loader2 className="mr-1 h-4 w-4 animate-spin" />
+                  ) : (
+                    <Check className="mr-1 h-4 w-4" />
+                  )}
+                  完成
+                </Button>
+              )}
+              <Button
+                type="button"
+                size="sm"
+                onClick={handleSave}
+                disabled={updateMut.isPending}
+                data-testid={PROJECTS_TESTIDS.taskSheetSave}
+              >
+                {updateMut.isPending && (
+                  <Loader2 className="mr-1 h-4 w-4 animate-spin" />
+                )}
+                儲存
+              </Button>
+            </div>
+          </SheetFooter>
+        </SheetContent>
+      </Sheet>
+
+      <AlertDialog open={confirmDelete} onOpenChange={setConfirmDelete}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>確認刪除任務？</AlertDialogTitle>
+            <AlertDialogDescription>
+              此操作無法復原，相關的 task_refs 也會一併刪除。
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>取消</AlertDialogCancel>
+            <AlertDialogAction
+              onClick={handleDelete}
+              className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+            >
+              刪除
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </>
+  );
+}

--- a/dev/frontend/components/task/upcoming-tasks-widget.tsx
+++ b/dev/frontend/components/task/upcoming-tasks-widget.tsx
@@ -1,0 +1,85 @@
+"use client";
+
+import * as React from "react";
+import Link from "next/link";
+import { CalendarClock } from "lucide-react";
+import { Skeleton } from "@/components/ui/skeleton";
+import { useUpcomingTasks } from "@/lib/hooks/use-tasks";
+import { PROJECTS_TESTIDS } from "@/lib/projects/testids";
+import { cn } from "@/lib/utils";
+
+interface UpcomingTasksWidgetProps {
+  /** 顯示天數，預設 7 */
+  days?: number;
+  /** 最多顯示筆數 */
+  limit?: number;
+}
+
+function isOverdue(dueDate: string | null): boolean {
+  if (!dueDate) return false;
+  const m = /^(\d{4})-(\d{2})-(\d{2})$/.exec(dueDate);
+  if (!m) return false;
+  const today = new Date();
+  today.setHours(0, 0, 0, 0);
+  return new Date(Number(m[1]), Number(m[2]) - 1, Number(m[3])) < today;
+}
+
+export function UpcomingTasksWidget({
+  days = 7,
+  limit = 5,
+}: UpcomingTasksWidgetProps) {
+  const { data, isLoading } = useUpcomingTasks(days);
+  const items = (data?.data ?? []).slice(0, limit);
+
+  return (
+    <div
+      className="rounded-md border bg-card p-3 text-sm"
+      data-testid={PROJECTS_TESTIDS.upcomingWidget}
+    >
+      <div className="mb-2 flex items-center gap-2 text-xs font-medium text-muted-foreground">
+        <CalendarClock className="h-3.5 w-3.5" />
+        即將到期（{days} 天內）
+      </div>
+      {isLoading ? (
+        <div className="space-y-1.5">
+          {Array.from({ length: 3 }).map((_, i) => (
+            <Skeleton key={i} className="h-6 w-full" />
+          ))}
+        </div>
+      ) : items.length === 0 ? (
+        <p
+          className="text-xs text-muted-foreground"
+          data-testid={PROJECTS_TESTIDS.upcomingWidgetEmpty}
+        >
+          目前無即將到期的任務
+        </p>
+      ) : (
+        <ul className="space-y-1">
+          {items.map((t) => (
+            <li
+              key={t.id}
+              data-testid={PROJECTS_TESTIDS.upcomingWidgetItem(t.id)}
+            >
+              <Link
+                href={`/projects/${t.project_id}#task-${t.id}`}
+                className="flex items-center justify-between gap-2 rounded px-1.5 py-1 hover:bg-muted/50"
+              >
+                <span className="truncate">{t.title}</span>
+                <span
+                  className={cn(
+                    "shrink-0 text-xs",
+                    isOverdue(t.due_date)
+                      ? "text-destructive"
+                      : "text-muted-foreground",
+                  )}
+                >
+                  {t.due_date ?? "—"}
+                </span>
+              </Link>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/dev/frontend/lib/projects/testids.ts
+++ b/dev/frontend/lib/projects/testids.ts
@@ -111,6 +111,34 @@ export const PROJECTS_TESTIDS = {
   taskListEmpty: "project-task-list-empty",
   taskListRow: (id: string) => `task-list-row-${id}`,
   taskListRowCheck: (id: string) => `task-list-row-${id}-check`,
+
+  // Task Sheet (F-032c)
+  taskSheet: "task-sheet",
+  taskSheetTitle: "task-sheet-title",
+  taskSheetDescription: "task-sheet-description",
+  taskSheetStatus: "task-sheet-status",
+  taskSheetPriority: "task-sheet-priority",
+  taskSheetDueDate: "task-sheet-due-date",
+  taskSheetRefs: "task-sheet-refs",
+  taskSheetSave: "task-sheet-save",
+  taskSheetComplete: "task-sheet-complete",
+  taskSheetDelete: "task-sheet-delete",
+  taskSheetClose: "task-sheet-close",
+
+  // Refs Picker
+  refsPicker: "refs-picker",
+  refsPickerTab: (kind: string) => `refs-picker-tab-${kind}`,
+  refsPickerSearch: "refs-picker-search",
+  refsPickerResultItem: (id: string) => `refs-picker-result-${id}`,
+  refsPickerChip: (id: string) => `refs-picker-chip-${id}`,
+  refsPickerChipRemove: (id: string) => `refs-picker-chip-${id}-remove`,
+  refsPickerEmpty: "refs-picker-empty",
+  refsPickerSourceDeleted: "refs-picker-source-deleted",
+
+  // Upcoming Tasks Widget
+  upcomingWidget: "upcoming-tasks-widget",
+  upcomingWidgetEmpty: "upcoming-tasks-widget-empty",
+  upcomingWidgetItem: (id: string) => `upcoming-tasks-widget-item-${id}`,
 } as const;
 
 /** Project color palette（與 design/tokens/projects.json `project-color-palette` 對齊） */


### PR DESCRIPTION
## Summary

- TaskSheet：右側 Sheet 編輯 task — title/description/status/priority/due/refs/完成/刪除
- RefsPicker：Entry/Journal/Gcal Tabs + 已選 chips。本版以「直接輸入 ID」建立關聯，後端搜尋串接留後續 PR
- UpcomingTasksWidget：sidebar 底部 widget，呼叫 #132 的 /tasks/upcoming
- ProjectDetailPage 整合 TaskSheet（取代 #134 的 hash placeholder）
- AppSidebar 嵌入 UpcomingTasksWidget

## 範圍

6 檔，+585 行：
- components/task/{task-sheet,refs-picker,upcoming-tasks-widget}.tsx
- components/app-sidebar.tsx (+ widget)
- app/(dashboard)/projects/[id]/page.tsx (TaskSheet wire-up)
- lib/projects/testids.ts (+ task-sheet / refs-picker / upcoming-widget)

## Note

由 orchestrator 直寫（多次嘗試派 engineer agent 都卡在元件研究階段）。後端串接搜尋（entries / journal / gcal）已標註 TODO，可拆為下一輪 polish PR。

## Closes

Closes #125

🤖 Generated with [Claude Code](https://claude.com/claude-code)