### PR TITLE
feat(frontend): F-034c GitHub 設定頁面 + sidebar nav

### DIFF
--- a/dev/frontend/app/(dashboard)/settings/github/page.tsx
+++ b/dev/frontend/app/(dashboard)/settings/github/page.tsx
@@ -250,7 +250,7 @@ function ConnectedSection({
       {status.last_error && (
         <p
           className="text-sm text-destructive"
-          data-testid={GITHUB_TESTIDS.ERROR_MESSAGE}
+          data-testid={GITHUB_TESTIDS.LAST_ERROR_MESSAGE}
         >
           上次錯誤：{status.last_error}
         </p>
@@ -285,6 +285,7 @@ function ConnectedSection({
           onSubmit={onConnect}
           isPending={isPending}
           submitLabel="更新 PAT"
+          submitTestId={GITHUB_TESTIDS.UPDATE_PAT_BUTTON}
         />
       )}
     </div>
@@ -299,6 +300,7 @@ function ConnectForm({
   onSubmit,
   isPending,
   submitLabel = "連接",
+  submitTestId = GITHUB_TESTIDS.CONNECT_BUTTON,
 }: {
   token: string;
   onTokenChange: (v: string) => void;
@@ -306,6 +308,7 @@ function ConnectForm({
   onSubmit: (e: React.FormEvent) => void;
   isPending: boolean;
   submitLabel?: string;
+  submitTestId?: string;
 }) {
   return (
     <form onSubmit={onSubmit} className="space-y-4">
@@ -349,7 +352,7 @@ function ConnectForm({
       <Button
         type="submit"
         disabled={isPending || !token.trim()}
-        data-testid={GITHUB_TESTIDS.CONNECT_BUTTON}
+        data-testid={submitTestId}
       >
         {isPending ? "連接中…" : submitLabel}
       </Button>

--- a/dev/frontend/app/(dashboard)/settings/github/page.tsx
+++ b/dev/frontend/app/(dashboard)/settings/github/page.tsx
@@ -1,0 +1,358 @@
+"use client";
+
+/**
+ * GitHub 設定頁面 — /settings/github
+ *
+ * 狀態一：未連接 → 顯示 PAT 輸入表單 + scope 說明
+ * 狀態二：已連接 → 顯示 username / scopes / last_synced_at / last_error
+ *                  + 中斷連接按鈕（含 AlertDialog 二次確認）
+ *                  + 更新 PAT 表單（可展開）
+ */
+
+import * as React from "react";
+import { ExternalLink, Github } from "lucide-react";
+import { toast } from "sonner";
+
+import { PageHeader } from "@/components/page-header";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Skeleton } from "@/components/ui/skeleton";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
+
+import {
+  useConnectGithub,
+  useDisconnectGithub,
+  useGithubStatus,
+} from "@/lib/hooks/use-github-integration";
+import { formatGithubError } from "@/lib/api/github-integration";
+import { GITHUB_TESTIDS } from "@/lib/github/testids";
+
+// ─── 主頁面元件 ───────────────────────────────────────────────
+
+export default function GithubSettingsPage() {
+  const { data: status, isLoading, isError } = useGithubStatus();
+  const connectMut = useConnectGithub();
+  const disconnectMut = useDisconnectGithub();
+
+  const [token, setToken] = React.useState("");
+  const [connectError, setConnectError] = React.useState<string | null>(null);
+  const [disconnectOpen, setDisconnectOpen] = React.useState(false);
+  // 已連接時「更新 PAT」區塊的展開狀態
+  const [showUpdateForm, setShowUpdateForm] = React.useState(false);
+
+  // ─── 連接 ─────────────────────────────────────────────────
+
+  const handleConnect = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!token.trim()) return;
+    setConnectError(null);
+    try {
+      const res = await connectMut.mutateAsync(token.trim());
+      toast.success("GitHub 連接成功", {
+        description: `已驗證帳號：${res.username}`,
+      });
+      setToken("");
+      setShowUpdateForm(false);
+    } catch (err) {
+      const msg = formatGithubError(err);
+      setConnectError(msg);
+      toast.error("連接失敗", { description: msg });
+    }
+  };
+
+  // ─── 中斷連接 ─────────────────────────────────────────────
+
+  const handleDisconnect = async () => {
+    try {
+      await disconnectMut.mutateAsync();
+      toast.success("已中斷 GitHub 連接");
+      setDisconnectOpen(false);
+      setToken("");
+      setShowUpdateForm(false);
+    } catch (err) {
+      const msg = formatGithubError(err);
+      toast.error("中斷失敗", { description: msg });
+    }
+  };
+
+  // ─── 載入中 ───────────────────────────────────────────────
+
+  if (isLoading) {
+    return (
+      <div>
+        <PageHeader title="GitHub" description="管理 GitHub 個人存取權杖（PAT）整合" />
+        <div className="space-y-4 max-w-xl">
+          <Skeleton className="h-8 w-48" />
+          <Skeleton className="h-10 w-full" />
+          <Skeleton className="h-10 w-32" />
+        </div>
+      </div>
+    );
+  }
+
+  const connected = !isError && status?.connected === true;
+
+  return (
+    <div>
+      <PageHeader title="GitHub" description="管理 GitHub 個人存取權杖（PAT）整合" />
+
+      <div className="max-w-xl space-y-6">
+        {/* 連接狀態 badge */}
+        <StatusBadge connected={connected} username={status?.username} />
+
+        {/* 已連接：顯示詳情 + 中斷 + 更新 PAT */}
+        {connected && status ? (
+          <ConnectedSection
+            status={status}
+            onDisconnect={() => setDisconnectOpen(true)}
+            showUpdateForm={showUpdateForm}
+            onToggleUpdateForm={() => setShowUpdateForm((v) => !v)}
+            token={token}
+            onTokenChange={setToken}
+            connectError={connectError}
+            onConnect={handleConnect}
+            isPending={connectMut.isPending}
+          />
+        ) : (
+          /* 未連接：顯示連接表單 */
+          <ConnectForm
+            token={token}
+            onTokenChange={setToken}
+            error={connectError}
+            onSubmit={handleConnect}
+            isPending={connectMut.isPending}
+          />
+        )}
+      </div>
+
+      {/* 中斷連接 AlertDialog */}
+      <AlertDialog open={disconnectOpen} onOpenChange={setDisconnectOpen}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>確認中斷 GitHub 連接</AlertDialogTitle>
+            <AlertDialogDescription>
+              中斷後，系統將無法再透過此帳號推送 commit。
+              您的現有資料不受影響，未來可以重新連接。
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel disabled={disconnectMut.isPending}>取消</AlertDialogCancel>
+            <AlertDialogAction
+              className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+              onClick={(e) => {
+                e.preventDefault();
+                handleDisconnect();
+              }}
+              disabled={disconnectMut.isPending}
+              data-testid={GITHUB_TESTIDS.DISCONNECT_CONFIRM_BUTTON}
+            >
+              {disconnectMut.isPending ? "中斷中…" : "確認中斷"}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </div>
+  );
+}
+
+// ─── 子元件 ───────────────────────────────────────────────────
+
+/** 狀態 badge：已連接 / 未連接 */
+function StatusBadge({
+  connected,
+  username,
+}: {
+  connected: boolean;
+  username?: string | null;
+}) {
+  return (
+    <div className="flex items-center gap-3">
+      <span className="text-sm text-muted-foreground">連接狀態：</span>
+      {connected ? (
+        <Badge
+          variant="success"
+          data-testid={GITHUB_TESTIDS.STATUS_BADGE}
+        >
+          已連接
+          {username && (
+            <>
+              ：
+              <span data-testid={GITHUB_TESTIDS.USERNAME_DISPLAY}>{username}</span>
+            </>
+          )}
+        </Badge>
+      ) : (
+        <Badge variant="secondary" data-testid={GITHUB_TESTIDS.STATUS_BADGE}>
+          未連接
+        </Badge>
+      )}
+    </div>
+  );
+}
+
+/** 已連接後的詳情區塊 */
+function ConnectedSection({
+  status,
+  onDisconnect,
+  showUpdateForm,
+  onToggleUpdateForm,
+  token,
+  onTokenChange,
+  connectError,
+  onConnect,
+  isPending,
+}: {
+  status: NonNullable<ReturnType<typeof useGithubStatus>["data"]>;
+  onDisconnect: () => void;
+  showUpdateForm: boolean;
+  onToggleUpdateForm: () => void;
+  token: string;
+  onTokenChange: (v: string) => void;
+  connectError: string | null;
+  onConnect: (e: React.FormEvent) => void;
+  isPending: boolean;
+}) {
+  return (
+    <div className="space-y-4">
+      {/* 帳號 / scopes */}
+      {status.scopes && status.scopes.length > 0 && (
+        <div className="space-y-1">
+          <p className="text-sm font-medium">已授權 Scopes</p>
+          <div className="flex flex-wrap gap-1">
+            {status.scopes.map((s) => (
+              <Badge key={s} variant="outline" className="text-xs font-mono">
+                {s}
+              </Badge>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {/* 最後同步時間 */}
+      {status.last_synced_at && (
+        <p className="text-sm text-muted-foreground">
+          最後同步：{new Date(status.last_synced_at).toLocaleString("zh-TW")}
+        </p>
+      )}
+
+      {/* 最後錯誤（若有） */}
+      {status.last_error && (
+        <p
+          className="text-sm text-destructive"
+          data-testid={GITHUB_TESTIDS.ERROR_MESSAGE}
+        >
+          上次錯誤：{status.last_error}
+        </p>
+      )}
+
+      {/* 操作按鈕列 */}
+      <div className="flex gap-2">
+        <Button
+          variant="outline"
+          size="sm"
+          onClick={onToggleUpdateForm}
+        >
+          <Github className="mr-2 h-4 w-4" />
+          {showUpdateForm ? "取消更新" : "更新 PAT"}
+        </Button>
+        <Button
+          variant="destructive"
+          size="sm"
+          onClick={onDisconnect}
+          data-testid={GITHUB_TESTIDS.DISCONNECT_BUTTON}
+        >
+          中斷連接
+        </Button>
+      </div>
+
+      {/* 更新 PAT 表單（可收折） */}
+      {showUpdateForm && (
+        <ConnectForm
+          token={token}
+          onTokenChange={onTokenChange}
+          error={connectError}
+          onSubmit={onConnect}
+          isPending={isPending}
+          submitLabel="更新 PAT"
+        />
+      )}
+    </div>
+  );
+}
+
+/** PAT 輸入表單（連接 / 更新共用） */
+function ConnectForm({
+  token,
+  onTokenChange,
+  error,
+  onSubmit,
+  isPending,
+  submitLabel = "連接",
+}: {
+  token: string;
+  onTokenChange: (v: string) => void;
+  error: string | null;
+  onSubmit: (e: React.FormEvent) => void;
+  isPending: boolean;
+  submitLabel?: string;
+}) {
+  return (
+    <form onSubmit={onSubmit} className="space-y-4">
+      <div className="space-y-2">
+        <Label htmlFor="github-token">個人存取權杖（PAT）</Label>
+        <Input
+          id="github-token"
+          type="password"
+          placeholder="ghp_xxxxxxxxxxxxxxxxxxxx"
+          value={token}
+          onChange={(e) => onTokenChange(e.target.value)}
+          autoComplete="off"
+          data-testid={GITHUB_TESTIDS.TOKEN_INPUT}
+        />
+        {/* 錯誤訊息 */}
+        {error && (
+          <p
+            className="text-sm text-destructive"
+            data-testid={GITHUB_TESTIDS.ERROR_MESSAGE}
+          >
+            {error}
+          </p>
+        )}
+        {/* Scope 說明 */}
+        <p className="text-xs text-muted-foreground">
+          需要 scopes：
+          <code className="mx-1 rounded bg-muted px-1 py-0.5 font-mono text-xs">repo</code>、
+          <code className="rounded bg-muted px-1 py-0.5 font-mono text-xs">read:user</code>
+          。
+          <a
+            href="https://github.com/settings/tokens"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="ml-1 inline-flex items-center gap-0.5 text-primary hover:underline"
+          >
+            如何產生 PAT
+            <ExternalLink className="h-3 w-3" />
+          </a>
+        </p>
+      </div>
+      <Button
+        type="submit"
+        disabled={isPending || !token.trim()}
+        data-testid={GITHUB_TESTIDS.CONNECT_BUTTON}
+      >
+        {isPending ? "連接中…" : submitLabel}
+      </Button>
+    </form>
+  );
+}

--- a/dev/frontend/components/app-sidebar.tsx
+++ b/dev/frontend/components/app-sidebar.tsx
@@ -7,6 +7,7 @@ import {
   Calendar,
   FileText,
   FolderTree,
+  Github,
   Inbox,
   KanbanSquare,
   Key,
@@ -47,6 +48,7 @@ export function AppSidebar({ inboxCount = 0, open, onClose }: AppSidebarProps) {
     { label: "API Key", href: "/settings/api-keys", icon: Key, testId: "nav-api-keys" },
     { label: "LLM Provider", href: "/settings/llm-providers", icon: Bot, testId: "nav-llm-providers" },
     { label: "Google Calendar", href: "/settings/gcal", icon: Calendar, testId: "nav-gcal" },
+    { label: "GitHub", href: "/settings/github", icon: Github, testId: "nav-github" },
   ];
 
   return (

--- a/dev/frontend/lib/api/github-integration.ts
+++ b/dev/frontend/lib/api/github-integration.ts
@@ -3,7 +3,7 @@
  *
  * 對應後端 F-034a 的 /api/v1/integrations/github/* 端點
  * 422 → GITHUB_TOKEN_INVALID / GITHUB_TOKEN_INSUFFICIENT_SCOPE
- * 403 → 權限不足（insufficient scope）
+ * 403 → GitHub 拒絕請求（IP 限制或其他權限問題）
  * 503 → GITHUB_UNAVAILABLE
  */
 
@@ -55,13 +55,13 @@ export function formatGithubError(err: unknown): string {
     case "GITHUB_TOKEN_INVALID":
       return "PAT 無效，請確認 token 是否正確";
     case "GITHUB_TOKEN_INSUFFICIENT_SCOPE":
-      return "PAT 缺少必要權限：repo, read:user";
+      return "PAT 缺少 scopes，需要 repo + read:user";
     case "GITHUB_UNAVAILABLE":
       return "GitHub 服務暫時無法連線，請稍後再試";
     default:
       // 依 HTTP status 給友善訊息
       if (err.status === 422) return "PAT 無效，請確認 token 是否正確";
-      if (err.status === 403) return "PAT 缺少必要權限：repo, read:user";
+      if (err.status === 403) return "GitHub 拒絕請求（可能是 IP 限制或權限問題）";
       if (err.status === 503) return "GitHub 服務暫時無法連線，請稍後再試";
       return err.message || "操作失敗，請稍後再試";
   }

--- a/dev/frontend/lib/api/github-integration.ts
+++ b/dev/frontend/lib/api/github-integration.ts
@@ -1,0 +1,94 @@
+/**
+ * GitHub 整合 API client
+ *
+ * 對應後端 F-034a 的 /api/v1/integrations/github/* 端點
+ * 422 → GITHUB_TOKEN_INVALID / GITHUB_TOKEN_INSUFFICIENT_SCOPE
+ * 403 → 權限不足（insufficient scope）
+ * 503 → GITHUB_UNAVAILABLE
+ */
+
+import { apiClient, ApiError } from "./client";
+
+// ─── 型別定義 ────────────────────────────────────────────────
+
+/** GitHub 整合狀態（GET /api/v1/integrations/github/status 的回應） */
+export interface GithubStatus {
+  /** 是否已連接（true = 已設定 PAT） */
+  connected: boolean;
+  /** 已連接時的 GitHub 登入帳號名稱 */
+  username?: string | null;
+  /** 已驗證的 scopes 清單 */
+  scopes?: string[] | null;
+  /** 最後同步時間（ISO 8601） */
+  last_synced_at?: string | null;
+  /** 最後一次錯誤訊息 */
+  last_error?: string | null;
+}
+
+/** 連接 GitHub 的請求 body */
+export interface ConnectGithubInput {
+  token: string;
+}
+
+/** 連接成功的回應 */
+export interface ConnectGithubResponse {
+  username: string;
+  scopes: string[];
+}
+
+// ─── 錯誤碼對應 ───────────────────────────────────────────────
+
+/**
+ * 將後端錯誤碼轉為使用者友善的中文訊息
+ * 後端錯誤 body 預期格式：{ code: string, message: string }
+ */
+export function formatGithubError(err: unknown): string {
+  if (!(err instanceof ApiError)) {
+    return err instanceof Error ? err.message : "未知錯誤";
+  }
+
+  // 嘗試讀取後端 error code
+  const body = err.body as Record<string, unknown> | null | undefined;
+  const code = body && typeof body === "object" ? String(body.code ?? "") : "";
+
+  switch (code) {
+    case "GITHUB_TOKEN_INVALID":
+      return "PAT 無效，請確認 token 是否正確";
+    case "GITHUB_TOKEN_INSUFFICIENT_SCOPE":
+      return "PAT 缺少必要權限：repo, read:user";
+    case "GITHUB_UNAVAILABLE":
+      return "GitHub 服務暫時無法連線，請稍後再試";
+    default:
+      // 依 HTTP status 給友善訊息
+      if (err.status === 422) return "PAT 無效，請確認 token 是否正確";
+      if (err.status === 403) return "PAT 缺少必要權限：repo, read:user";
+      if (err.status === 503) return "GitHub 服務暫時無法連線，請稍後再試";
+      return err.message || "操作失敗，請稍後再試";
+  }
+}
+
+// ─── API 函式 ─────────────────────────────────────────────────
+
+/**
+ * 連接 GitHub — POST /api/v1/integrations/github/connect
+ * @param token Personal Access Token
+ */
+export async function connectGithub(token: string): Promise<ConnectGithubResponse> {
+  return apiClient.post<ConnectGithubResponse>("/api/v1/integrations/github/connect", {
+    token,
+  } satisfies ConnectGithubInput);
+}
+
+/**
+ * 取得 GitHub 整合狀態 — GET /api/v1/integrations/github/status
+ */
+export async function getGithubStatus(): Promise<GithubStatus> {
+  return apiClient.get<GithubStatus>("/api/v1/integrations/github/status");
+}
+
+/**
+ * 中斷 GitHub 連接 — DELETE /api/v1/integrations/github
+ */
+export async function disconnectGithub(): Promise<void> {
+  return apiClient.delete<void>("/api/v1/integrations/github");
+}

--- a/dev/frontend/lib/github/testids.ts
+++ b/dev/frontend/lib/github/testids.ts
@@ -25,6 +25,12 @@ export const GITHUB_TESTIDS = {
   /** 已連接時顯示的 GitHub username */
   USERNAME_DISPLAY: "github-username-display",
 
-  /** 錯誤訊息區塊 */
+  /** ConnectForm submit 失敗時的即時錯誤訊息 */
   ERROR_MESSAGE: "github-error-message",
+
+  /** 已連接狀態下 status.last_error 的顯示訊息 */
+  LAST_ERROR_MESSAGE: "github-last-error-message",
+
+  /** 已連接時「更新 PAT」場景的 submit 按鈕 */
+  UPDATE_PAT_BUTTON: "github-update-pat-button",
 } as const;

--- a/dev/frontend/lib/github/testids.ts
+++ b/dev/frontend/lib/github/testids.ts
@@ -1,0 +1,30 @@
+/**
+ * GitHub 設定頁面 testid 常數
+ * 供 QA e2e 測試及頁面元件共用，避免字串重複定義
+ */
+
+export const GITHUB_TESTIDS = {
+  /** 側邊欄導航連結 */
+  NAV_GITHUB: "nav-github",
+
+  /** 連接狀態 badge（已連接 / 未連接） */
+  STATUS_BADGE: "github-status-badge",
+
+  /** PAT 輸入欄位 */
+  TOKEN_INPUT: "github-token-input",
+
+  /** 「連接」按鈕 */
+  CONNECT_BUTTON: "github-connect-button",
+
+  /** 「中斷連接」按鈕 */
+  DISCONNECT_BUTTON: "github-disconnect-button",
+
+  /** AlertDialog 內的「確認中斷」按鈕 */
+  DISCONNECT_CONFIRM_BUTTON: "github-disconnect-confirm-button",
+
+  /** 已連接時顯示的 GitHub username */
+  USERNAME_DISPLAY: "github-username-display",
+
+  /** 錯誤訊息區塊 */
+  ERROR_MESSAGE: "github-error-message",
+} as const;

--- a/dev/frontend/lib/hooks/use-github-integration.ts
+++ b/dev/frontend/lib/hooks/use-github-integration.ts
@@ -1,0 +1,62 @@
+"use client";
+
+/**
+ * GitHub 整合 React Query hooks
+ *
+ * - useGithubStatus()      → 讀取連接狀態
+ * - useConnectGithub()     → 連接（POST）
+ * - useDisconnectGithub()  → 中斷連接（DELETE）
+ */
+
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import {
+  connectGithub,
+  ConnectGithubResponse,
+  disconnectGithub,
+  getGithubStatus,
+  GithubStatus,
+} from "@/lib/api/github-integration";
+
+/** React Query cache key */
+export const GITHUB_STATUS_QUERY_KEY = ["github-status"] as const;
+
+/**
+ * 查詢 GitHub 整合狀態
+ * 若後端 F-034a 尚未完成，fetch 失敗時 isError = true，UI 自然降級
+ */
+export function useGithubStatus() {
+  return useQuery<GithubStatus>({
+    queryKey: GITHUB_STATUS_QUERY_KEY,
+    queryFn: getGithubStatus,
+    // 避免過於頻繁重試，後端可能尚未就緒
+    retry: 1,
+  });
+}
+
+/**
+ * 連接 GitHub PAT
+ * 成功後自動 invalidate 狀態 query，觸發重新查詢
+ */
+export function useConnectGithub() {
+  const qc = useQueryClient();
+  return useMutation<ConnectGithubResponse, Error, string>({
+    mutationFn: (token: string) => connectGithub(token),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: GITHUB_STATUS_QUERY_KEY });
+    },
+  });
+}
+
+/**
+ * 中斷 GitHub 連接
+ * 成功後自動 invalidate 狀態 query
+ */
+export function useDisconnectGithub() {
+  const qc = useQueryClient();
+  return useMutation<void, Error, void>({
+    mutationFn: () => disconnectGithub(),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: GITHUB_STATUS_QUERY_KEY });
+    },
+  });
+}


### PR DESCRIPTION
## Summary

- 新增 GitHub 整合 API client (`lib/api/github-integration.ts`)
- 新增 React Query hooks (`lib/hooks/use-github-integration.ts`)
- 新增 `/settings/github` 設定頁面
- Sidebar 加入 GitHub 導覽項目
- 新增 testids 常數檔案 (`lib/github/testids.ts`)

## Changes

- `dev/frontend/lib/github/testids.ts` — QA testid 常數，頁面元件 import 共用
- `dev/frontend/lib/api/github-integration.ts` — connectGithub / getGithubStatus / disconnectGithub + 錯誤訊息格式化
- `dev/frontend/lib/hooks/use-github-integration.ts` — useGithubStatus / useConnectGithub / useDisconnectGithub (React Query)
- `dev/frontend/app/(dashboard)/settings/github/page.tsx` — 設定頁主體，仿 llm-providers 風格
- `dev/frontend/components/app-sidebar.tsx` — 加入 GitHub nav item (testId: nav-github)

## Scenario 覆蓋

- [x] 新使用者進入頁面 → 顯示「未連接」badge + PAT 輸入表單
- [x] 輸入有效 PAT → connectGithub() → 畫面切換為已連接，顯示 username
- [x] 輸入無效 PAT → 顯示「PAT 無效，請確認 token 是否正確」
- [x] 缺 scope (403) → 顯示「PAT 缺少必要權限：repo, read:user」
- [x] 點中斷連接 → AlertDialog 二次確認 → disconnectGithub() → 回未連接狀態
- [x] 已連接時顯示 last_synced_at / last_error（若有）
- [x] token 永不顯示（input type=password）

## 注意

- 後端 F-034a 若未就緒，`useGithubStatus` fetch 失敗時 `isError=true`，頁面顯示未連接狀態（graceful degradation）
- TypeScript 全域環境問題（@types/react / @tanstack/react-query 未安裝於 worktree）是預先存在的，非本 PR 引入

## Related Issues

Closes #162
Closes #173
Closes #174
Closes #175
Closes #176