### PR TITLE
fix(frontend): /calendar 用 Suspense 包 useSearchParams (#94)

### DIFF
--- a/dev/frontend/app/(dashboard)/calendar/page.tsx
+++ b/dev/frontend/app/(dashboard)/calendar/page.tsx
@@ -1,8 +1,10 @@
 "use client";
 
 import * as React from "react";
+import { Suspense } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
 import { toast } from "sonner";
+import { Skeleton } from "@/components/ui/skeleton";
 import { CalendarToolbar } from "@/components/calendar/calendar-toolbar";
 import { MonthView } from "@/components/calendar/month-view";
 import { WeekView } from "@/components/calendar/week-view";
@@ -42,7 +44,24 @@ function parseView(v: string | null): CalendarView {
   return v === "week" || v === "day" ? v : "month";
 }
 
+function CalendarPageSkeleton() {
+  return (
+    <div className="flex flex-col gap-4">
+      <Skeleton className="h-10 w-full" />
+      <Skeleton className="h-[480px] w-full" />
+    </div>
+  );
+}
+
 export default function CalendarPage() {
+  return (
+    <Suspense fallback={<CalendarPageSkeleton />}>
+      <CalendarPageInner />
+    </Suspense>
+  );
+}
+
+function CalendarPageInner() {
   const router = useRouter();
   const searchParams = useSearchParams();
   const tz = React.useMemo(resolveTimezone, []);


### PR DESCRIPTION
## Summary
修復 #94：`/calendar` production build 失敗（`useSearchParams() should be wrapped in a suspense boundary`）。

## Changes
- `dev/frontend/app/(dashboard)/calendar/page.tsx`
  - 將原 `CalendarPage` 內容抽成 `CalendarPageInner`
  - 新增 `CalendarPageSkeleton` 作為 fallback
  - 預設 export 改為 `<Suspense fallback={<CalendarPageSkeleton />}><CalendarPageInner /></Suspense>`
  - 與既有 `search/page.tsx` 處理方式一致

## 影響範圍掃描
`grep -r useSearchParams dev/frontend/app` 找到兩個使用點：
- `app/(dashboard)/calendar/page.tsx` ← 本次修復
- `app/(dashboard)/search/page.tsx` ← 已有 Suspense（無需處理）

## 測試
- 本地 worktree 缺 `node_modules`，typecheck 與 `next build` 改交由 CI 驗證
- 改動為純結構性 wrapper，不影響原有邏輯

## Related Issues
Closes #94