### PR TITLE
feat(frontend): F-033b ProjectCard 補 cardOpenTaskCount

### DIFF
--- a/dev/frontend/components/projects/project-card.tsx
+++ b/dev/frontend/components/projects/project-card.tsx
@@ -114,6 +114,14 @@ export function ProjectCard({ project, onEdit, onArchive, onDelete }: ProjectCar
 
         {/* Meta footer */}
         <div className="flex items-center gap-3 text-xs text-muted-foreground">
+          {project.task_counts && (
+            <span data-testid={PROJECTS_TESTIDS.cardOpenTaskCount}>
+              未完成{" "}
+              {(project.task_counts.by_status.todo ?? 0) +
+                (project.task_counts.by_status.in_progress ?? 0) +
+                (project.task_counts.by_status.blocked ?? 0)}
+            </span>
+          )}
           {project.end_date && (
             <span data-testid={PROJECTS_TESTIDS.cardNextDue} className="truncate">
               至 {project.end_date}

--- a/dev/frontend/lib/api/projects.ts
+++ b/dev/frontend/lib/api/projects.ts
@@ -25,11 +25,13 @@ export interface Project {
 export interface ProjectListItem {
   id: string;
   name: string;
+  description?: string | null;
   color: string;
   status: ProjectStatus;
   start_date: string | null;
   end_date: string | null;
   progress: number;
+  task_counts?: TaskCounts;
   created_at: string;
   updated_at: string;
 }


### PR DESCRIPTION
## Summary

跑 sprint 10 e2e 時發現 ProjectCard 缺 `cardOpenTaskCount` data-testid，spec 預期顯示「未完成 N」。本 PR：
- ProjectListItem 加 `task_counts?: TaskCounts`（與 Project 對齊）
- ProjectCard 在 task_counts 存在時渲染未完成數（todo + in_progress + blocked）

## 已知 limitation

實際 e2e 仍跑不通，root cause：`ApiClient.bootstrap` 對已 bootstrap 過的 API 會被擋（POST /auth/api-keys 要求 X-API-Key），本機 dev 環境已 bootstrap 過。需 e2e DB reset 機制（test container per run / fixture seed）才能 verify。

留作 follow-up：
- e2e 跑前 reset DB 或建立 sandbox 環境
- 跑通後再合併 sprint 10 全 e2e 解 skip 的 PR

## Refs

Refs #141

🤖 Generated with [Claude Code](https://claude.com/claude-code)