### PR TITLE
test(e2e): F-034 GitHub 整合 e2e mocks + 17 scenarios skeleton

### DIFF
--- a/test/browser/fixtures/github.ts
+++ b/test/browser/fixtures/github.ts
@@ -1,0 +1,285 @@
+/**
+ * GitHub 整合測試共用 fixtures 與 testid 常數（Sprint 12, F-034）
+ *
+ * 所有 GitHub API 與後端都用 page.route() 攔截，不需真實環境。
+ *
+ * 對應 issue：#181
+ * 對應 spec：specs/features/f034-github-commit-integration.md
+ */
+
+import type { Page, Route } from "@playwright/test";
+
+// ---------------------------------------------------------------------------
+// data-testid 常數（對應 dev/frontend/lib/github/testids.ts）
+// ---------------------------------------------------------------------------
+
+export const GITHUB_SETTINGS_TESTIDS = {
+  // 設定頁面 GitHub 區塊
+  section: "github-settings-section",
+
+  // 未連接狀態
+  notConnectedState: "github-settings-not-connected",
+  patInput: "github-settings-pat-input",
+  connectButton: "github-settings-connect-button",
+
+  // 已連接狀態
+  connectedState: "github-settings-connected",
+  usernameLabel: "github-settings-username",
+  lastSyncedLabel: "github-settings-last-synced",
+  lastErrorBanner: "github-settings-last-error-banner",
+  disconnectButton: "github-settings-disconnect-button",
+
+  // 中斷確認 Dialog
+  disconnectDialog: "github-settings-disconnect-dialog",
+  disconnectDialogConfirm: "github-settings-disconnect-dialog-confirm",
+  disconnectDialogCancel: "github-settings-disconnect-dialog-cancel",
+
+  // Toast / Banner
+  toastConnected: "github-settings-toast-connected",
+  toastDisconnected: "github-settings-toast-disconnected",
+  toastError: "github-settings-toast-error",
+} as const;
+
+export const GITHUB_JOURNAL_TESTIDS = {
+  // DayDetailSheet 中的 journal section
+  githubSection: "journal-github-section",
+  githubWarnings: "journal-github-warnings",
+} as const;
+
+// ---------------------------------------------------------------------------
+// Mock data shapes
+// ---------------------------------------------------------------------------
+
+export interface MockGithubStatus {
+  connected: boolean;
+  id?: string;
+  username?: string;
+  scopes?: string[];
+  token_set?: boolean;
+  last_synced_at?: string | null;
+  last_error?: string | null;
+  last_error_at?: string | null;
+  created_at?: string;
+  updated_at?: string;
+}
+
+export interface MockGithubCommit {
+  sha: string;
+  repo: string;
+  message: string;
+  url: string;
+  committed_at: string;
+  additions?: number | null;
+  deletions?: number | null;
+}
+
+export interface MockGithubCommitsResponse {
+  date: string;
+  username: string;
+  commits: MockGithubCommit[];
+  total: number;
+  truncated: boolean;
+  warning?: string | null;
+}
+
+export interface InstallGithubMockOpts {
+  /** GET /status 回應 */
+  status?: MockGithubStatus;
+  /** POST /connect 回應 */
+  connectResponse?:
+    | { status: 201; body: MockGithubStatus }
+    | { status: 400; body: { code: string; message: string } }
+    | { status: 422; body: { code: string; message: string } }
+    | { status: 503; body: { code: string; message: string } };
+  /** DELETE 回應（預設 204） */
+  deleteResponse?: { status: 204 } | { status: 404; body: { code: string } };
+  /** GET /commits 回應 */
+  commitsResponse?:
+    | { status: 200; body: MockGithubCommitsResponse }
+    | { status: 400; body: { code: string; message: string } }
+    | { status: 404; body: { code: string; message: string } }
+    | { status: 422; body: { code: string; message: string } }
+    | { status: 429; body: { code: string; message: string; retry_after_seconds: number } }
+    | { status: 503; body: { code: string; message: string } };
+  /** 請求錄製器（用於斷言 request 發送情況） */
+  recorder?: {
+    requests: Array<{ url: string; method: string; body?: unknown }>;
+  };
+}
+
+/**
+ * 安裝 `/api/v1/integrations/github*` 的 mock。
+ *
+ * 攔截所有 GitHub 整合相關 API，不需真實後端。
+ */
+export async function installGithubMock(
+  page: Page,
+  opts: InstallGithubMockOpts = {},
+): Promise<void> {
+  const defaultStatus: MockGithubStatus = opts.status ?? { connected: false };
+
+  await page.route("**/api/v1/integrations/github**", async (route: Route) => {
+    const req = route.request();
+    const url = req.url();
+    const method = req.method();
+
+    if (opts.recorder) {
+      let body: unknown = undefined;
+      try {
+        body = req.postDataJSON();
+      } catch {
+        // ignore non-JSON bodies
+      }
+      opts.recorder.requests.push({ url, method, body });
+    }
+
+    // GET /status
+    if (method === "GET" && /\/integrations\/github\/status/.test(url)) {
+      await route.fulfill({
+        status: 200,
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify(defaultStatus),
+      });
+      return;
+    }
+
+    // GET /commits
+    if (method === "GET" && /\/integrations\/github\/commits/.test(url)) {
+      const resp = opts.commitsResponse ?? {
+        status: 200,
+        body: {
+          date: new Date().toISOString().slice(0, 10),
+          username: defaultStatus.username ?? "testuser",
+          commits: [],
+          total: 0,
+          truncated: false,
+          warning: null,
+        },
+      };
+      await route.fulfill({
+        status: resp.status,
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify(resp.body),
+      });
+      return;
+    }
+
+    // POST /connect
+    if (method === "POST" && /\/integrations\/github\/connect/.test(url)) {
+      const resp = opts.connectResponse ?? {
+        status: 201,
+        body: {
+          connected: true,
+          id: "mock-uuid",
+          username: defaultStatus.username ?? "testuser",
+          scopes: ["repo", "read:user"],
+          token_set: true,
+          last_synced_at: null,
+          created_at: new Date().toISOString(),
+          updated_at: new Date().toISOString(),
+        },
+      };
+      await route.fulfill({
+        status: resp.status,
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify(resp.body),
+      });
+      return;
+    }
+
+    // DELETE /integrations/github（精確匹配，避免吃到 /status 等子路由）
+    if (method === "DELETE" && /\/integrations\/github(\?|$|\/?$)/.test(url)) {
+      const resp = opts.deleteResponse ?? { status: 204 };
+      if (resp.status === 204) {
+        await route.fulfill({
+          status: 204,
+          headers: {},
+          body: "",
+        });
+      } else {
+        await route.fulfill({
+          status: resp.status,
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify("body" in resp ? resp.body : {}),
+        });
+      }
+      return;
+    }
+
+    await route.continue();
+  });
+}
+
+/**
+ * 安裝 journal auto draft mock（POST /api/v1/journal/:date/auto）
+ *
+ * 用於測試 journal draft 含/不含 GitHub commits 區塊的場景。
+ */
+export interface MockJournalAutoResponse {
+  content: string;
+  is_draft: boolean;
+  warnings?: string[];
+  source_refs?: unknown[];
+}
+
+export interface InstallJournalAutoMockOpts {
+  response: MockJournalAutoResponse;
+  recorder?: {
+    requests: Array<{ url: string; method: string; body?: unknown }>;
+  };
+}
+
+export async function installJournalAutoMock(
+  page: Page,
+  opts: InstallJournalAutoMockOpts,
+): Promise<void> {
+  await page.route("**/api/v1/journal/*/auto", async (route: Route) => {
+    const req = route.request();
+    if (opts.recorder) {
+      let body: unknown = undefined;
+      try {
+        body = req.postDataJSON();
+      } catch {
+        // ignore
+      }
+      opts.recorder.requests.push({ url: req.url(), method: req.method(), body });
+    }
+    await route.fulfill({
+      status: 201,
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(opts.response),
+    });
+  });
+}
+
+// ---------------------------------------------------------------------------
+// 常用 commit fixture 工廠
+// ---------------------------------------------------------------------------
+
+export function makeCommit(overrides: Partial<MockGithubCommit> = {}): MockGithubCommit {
+  return {
+    sha: "abc1234",
+    repo: "testuser/aibo",
+    message: "feat: test commit",
+    url: "https://github.com/testuser/aibo/commit/abc1234",
+    committed_at: "2026-04-26T08:00:00Z",
+    additions: 10,
+    deletions: 3,
+    ...overrides,
+  };
+}
+
+export function makeCommitsResponse(
+  commits: MockGithubCommit[],
+  overrides: Partial<MockGithubCommitsResponse> = {},
+): MockGithubCommitsResponse {
+  return {
+    date: "2026-04-26",
+    username: "testuser",
+    commits,
+    total: commits.length,
+    truncated: false,
+    warning: null,
+    ...overrides,
+  };
+}

--- a/test/browser/fixtures/github.ts
+++ b/test/browser/fixtures/github.ts
@@ -10,34 +10,39 @@
 import type { Page, Route } from "@playwright/test";
 
 // ---------------------------------------------------------------------------
-// data-testid 常數（對應 dev/frontend/lib/github/testids.ts）
+// data-testid 常數（對齊 dev/frontend/lib/github/testids.ts GITHUB_TESTIDS）
 // ---------------------------------------------------------------------------
 
 export const GITHUB_SETTINGS_TESTIDS = {
-  // 設定頁面 GitHub 區塊
-  section: "github-settings-section",
+  // 側邊欄導航連結
+  navGithub: "nav-github",
 
-  // 未連接狀態
-  notConnectedState: "github-settings-not-connected",
-  patInput: "github-settings-pat-input",
-  connectButton: "github-settings-connect-button",
+  // 連接狀態 badge（已連接 / 未連接）
+  statusBadge: "github-status-badge",
 
-  // 已連接狀態
-  connectedState: "github-settings-connected",
-  usernameLabel: "github-settings-username",
-  lastSyncedLabel: "github-settings-last-synced",
-  lastErrorBanner: "github-settings-last-error-banner",
-  disconnectButton: "github-settings-disconnect-button",
+  // PAT 輸入欄位
+  patInput: "github-token-input",
 
-  // 中斷確認 Dialog
-  disconnectDialog: "github-settings-disconnect-dialog",
-  disconnectDialogConfirm: "github-settings-disconnect-dialog-confirm",
-  disconnectDialogCancel: "github-settings-disconnect-dialog-cancel",
+  // 「連接」按鈕
+  connectButton: "github-connect-button",
 
-  // Toast / Banner
-  toastConnected: "github-settings-toast-connected",
-  toastDisconnected: "github-settings-toast-disconnected",
-  toastError: "github-settings-toast-error",
+  // 「中斷連接」按鈕
+  disconnectButton: "github-disconnect-button",
+
+  // AlertDialog 內的「確認中斷」按鈕
+  disconnectDialogConfirm: "github-disconnect-confirm-button",
+
+  // 已連接時顯示的 GitHub username
+  usernameLabel: "github-username-display",
+
+  // ConnectForm submit 失敗時的即時錯誤訊息
+  errorMessage: "github-error-message",
+
+  // 已連接狀態下 status.last_error 的顯示訊息
+  lastErrorMessage: "github-last-error-message",
+
+  // 已連接時「更新 PAT」場景的 submit 按鈕
+  updatePatButton: "github-update-pat-button",
 } as const;
 
 export const GITHUB_JOURNAL_TESTIDS = {
@@ -188,7 +193,7 @@ export async function installGithubMock(
     }
 
     // DELETE /integrations/github（精確匹配，避免吃到 /status 等子路由）
-    if (method === "DELETE" && /\/integrations\/github(\?|$|\/?$)/.test(url)) {
+    if (method === "DELETE" && /\/integrations\/github\/?$/.test(url)) {
       const resp = opts.deleteResponse ?? { status: 204 };
       if (resp.status === 204) {
         await route.fulfill({
@@ -224,6 +229,8 @@ export interface MockJournalAutoResponse {
 
 export interface InstallJournalAutoMockOpts {
   response: MockJournalAutoResponse;
+  /** HTTP status code，預設 201 */
+  status?: number;
   recorder?: {
     requests: Array<{ url: string; method: string; body?: unknown }>;
   };
@@ -245,7 +252,7 @@ export async function installJournalAutoMock(
       opts.recorder.requests.push({ url: req.url(), method: req.method(), body });
     }
     await route.fulfill({
-      status: 201,
+      status: opts.status ?? 201,
       headers: { "content-type": "application/json" },
       body: JSON.stringify(opts.response),
     });

--- a/test/browser/specs/github-commits-api.spec.ts
+++ b/test/browser/specs/github-commits-api.spec.ts
@@ -7,9 +7,13 @@
  * 涵蓋 scenarios：
  *  1. 未連 GitHub → /journal/:date/auto warnings 含「未連 GitHub」（不阻擋）
  *  2. 連線 + 當日有 commits → journal content 含「## GitHub 推送」區塊
- *  3. Rate limit 429 → warnings 含 retry_after
+ *  3. Rate limit 429 → GET /commits 回 429 + retry_after_seconds
  *  4. Commits > 200 → truncated=true + warnings
- *  5. PAT 過期 → warnings 含「PAT 失效」+ status last_error 寫入
+ *  5. PAT 過期 → GET /commits 回 422 GITHUB_TOKEN_INVALID + status.last_error 有值
+ *  6. 取 commits 但未連接 → GET /commits 回 404 GITHUB_NOT_CONNECTED
+ *  7. GitHub 暫時不可用 → GET /commits 回 503 GITHUB_UNAVAILABLE
+ *  8. 當日無 commits → GET /commits 回 200 + commits=[] + total=0
+ *  9. Journal draft 中 GitHub 失敗 → degraded → POST journal/auto 仍回 201，warnings 含 GitHub 錯誤
  *
  * 注意：此檔案測試的是後端 API 回應格式，透過 page.route() mock 後端。
  * 前端 UI 呈現由 github-journal-integration.spec.ts 覆蓋。
@@ -73,7 +77,7 @@ test.describe("GitHub Commits API 行為（F-034a/b/d）", () => {
     const journalAutoResponse = await page.evaluate(async () => {
       const res = await fetch("/api/v1/journal/2026-04-26/auto", {
         method: "POST",
-        headers: { "Content-Type": "application/json" },
+        headers: { "Content-Type": "application/json", "X-API-Key": "mock-key" },
         body: JSON.stringify({ tone: "reflective" }),
       });
       return res.json();
@@ -123,7 +127,7 @@ test.describe("GitHub Commits API 行為（F-034a/b/d）", () => {
     const journalAutoResponse = await page.evaluate(async () => {
       const res = await fetch("/api/v1/journal/2026-04-26/auto", {
         method: "POST",
-        headers: { "Content-Type": "application/json" },
+        headers: { "Content-Type": "application/json", "X-API-Key": "mock-key" },
         body: JSON.stringify({ tone: "reflective" }),
       });
       return res.json();
@@ -160,7 +164,7 @@ test.describe("GitHub Commits API 行為（F-034a/b/d）", () => {
     // WHEN 呼叫 GET /commits
     const commitsResponse = await page.evaluate(async () => {
       const res = await fetch("/api/v1/integrations/github/commits?date=2026-04-26", {
-        headers: { "Content-Type": "application/json" },
+        headers: { "Content-Type": "application/json", "X-API-Key": "mock-key" },
       });
       return { status: res.status, body: await res.json() };
     });
@@ -200,7 +204,7 @@ test.describe("GitHub Commits API 行為（F-034a/b/d）", () => {
     // WHEN 呼叫 GET /commits
     const commitsResponse = await page.evaluate(async () => {
       const res = await fetch("/api/v1/integrations/github/commits?date=2026-04-26", {
-        headers: { "Content-Type": "application/json" },
+        headers: { "Content-Type": "application/json", "X-API-Key": "mock-key" },
       });
       return { status: res.status, body: await res.json() };
     });
@@ -244,7 +248,7 @@ test.describe("GitHub Commits API 行為（F-034a/b/d）", () => {
     // WHEN 呼叫 GET /commits
     const commitsResponse = await page.evaluate(async () => {
       const res = await fetch("/api/v1/integrations/github/commits?date=2026-04-26", {
-        headers: { "Content-Type": "application/json" },
+        headers: { "Content-Type": "application/json", "X-API-Key": "mock-key" },
       });
       return { status: res.status, body: await res.json() };
     });
@@ -255,12 +259,172 @@ test.describe("GitHub Commits API 行為（F-034a/b/d）", () => {
 
     // THEN GET /status 中 last_error 有值（前端應顯示 last_error banner）
     const statusResponse = await page.evaluate(async () => {
-      const res = await fetch("/api/v1/integrations/github/status");
+      const res = await fetch("/api/v1/integrations/github/status", {
+        headers: { "X-API-Key": "mock-key" },
+      });
       return res.json();
     });
 
     expect(statusResponse.connected).toBe(true);
     expect(statusResponse.last_error).toBeTruthy();
     expect(statusResponse.last_error_at).toBeTruthy();
+  });
+
+  // ---------------------------------------------------------------------------
+  // Scenario 6: 取 commits 但未連接 → 404 GITHUB_NOT_CONNECTED
+  // ---------------------------------------------------------------------------
+  test("Scenario: 取 commits 但未連接 → GET /commits 回 404 GITHUB_NOT_CONNECTED", async ({
+    page,
+  }) => {
+    test.skip(true, "Wave 0 — 等 F-034b GET /commits 未連接錯誤處理實作完成再啟用");
+
+    // GIVEN 無 github_integrations row
+    await installGithubMock(page, {
+      status: { connected: false },
+      commitsResponse: {
+        status: 404,
+        body: {
+          code: "GITHUB_NOT_CONNECTED",
+          message: "尚未連接 GitHub",
+        },
+      },
+    });
+
+    // WHEN 呼叫 GET /commits
+    const commitsResponse = await page.evaluate(async () => {
+      const res = await fetch("/api/v1/integrations/github/commits?date=2026-04-26", {
+        headers: { "Content-Type": "application/json", "X-API-Key": "mock-key" },
+      });
+      return { status: res.status, body: await res.json() };
+    });
+
+    // THEN status = 404 + code = GITHUB_NOT_CONNECTED
+    expect(commitsResponse.status).toBe(404);
+    expect(commitsResponse.body.code).toBe("GITHUB_NOT_CONNECTED");
+  });
+
+  // ---------------------------------------------------------------------------
+  // Scenario 7: GitHub 暫時不可用 → GET /commits 回 503 GITHUB_UNAVAILABLE
+  // ---------------------------------------------------------------------------
+  test("Scenario: GitHub 暫時不可用 → GET /commits 回 503 GITHUB_UNAVAILABLE", async ({
+    page,
+  }) => {
+    test.skip(true, "Wave 0 — 等 F-034b GitHub 503 / timeout 錯誤處理實作完成再啟用");
+
+    // GIVEN 已連接，但 GitHub API 回 503 或 timeout
+    await installGithubMock(page, {
+      status: { connected: true, username: "testuser", token_set: true },
+      commitsResponse: {
+        status: 503,
+        body: {
+          code: "GITHUB_UNAVAILABLE",
+          message: "GitHub API 暫時無法使用",
+        },
+      },
+    });
+
+    // WHEN 呼叫 GET /commits
+    const commitsResponse = await page.evaluate(async () => {
+      const res = await fetch("/api/v1/integrations/github/commits?date=2026-04-26", {
+        headers: { "Content-Type": "application/json", "X-API-Key": "mock-key" },
+      });
+      return { status: res.status, body: await res.json() };
+    });
+
+    // THEN status = 503 + code = GITHUB_UNAVAILABLE
+    expect(commitsResponse.status).toBe(503);
+    expect(commitsResponse.body.code).toBe("GITHUB_UNAVAILABLE");
+  });
+
+  // ---------------------------------------------------------------------------
+  // Scenario 8: 當日無 commits → GET /commits 回 200 + commits=[] + total=0
+  // ---------------------------------------------------------------------------
+  test("Scenario: 當日無 commits → GET /commits 回 200 + commits=[] + total=0", async ({
+    page,
+  }) => {
+    test.skip(true, "Wave 0 — 等 F-034b GET /commits empty response 實作完成再啟用");
+
+    // GIVEN 已連接，但當日無任何 commits
+    await installGithubMock(page, {
+      status: { connected: true, username: "testuser", token_set: true },
+      commitsResponse: {
+        status: 200,
+        body: {
+          date: TARGET_DATE,
+          username: "testuser",
+          commits: [],
+          total: 0,
+          truncated: false,
+          warning: null,
+        },
+      },
+    });
+
+    // WHEN 呼叫 GET /commits
+    const commitsResponse = await page.evaluate(async () => {
+      const res = await fetch("/api/v1/integrations/github/commits?date=2026-04-26", {
+        headers: { "Content-Type": "application/json", "X-API-Key": "mock-key" },
+      });
+      return { status: res.status, body: await res.json() };
+    });
+
+    // THEN status = 200 + commits = [] + total = 0
+    expect(commitsResponse.status).toBe(200);
+    expect(commitsResponse.body.commits).toEqual([]);
+    expect(commitsResponse.body.total).toBe(0);
+    expect(commitsResponse.body.truncated).toBe(false);
+  });
+
+  // ---------------------------------------------------------------------------
+  // Scenario 9: Journal draft 中 GitHub 失敗 → degraded
+  //   GIVEN 已連接 GitHub，但 GitHub API 暫時 503
+  //   WHEN POST /journal/:date/auto
+  //   THEN response 201（draft 仍生成），warnings 含 GitHub 相關提示，content 不含 ## GitHub 推送
+  // ---------------------------------------------------------------------------
+  test("Scenario: Journal draft 中 GitHub 503 → degraded → 仍回 201，warnings 含 GitHub 錯誤提示", async ({
+    page,
+  }) => {
+    test.skip(true, "Wave 0 — 等 F-034d JournalDraftService degraded 模式實作完成再啟用");
+
+    // GIVEN 已連接，但 GitHub API 暫時不可用
+    await installGithubMock(page, {
+      status: { connected: true, username: "testuser", token_set: true },
+      commitsResponse: {
+        status: 503,
+        body: {
+          code: "GITHUB_UNAVAILABLE",
+          message: "GitHub API 暫時無法使用",
+        },
+      },
+    });
+
+    // journal/auto：draft 仍生成，warnings 含 GitHub 失敗提示，content 不含 ## GitHub 推送
+    await installJournalAutoMock(page, {
+      response: {
+        is_draft: true,
+        content: "今天完成了一些開發工作...",
+        warnings: ["GitHub 暫時無法取得當日 commits，已略過"],
+        source_refs: [],
+      },
+    });
+
+    // WHEN 呼叫 journal/auto
+    const journalAutoResponse = await page.evaluate(async () => {
+      const res = await fetch("/api/v1/journal/2026-04-26/auto", {
+        method: "POST",
+        headers: { "Content-Type": "application/json", "X-API-Key": "mock-key" },
+        body: JSON.stringify({ tone: "reflective" }),
+      });
+      return res.json();
+    });
+
+    // THEN draft 仍生成（status = 201 由 mock 保證，body.is_draft = true）
+    expect(journalAutoResponse.is_draft).toBe(true);
+    // THEN warnings 包含 GitHub 相關錯誤提示
+    expect(journalAutoResponse.warnings).toEqual(
+      expect.arrayContaining([expect.stringMatching(/GitHub/i)]),
+    );
+    // THEN content 不含 ## GitHub 推送（degraded 不加入 commits 區塊）
+    expect(journalAutoResponse.content).not.toContain("## GitHub 推送");
   });
 });

--- a/test/browser/specs/github-commits-api.spec.ts
+++ b/test/browser/specs/github-commits-api.spec.ts
@@ -1,0 +1,266 @@
+/**
+ * F-034a / F-034b / F-034d — GitHub commits API 行為測試（後端 mock）
+ *
+ * 對應 issue：#181（Wave 0 skeleton；F-034a/b/d 實作完成後解 skip）
+ * 對應 spec：specs/features/f034-github-commit-integration.md
+ *
+ * 涵蓋 scenarios：
+ *  1. 未連 GitHub → /journal/:date/auto warnings 含「未連 GitHub」（不阻擋）
+ *  2. 連線 + 當日有 commits → journal content 含「## GitHub 推送」區塊
+ *  3. Rate limit 429 → warnings 含 retry_after
+ *  4. Commits > 200 → truncated=true + warnings
+ *  5. PAT 過期 → warnings 含「PAT 失效」+ status last_error 寫入
+ *
+ * 注意：此檔案測試的是後端 API 回應格式，透過 page.route() mock 後端。
+ * 前端 UI 呈現由 github-journal-integration.spec.ts 覆蓋。
+ *
+ * Wave 0：所有 test 皆 test.skip(true, ...) 包起來。
+ */
+
+import { test, expect } from "@playwright/test";
+import { ApiClient } from "../helpers/api-client";
+import { setupAuth } from "../helpers/auth";
+import {
+  installGithubMock,
+  installJournalAutoMock,
+  makeCommit,
+  makeCommitsResponse,
+} from "../fixtures/github";
+import { installCalendarMock, makeMockDay, emptyMonthGrid } from "../fixtures/calendar";
+
+const TARGET_DATE = "2026-04-26";
+
+test.describe("GitHub Commits API 行為（F-034a/b/d）", () => {
+  test.beforeEach(async ({ page, request }) => {
+    const { key } = await ApiClient.bootstrap(request, `qa12-github-api-${Date.now()}`);
+    await page.goto("/");
+    await setupAuth(page, key);
+  });
+
+  // ---------------------------------------------------------------------------
+  // Scenario 1: 未連 GitHub → journal/auto warnings 含「未連 GitHub」，不阻擋 draft
+  // ---------------------------------------------------------------------------
+  test("Scenario: 未連 GitHub → journal auto draft 仍生成，warnings 含未連接提示", async ({
+    page,
+  }) => {
+    test.skip(true, "Wave 0 — 等 F-034d JournalDraftService GitHub 整合實作完成再啟用");
+
+    // GIVEN 未連接 GitHub
+    await installGithubMock(page, { status: { connected: false } });
+
+    // journal/auto 回應：draft 正常生成，warnings 含 GitHub 未連接
+    await installJournalAutoMock(page, {
+      response: {
+        is_draft: true,
+        content: "今天完成了幾件事...",
+        warnings: ["尚未連接 GitHub，無法取得當日 commits"],
+        source_refs: [],
+      },
+    });
+
+    // WHEN 在 calendar sheet 觸發 journal auto（直接呼叫 mock API 驗證格式）
+    const days = emptyMonthGrid(TARGET_DATE);
+    const dayWithJournal = makeMockDay(TARGET_DATE, {});
+    const dayMap = days.map((d) => (d.date === TARGET_DATE ? dayWithJournal : d));
+    await installCalendarMock(page, { days: dayMap, dayDetails: { [TARGET_DATE]: dayWithJournal } });
+
+    // 導航到 calendar + 開啟 day sheet
+    await page.goto(`/calendar?view=month&date=${TARGET_DATE}&sheet=${TARGET_DATE}`);
+
+    // THEN：在 sheet 中找到日記區塊，觸發 auto draft
+    // 注意：此 scenario 主要驗證 API 回應格式；前端 UI 由 github-journal-integration 覆蓋
+    // 這裡透過 page.evaluate 驗證 mock 回傳的 warnings
+    const journalAutoResponse = await page.evaluate(async () => {
+      const res = await fetch("/api/v1/journal/2026-04-26/auto", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ tone: "reflective" }),
+      });
+      return res.json();
+    });
+
+    expect(journalAutoResponse.is_draft).toBe(true);
+    expect(journalAutoResponse.warnings).toEqual(
+      expect.arrayContaining([expect.stringMatching(/未連接|GitHub|connect/i)]),
+    );
+    // draft 內容存在（不因 GitHub 失敗而失敗）
+    expect(journalAutoResponse.content).toBeTruthy();
+  });
+
+  // ---------------------------------------------------------------------------
+  // Scenario 2: 連線 + 當日有 commits → journal content 含 ## GitHub 區塊
+  // ---------------------------------------------------------------------------
+  test("Scenario: 連線 + 當日 2 筆 commits → journal auto draft content 含 GitHub 推送區塊", async ({
+    page,
+  }) => {
+    test.skip(true, "Wave 0 — 等 F-034d prompt 整合實作完成再啟用");
+
+    const commits = [
+      makeCommit({ sha: "aaa1111", message: "feat(api): add github endpoint", committed_at: `${TARGET_DATE}T08:00:00Z` }),
+      makeCommit({ sha: "bbb2222", repo: "testuser/other-repo", message: "fix: typo", committed_at: `${TARGET_DATE}T14:00:00Z` }),
+    ];
+
+    // GIVEN 已連接 + 有 commits
+    await installGithubMock(page, {
+      status: { connected: true, username: "testuser", token_set: true },
+      commitsResponse: {
+        status: 200,
+        body: makeCommitsResponse(commits),
+      },
+    });
+
+    // journal/auto 回應：content 含 ## GitHub 推送區塊
+    await installJournalAutoMock(page, {
+      response: {
+        is_draft: true,
+        content: "今天做了幾件事...\n\n## GitHub 推送\n- aaa1111 feat(api): add github endpoint\n- bbb2222 fix: typo",
+        warnings: [],
+        source_refs: [],
+      },
+    });
+
+    // WHEN 呼叫 journal auto mock
+    const journalAutoResponse = await page.evaluate(async () => {
+      const res = await fetch("/api/v1/journal/2026-04-26/auto", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ tone: "reflective" }),
+      });
+      return res.json();
+    });
+
+    // THEN response.content 含 ## GitHub 推送
+    expect(journalAutoResponse.is_draft).toBe(true);
+    expect(journalAutoResponse.content).toContain("## GitHub 推送");
+    // warnings 為空（無錯誤）
+    expect(journalAutoResponse.warnings).toEqual([]);
+  });
+
+  // ---------------------------------------------------------------------------
+  // Scenario 3: Rate limit 429 → warnings 含 retry_after
+  // ---------------------------------------------------------------------------
+  test("Scenario: GitHub rate limit 429 → GET /commits 回 429 + retry_after_seconds", async ({
+    page,
+  }) => {
+    test.skip(true, "Wave 0 — 等 F-034b rate limit 處理實作完成再啟用");
+
+    // GIVEN 已連接，但 GitHub rate limit 用完（GET /commits 回 429）
+    await installGithubMock(page, {
+      status: { connected: true, username: "testuser", token_set: true },
+      commitsResponse: {
+        status: 429,
+        body: {
+          code: "GITHUB_RATE_LIMITED",
+          message: "GitHub API rate limit 用完",
+          retry_after_seconds: 3600,
+        },
+      },
+    });
+
+    // WHEN 呼叫 GET /commits
+    const commitsResponse = await page.evaluate(async () => {
+      const res = await fetch("/api/v1/integrations/github/commits?date=2026-04-26", {
+        headers: { "Content-Type": "application/json" },
+      });
+      return { status: res.status, body: await res.json() };
+    });
+
+    // THEN status = 429 + code = GITHUB_RATE_LIMITED + retry_after_seconds > 0
+    expect(commitsResponse.status).toBe(429);
+    expect(commitsResponse.body.code).toBe("GITHUB_RATE_LIMITED");
+    expect(commitsResponse.body.retry_after_seconds).toBeGreaterThan(0);
+  });
+
+  // ---------------------------------------------------------------------------
+  // Scenario 4: Commits > 200 → truncated=true
+  // ---------------------------------------------------------------------------
+  test("Scenario: 當日 commits 超過 200 → response.truncated=true + total=200", async ({
+    page,
+  }) => {
+    test.skip(true, "Wave 0 — 等 F-034b commits 截斷邏輯實作完成再啟用");
+
+    // 製造 200 筆 commits（模擬截斷後的回應）
+    const truncatedCommits = Array.from({ length: 200 }, (_, i) =>
+      makeCommit({ sha: `sha${String(i).padStart(4, "0")}`, message: `commit #${i}` }),
+    );
+
+    // GIVEN 已連接，GET /commits 回 200 筆（truncated=true）
+    await installGithubMock(page, {
+      status: { connected: true, username: "testuser", token_set: true },
+      commitsResponse: {
+        status: 200,
+        body: makeCommitsResponse(truncatedCommits, {
+          total: 200,
+          truncated: true,
+          warning: "當日 commits 超過 200 筆上限，已截斷",
+        }),
+      },
+    });
+
+    // WHEN 呼叫 GET /commits
+    const commitsResponse = await page.evaluate(async () => {
+      const res = await fetch("/api/v1/integrations/github/commits?date=2026-04-26", {
+        headers: { "Content-Type": "application/json" },
+      });
+      return { status: res.status, body: await res.json() };
+    });
+
+    // THEN commits.length = 200，truncated = true
+    expect(commitsResponse.status).toBe(200);
+    expect(commitsResponse.body.commits).toHaveLength(200);
+    expect(commitsResponse.body.truncated).toBe(true);
+    expect(commitsResponse.body.total).toBe(200);
+    expect(commitsResponse.body.warning).toBeTruthy();
+  });
+
+  // ---------------------------------------------------------------------------
+  // Scenario 5: PAT 過期 → warnings 含「PAT 失效」+ status last_error 寫入
+  // ---------------------------------------------------------------------------
+  test("Scenario: PAT 過期 → GET /commits 回 422 GITHUB_TOKEN_INVALID + status.last_error 有值", async ({
+    page,
+  }) => {
+    test.skip(true, "Wave 0 — 等 F-034b PAT 失效偵測 + last_error 寫入實作完成再啟用");
+
+    // GIVEN 已連接但 PAT 已過期
+    // 初始 status 顯示已連接
+    // GET /commits 回 422（PAT 失效）
+    await installGithubMock(page, {
+      status: {
+        connected: true,
+        username: "testuser",
+        token_set: true,
+        last_error: "PAT 已被撤銷，請至設定頁更新",
+        last_error_at: "2026-04-26T09:00:00Z",
+      },
+      commitsResponse: {
+        status: 422,
+        body: {
+          code: "GITHUB_TOKEN_INVALID",
+          message: "PAT 已失效，請至 GitHub Settings 重新產生",
+        },
+      },
+    });
+
+    // WHEN 呼叫 GET /commits
+    const commitsResponse = await page.evaluate(async () => {
+      const res = await fetch("/api/v1/integrations/github/commits?date=2026-04-26", {
+        headers: { "Content-Type": "application/json" },
+      });
+      return { status: res.status, body: await res.json() };
+    });
+
+    // THEN status = 422 + code = GITHUB_TOKEN_INVALID
+    expect(commitsResponse.status).toBe(422);
+    expect(commitsResponse.body.code).toBe("GITHUB_TOKEN_INVALID");
+
+    // THEN GET /status 中 last_error 有值（前端應顯示 last_error banner）
+    const statusResponse = await page.evaluate(async () => {
+      const res = await fetch("/api/v1/integrations/github/status");
+      return res.json();
+    });
+
+    expect(statusResponse.connected).toBe(true);
+    expect(statusResponse.last_error).toBeTruthy();
+    expect(statusResponse.last_error_at).toBeTruthy();
+  });
+});

--- a/test/browser/specs/github-journal-integration.spec.ts
+++ b/test/browser/specs/github-journal-integration.spec.ts
@@ -1,0 +1,243 @@
+/**
+ * F-034c / F-034d — GitHub 整合前端 Calendar 顯示測試
+ *
+ * 對應 issue：#181（Wave 0 skeleton；F-034c/d 實作完成後解 skip）
+ * 對應 spec：specs/features/f034-github-commit-integration.md
+ *
+ * 涵蓋 scenarios：
+ *  1. 開 calendar 某天 → DayDetailSheet 自動觸發 journal/auto → content 含 GitHub 條列
+ *  2. Journal draft warnings 顯示在 sheet（小字提示）
+ *
+ * 注意：
+ *  - 全部 API（包含後端 journal/auto + GitHub）都用 page.route() mock，不需真實環境
+ *  - 測試聚焦在前端 UI 呈現，API 行為由 github-commits-api.spec.ts 覆蓋
+ *
+ * Wave 0：所有 test 皆 test.skip(true, ...) 包起來。
+ */
+
+import { test, expect } from "@playwright/test";
+import { ApiClient } from "../helpers/api-client";
+import { setupAuth } from "../helpers/auth";
+import {
+  GITHUB_JOURNAL_TESTIDS as GJ,
+  installGithubMock,
+  installJournalAutoMock,
+  makeCommit,
+  makeCommitsResponse,
+} from "../fixtures/github";
+import {
+  CALENDAR_TESTIDS as T,
+  DEFAULT_TEST_TIMEZONE,
+  installCalendarMock,
+  makeMockDay,
+  emptyMonthGrid,
+} from "../fixtures/calendar";
+
+test.use({ timezoneId: DEFAULT_TEST_TIMEZONE });
+
+const TARGET_DATE = "2026-04-26";
+
+test.describe("GitHub 整合 — Calendar DayDetailSheet 顯示（F-034c/d）", () => {
+  test.beforeEach(async ({ page, request }) => {
+    const { key } = await ApiClient.bootstrap(
+      request,
+      `qa12-github-journal-${Date.now()}`,
+    );
+    await page.goto("/");
+    await setupAuth(page, key);
+  });
+
+  // ---------------------------------------------------------------------------
+  // Scenario 1:
+  //   開 calendar 某天 → DayDetailSheet 自動觸發 journal/auto → content 含 GitHub 條列
+  // ---------------------------------------------------------------------------
+  test("Scenario: 開 DayDetailSheet → journal/auto draft 包含 GitHub 推送條列", async ({
+    page,
+  }) => {
+    test.skip(
+      true,
+      "Wave 0 — 等 F-034c DayDetailSheet GitHub 區塊 + F-034d journal/auto 整合實作完成再啟用",
+    );
+
+    const commits = [
+      makeCommit({
+        sha: "aaa1111",
+        message: "feat(api): add github integration",
+        repo: "testuser/aibo",
+        committed_at: `${TARGET_DATE}T08:00:00Z`,
+      }),
+      makeCommit({
+        sha: "bbb2222",
+        message: "fix(frontend): style tweak",
+        repo: "testuser/aibo",
+        committed_at: `${TARGET_DATE}T15:30:00Z`,
+      }),
+    ];
+
+    // GIVEN 已連接 GitHub + 當日 2 筆 commits
+    await installGithubMock(page, {
+      status: {
+        connected: true,
+        username: "testuser",
+        token_set: true,
+        last_synced_at: null,
+        last_error: null,
+      },
+      commitsResponse: {
+        status: 200,
+        body: makeCommitsResponse(commits),
+      },
+    });
+
+    // journal/auto 回應包含 ## GitHub 推送區塊
+    await installJournalAutoMock(page, {
+      response: {
+        is_draft: true,
+        content: [
+          "## 今日回顧",
+          "今天專注在 GitHub 整合開發。",
+          "",
+          "## GitHub 推送",
+          "- [aibo] feat(api): add github integration",
+          "- [aibo] fix(frontend): style tweak",
+        ].join("\n"),
+        warnings: [],
+        source_refs: [],
+      },
+    });
+
+    // calendar mock：TARGET_DATE 有日記
+    const days = emptyMonthGrid(TARGET_DATE);
+    const dayWithJournal = makeMockDay(TARGET_DATE, {
+      has_journal: true,
+      journal: { id: "journal-001" },
+    });
+    const dayMap = days.map((d) => (d.date === TARGET_DATE ? dayWithJournal : d));
+    await installCalendarMock(page, {
+      days: dayMap,
+      dayDetails: { [TARGET_DATE]: dayWithJournal },
+    });
+
+    // WHEN 開啟 calendar + 打開 DayDetailSheet
+    await page.goto(`/calendar?view=month&date=${TARGET_DATE}&sheet=${TARGET_DATE}`);
+
+    // 等待 sheet 出現
+    await expect(page.getByTestId(T.sheet)).toBeVisible();
+
+    // THEN journal 區塊出現
+    await expect(page.getByTestId(T.sheetSectionJournal)).toBeVisible();
+
+    // THEN GitHub 推送區塊出現（前端渲染 ## GitHub 推送）
+    await expect(page.getByTestId(GJ.githubSection)).toBeVisible();
+
+    // THEN GitHub 推送內容包含 commits 條列
+    const githubSection = page.getByTestId(GJ.githubSection);
+    await expect(githubSection).toContainText("feat(api): add github integration");
+    await expect(githubSection).toContainText("fix(frontend): style tweak");
+  });
+
+  // ---------------------------------------------------------------------------
+  // Scenario 2:
+  //   journal draft warnings 顯示在 sheet（小字提示）
+  // ---------------------------------------------------------------------------
+  test("Scenario: journal auto warnings → DayDetailSheet 顯示小字提示", async ({ page }) => {
+    test.skip(
+      true,
+      "Wave 0 — 等 F-034c DayDetailSheet warnings 提示 UI 實作完成再啟用",
+    );
+
+    // GIVEN 已連接 GitHub，但 GitHub API 暫時不可用（degraded）
+    await installGithubMock(page, {
+      status: {
+        connected: true,
+        username: "testuser",
+        token_set: true,
+      },
+    });
+
+    // journal/auto 回應：draft 正常生成，warnings 包含 GitHub 失敗提示
+    await installJournalAutoMock(page, {
+      response: {
+        is_draft: true,
+        content: "今天完成了一些開發工作...",
+        warnings: ["GitHub 暫時無法取得當日 commits，已略過"],
+        source_refs: [],
+      },
+    });
+
+    // calendar mock
+    const days = emptyMonthGrid(TARGET_DATE);
+    const dayWithJournal = makeMockDay(TARGET_DATE, {
+      has_journal: true,
+      journal: { id: "journal-002" },
+    });
+    const dayMap = days.map((d) => (d.date === TARGET_DATE ? dayWithJournal : d));
+    await installCalendarMock(page, {
+      days: dayMap,
+      dayDetails: { [TARGET_DATE]: dayWithJournal },
+    });
+
+    // WHEN 開啟 DayDetailSheet
+    await page.goto(`/calendar?view=month&date=${TARGET_DATE}&sheet=${TARGET_DATE}`);
+    await expect(page.getByTestId(T.sheet)).toBeVisible();
+
+    // THEN journal 區塊出現
+    await expect(page.getByTestId(T.sheetSectionJournal)).toBeVisible();
+
+    // THEN warnings 提示顯示在 sheet（小字）
+    await expect(page.getByTestId(GJ.githubWarnings)).toBeVisible();
+    await expect(page.getByTestId(GJ.githubWarnings)).toContainText("GitHub");
+
+    // THEN GitHub 推送主區塊不應顯示（因為 draft 沒有 commits 區塊）
+    // 注意：若 engineer 選擇只隱藏 GJ.githubSection 而顯示 warnings，此 assertion 仍合理
+    await expect(page.getByTestId(GJ.githubSection)).toBeHidden();
+  });
+
+  // ---------------------------------------------------------------------------
+  // 附加 Scenario: 未連 GitHub → DayDetailSheet 不顯示 GitHub 相關 UI
+  // ---------------------------------------------------------------------------
+  test("Scenario: 未連 GitHub → DayDetailSheet 的 journal 區塊不顯示 GitHub 相關 UI", async ({
+    page,
+  }) => {
+    test.skip(
+      true,
+      "Wave 0 — 等 F-034c GitHub 區塊條件渲染實作完成再啟用",
+    );
+
+    // GIVEN 未連接 GitHub
+    await installGithubMock(page, { status: { connected: false } });
+
+    // journal/auto 回應：無 GitHub 內容
+    await installJournalAutoMock(page, {
+      response: {
+        is_draft: true,
+        content: "今天寫了一些筆記...",
+        warnings: [],
+        source_refs: [],
+      },
+    });
+
+    // calendar mock
+    const days = emptyMonthGrid(TARGET_DATE);
+    const dayWithJournal = makeMockDay(TARGET_DATE, {
+      has_journal: true,
+      journal: { id: "journal-003" },
+    });
+    const dayMap = days.map((d) => (d.date === TARGET_DATE ? dayWithJournal : d));
+    await installCalendarMock(page, {
+      days: dayMap,
+      dayDetails: { [TARGET_DATE]: dayWithJournal },
+    });
+
+    // WHEN 開啟 DayDetailSheet
+    await page.goto(`/calendar?view=month&date=${TARGET_DATE}&sheet=${TARGET_DATE}`);
+    await expect(page.getByTestId(T.sheet)).toBeVisible();
+
+    // THEN journal 區塊可見（draft 正常）
+    await expect(page.getByTestId(T.sheetSectionJournal)).toBeVisible();
+
+    // THEN GitHub 專屬 UI 不顯示
+    await expect(page.getByTestId(GJ.githubSection)).toBeHidden();
+    await expect(page.getByTestId(GJ.githubWarnings)).toBeHidden();
+  });
+});

--- a/test/browser/specs/github-settings.spec.ts
+++ b/test/browser/specs/github-settings.spec.ts
@@ -1,0 +1,249 @@
+/**
+ * F-034c — GitHub 設定頁面（/settings/github）
+ *
+ * 對應 issue：#181（Wave 0 skeleton；F-034c 實作完成後解 skip）
+ * 對應 spec：specs/features/f034-github-commit-integration.md
+ *
+ * 涵蓋 scenarios：
+ *  1. 訪問頁面顯示「未連接」狀態
+ *  2. 填 valid PAT → 連接成功 → 顯示 username
+ *  3. 填 invalid PAT → 顯示 422 錯誤 toast
+ *  4. 填 missing scope PAT → 顯示 403 錯誤 + 提示需 repo + read:user
+ *  5. 已連接 → 點中斷 → 二次確認 → DELETE → 回未連接
+ *
+ * Wave 0：所有 test 皆 test.skip(true, ...) 包起來。
+ * 等 F-034c 前端實作完成後 unskip 並確認 testid 對齊。
+ */
+
+import { test, expect } from "@playwright/test";
+import { ApiClient } from "../helpers/api-client";
+import { setupAuth } from "../helpers/auth";
+import {
+  GITHUB_SETTINGS_TESTIDS as G,
+  installGithubMock,
+} from "../fixtures/github";
+
+const SETTINGS_PATH = "/settings/github";
+
+test.describe("GitHub 設定頁面 — 連線與中斷流程（F-034c）", () => {
+  test.beforeEach(async ({ page, request }) => {
+    const { key } = await ApiClient.bootstrap(request, `qa12-github-settings-${Date.now()}`);
+    await page.goto("/");
+    await setupAuth(page, key);
+  });
+
+  // ---------------------------------------------------------------------------
+  // Scenario 1: 訪問頁面顯示「未連接」狀態
+  // ---------------------------------------------------------------------------
+  test("Scenario: 訪問 /settings/github → 顯示未連接狀態與 PAT 輸入欄", async ({ page }) => {
+    test.skip(true, "Wave 0 — 等 F-034c /settings/github 頁面實作完成再啟用");
+
+    // GIVEN GET /status 回 connected=false
+    await installGithubMock(page, {
+      status: { connected: false },
+    });
+
+    // WHEN 進設定頁
+    await page.goto(SETTINGS_PATH);
+
+    // THEN 顯示未連接 state + PAT 輸入欄 + 連接按鈕
+    await expect(page.getByTestId(G.section)).toBeVisible();
+    await expect(page.getByTestId(G.notConnectedState)).toBeVisible();
+    await expect(page.getByTestId(G.patInput)).toBeVisible();
+    await expect(page.getByTestId(G.connectButton)).toBeVisible();
+    // 已連接狀態不應顯示
+    await expect(page.getByTestId(G.connectedState)).toBeHidden();
+  });
+
+  // ---------------------------------------------------------------------------
+  // Scenario 2: 填 valid PAT → 連接成功 → 顯示 username
+  // ---------------------------------------------------------------------------
+  test("Scenario: 填 valid PAT → POST /connect 成功 → 顯示已連接 + username", async ({
+    page,
+  }) => {
+    test.skip(true, "Wave 0 — 等 F-034c connect 表單實作完成再啟用");
+
+    const recorder = { requests: [] as Array<{ url: string; method: string; body?: unknown }> };
+
+    // GIVEN 初始未連接，POST /connect 回 201
+    await installGithubMock(page, {
+      status: { connected: false },
+      connectResponse: {
+        status: 201,
+        body: {
+          connected: true,
+          id: "mock-uuid-001",
+          username: "gpwork4u",
+          scopes: ["repo", "read:user"],
+          token_set: true,
+          last_synced_at: null,
+          created_at: "2026-04-26T10:00:00Z",
+          updated_at: "2026-04-26T10:00:00Z",
+        },
+      },
+      recorder,
+    });
+
+    // WHEN 前往設定頁 + 填入 PAT + 點連接
+    await page.goto(SETTINGS_PATH);
+    await page.getByTestId(G.patInput).fill("ghp_validtoken123456");
+    await page.getByTestId(G.connectButton).click();
+
+    // THEN POST /connect 有被呼叫
+    await expect
+      .poll(() => recorder.requests.some((r) => r.method === "POST" && /connect/.test(r.url)))
+      .toBeTruthy();
+
+    // THEN 顯示已連接狀態與 username
+    await expect(page.getByTestId(G.connectedState)).toBeVisible();
+    await expect(page.getByTestId(G.usernameLabel)).toContainText("gpwork4u");
+    // 未連接狀態隱藏
+    await expect(page.getByTestId(G.notConnectedState)).toBeHidden();
+    // 成功 toast
+    await expect(page.getByTestId(G.toastConnected)).toBeVisible();
+
+    // 確認 request body 不含明文 token 回傳（只是發出，不是斷言回傳）
+    const connectReq = recorder.requests.find((r) => /connect/.test(r.url));
+    expect(connectReq?.body).toMatchObject({ token: expect.any(String) });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Scenario 3: 填 invalid PAT → 顯示 422 錯誤 toast
+  // ---------------------------------------------------------------------------
+  test("Scenario: 填 invalid PAT → POST /connect 回 422 GITHUB_TOKEN_INVALID → 顯示錯誤 toast", async ({
+    page,
+  }) => {
+    test.skip(true, "Wave 0 — 等 F-034c 錯誤處理 UI 實作完成再啟用");
+
+    // GIVEN POST /connect 回 422 GITHUB_TOKEN_INVALID
+    await installGithubMock(page, {
+      status: { connected: false },
+      connectResponse: {
+        status: 422,
+        body: {
+          code: "GITHUB_TOKEN_INVALID",
+          message: "PAT 無法通過 GitHub 驗證，請確認 token 是否正確",
+        },
+      },
+    });
+
+    // WHEN 填入無效 PAT 並送出
+    await page.goto(SETTINGS_PATH);
+    await page.getByTestId(G.patInput).fill("ghp_invalid_token_xxx");
+    await page.getByTestId(G.connectButton).click();
+
+    // THEN 顯示錯誤 toast，仍維持未連接狀態
+    await expect(page.getByTestId(G.toastError)).toBeVisible();
+    await expect(page.getByTestId(G.notConnectedState)).toBeVisible();
+    await expect(page.getByTestId(G.connectedState)).toBeHidden();
+  });
+
+  // ---------------------------------------------------------------------------
+  // Scenario 4: 填 missing scope PAT → 顯示 422 + 提示需 repo + read:user
+  // ---------------------------------------------------------------------------
+  test("Scenario: 填缺少 scope 的 PAT → POST /connect 回 422 GITHUB_TOKEN_INSUFFICIENT_SCOPE → 提示缺少 repo/read:user", async ({
+    page,
+  }) => {
+    test.skip(true, "Wave 0 — 等 F-034c scope 錯誤提示 UI 實作完成再啟用");
+
+    // GIVEN POST /connect 回 422 GITHUB_TOKEN_INSUFFICIENT_SCOPE
+    await installGithubMock(page, {
+      status: { connected: false },
+      connectResponse: {
+        status: 422,
+        body: {
+          code: "GITHUB_TOKEN_INSUFFICIENT_SCOPE",
+          message: "PAT 缺少必要 scope，請確認已勾選 repo 與 read:user",
+        },
+      },
+    });
+
+    // WHEN 填入 scope 不足的 PAT
+    await page.goto(SETTINGS_PATH);
+    await page.getByTestId(G.patInput).fill("ghp_noscope_token_xxx");
+    await page.getByTestId(G.connectButton).click();
+
+    // THEN 顯示錯誤提示，並包含 repo / read:user 字樣
+    await expect(page.getByTestId(G.toastError)).toBeVisible();
+    // toast 或 banner 應提及所需 scopes
+    const errorText = await page.getByTestId(G.toastError).textContent();
+    expect(errorText).toMatch(/repo|read:user/i);
+    // 仍維持未連接
+    await expect(page.getByTestId(G.notConnectedState)).toBeVisible();
+  });
+
+  // ---------------------------------------------------------------------------
+  // Scenario 5: 已連接 → 點中斷 → 二次確認 → DELETE → 回未連接
+  // ---------------------------------------------------------------------------
+  test("Scenario: 已連接 → 點中斷按鈕 → AlertDialog 確認 → DELETE → 回到未連接狀態", async ({
+    page,
+  }) => {
+    test.skip(true, "Wave 0 — 等 F-034c disconnect 流程實作完成再啟用");
+
+    const recorder = { requests: [] as Array<{ url: string; method: string; body?: unknown }> };
+
+    // GIVEN 已連接
+    await installGithubMock(page, {
+      status: {
+        connected: true,
+        id: "mock-uuid-001",
+        username: "gpwork4u",
+        scopes: ["repo", "read:user"],
+        token_set: true,
+        last_synced_at: "2026-04-26T10:00:00Z",
+        last_error: null,
+      },
+      deleteResponse: { status: 204 },
+      recorder,
+    });
+
+    // WHEN 進設定頁
+    await page.goto(SETTINGS_PATH);
+    await expect(page.getByTestId(G.connectedState)).toBeVisible();
+    await expect(page.getByTestId(G.usernameLabel)).toContainText("gpwork4u");
+
+    // WHEN 點中斷按鈕 → 跳出確認 dialog
+    await page.getByTestId(G.disconnectButton).click();
+    await expect(page.getByTestId(G.disconnectDialog)).toBeVisible();
+
+    // WHEN 點確認中斷
+    await page.getByTestId(G.disconnectDialogConfirm).click();
+
+    // THEN DELETE 有被呼叫
+    await expect
+      .poll(() => recorder.requests.some((r) => r.method === "DELETE"))
+      .toBeTruthy();
+
+    // THEN 顯示成功 toast + 切回未連接狀態
+    await expect(page.getByTestId(G.toastDisconnected)).toBeVisible();
+    await expect(page.getByTestId(G.notConnectedState)).toBeVisible();
+    await expect(page.getByTestId(G.connectedState)).toBeHidden();
+  });
+
+  // ---------------------------------------------------------------------------
+  // 附加：點中斷後在 dialog 取消 → 仍維持已連接
+  // ---------------------------------------------------------------------------
+  test("Scenario: 已連接 → 點中斷 → 在 dialog 取消 → 仍維持已連接狀態", async ({ page }) => {
+    test.skip(true, "Wave 0 — 等 F-034c dialog 取消流程完成再啟用");
+
+    await installGithubMock(page, {
+      status: {
+        connected: true,
+        username: "gpwork4u",
+        scopes: ["repo", "read:user"],
+        token_set: true,
+      },
+    });
+
+    await page.goto(SETTINGS_PATH);
+    await page.getByTestId(G.disconnectButton).click();
+    await expect(page.getByTestId(G.disconnectDialog)).toBeVisible();
+
+    // WHEN 取消
+    await page.getByTestId(G.disconnectDialogCancel).click();
+
+    // THEN dialog 關閉，仍顯示已連接
+    await expect(page.getByTestId(G.disconnectDialog)).toBeHidden();
+    await expect(page.getByTestId(G.connectedState)).toBeVisible();
+  });
+});

--- a/test/browser/specs/github-settings.spec.ts
+++ b/test/browser/specs/github-settings.spec.ts
@@ -7,12 +7,17 @@
  * 涵蓋 scenarios：
  *  1. 訪問頁面顯示「未連接」狀態
  *  2. 填 valid PAT → 連接成功 → 顯示 username
- *  3. 填 invalid PAT → 顯示 422 錯誤 toast
- *  4. 填 missing scope PAT → 顯示 403 錯誤 + 提示需 repo + read:user
+ *  3. 填 invalid PAT → 顯示 422 GITHUB_TOKEN_INVALID 錯誤訊息
+ *  4. 填 missing scope PAT → 顯示 422 GITHUB_TOKEN_INSUFFICIENT_SCOPE + 提示需 repo + read:user
  *  5. 已連接 → 點中斷 → 二次確認 → DELETE → 回未連接
+ *  6. 已連接 → 點中斷後在 dialog 取消 → 仍維持已連接
+ *  7. 未認證 → POST /connect without X-API-Key → 401 UNAUTHORIZED
+ *  8. 重新連接（覆蓋既有 token）→ POST /connect 201，username 不變
  *
  * Wave 0：所有 test 皆 test.skip(true, ...) 包起來。
  * 等 F-034c 前端實作完成後 unskip 並確認 testid 對齊。
+ *
+ * testid 對應：dev/frontend/lib/github/testids.ts GITHUB_TESTIDS
  */
 
 import { test, expect } from "@playwright/test";
@@ -46,13 +51,11 @@ test.describe("GitHub 設定頁面 — 連線與中斷流程（F-034c）", () =>
     // WHEN 進設定頁
     await page.goto(SETTINGS_PATH);
 
-    // THEN 顯示未連接 state + PAT 輸入欄 + 連接按鈕
-    await expect(page.getByTestId(G.section)).toBeVisible();
-    await expect(page.getByTestId(G.notConnectedState)).toBeVisible();
+    // THEN 顯示 PAT 輸入欄 + 連接按鈕（未連接狀態）
     await expect(page.getByTestId(G.patInput)).toBeVisible();
     await expect(page.getByTestId(G.connectButton)).toBeVisible();
-    // 已連接狀態不應顯示
-    await expect(page.getByTestId(G.connectedState)).toBeHidden();
+    // 已連接才有的 username 不應顯示
+    await expect(page.getByTestId(G.usernameLabel)).toBeHidden();
   });
 
   // ---------------------------------------------------------------------------
@@ -94,23 +97,20 @@ test.describe("GitHub 設定頁面 — 連線與中斷流程（F-034c）", () =>
       .poll(() => recorder.requests.some((r) => r.method === "POST" && /connect/.test(r.url)))
       .toBeTruthy();
 
-    // THEN 顯示已連接狀態與 username
-    await expect(page.getByTestId(G.connectedState)).toBeVisible();
+    // THEN 顯示已連接 username，PAT 輸入欄與連接按鈕隱藏
+    await expect(page.getByTestId(G.usernameLabel)).toBeVisible();
     await expect(page.getByTestId(G.usernameLabel)).toContainText("gpwork4u");
-    // 未連接狀態隱藏
-    await expect(page.getByTestId(G.notConnectedState)).toBeHidden();
-    // 成功 toast
-    await expect(page.getByTestId(G.toastConnected)).toBeVisible();
+    await expect(page.getByTestId(G.connectButton)).toBeHidden();
 
-    // 確認 request body 不含明文 token 回傳（只是發出，不是斷言回傳）
+    // 確認 request body 含 token 欄位（前端有把 PAT 帶進去）
     const connectReq = recorder.requests.find((r) => /connect/.test(r.url));
     expect(connectReq?.body).toMatchObject({ token: expect.any(String) });
   });
 
   // ---------------------------------------------------------------------------
-  // Scenario 3: 填 invalid PAT → 顯示 422 錯誤 toast
+  // Scenario 3: 填 invalid PAT → 顯示 GITHUB_TOKEN_INVALID 錯誤訊息
   // ---------------------------------------------------------------------------
-  test("Scenario: 填 invalid PAT → POST /connect 回 422 GITHUB_TOKEN_INVALID → 顯示錯誤 toast", async ({
+  test("Scenario: 填 invalid PAT → POST /connect 回 422 GITHUB_TOKEN_INVALID → 顯示錯誤訊息", async ({
     page,
   }) => {
     test.skip(true, "Wave 0 — 等 F-034c 錯誤處理 UI 實作完成再啟用");
@@ -132,10 +132,9 @@ test.describe("GitHub 設定頁面 — 連線與中斷流程（F-034c）", () =>
     await page.getByTestId(G.patInput).fill("ghp_invalid_token_xxx");
     await page.getByTestId(G.connectButton).click();
 
-    // THEN 顯示錯誤 toast，仍維持未連接狀態
-    await expect(page.getByTestId(G.toastError)).toBeVisible();
-    await expect(page.getByTestId(G.notConnectedState)).toBeVisible();
-    await expect(page.getByTestId(G.connectedState)).toBeHidden();
+    // THEN 顯示即時錯誤訊息（github-error-message），仍維持未連接狀態
+    await expect(page.getByTestId(G.errorMessage)).toBeVisible();
+    await expect(page.getByTestId(G.usernameLabel)).toBeHidden();
   });
 
   // ---------------------------------------------------------------------------
@@ -153,7 +152,7 @@ test.describe("GitHub 設定頁面 — 連線與中斷流程（F-034c）", () =>
         status: 422,
         body: {
           code: "GITHUB_TOKEN_INSUFFICIENT_SCOPE",
-          message: "PAT 缺少必要 scope，請確認已勾選 repo 與 read:user",
+          message: "PAT 缺少 scopes，需要 repo + read:user",
         },
       },
     });
@@ -164,12 +163,11 @@ test.describe("GitHub 設定頁面 — 連線與中斷流程（F-034c）", () =>
     await page.getByTestId(G.connectButton).click();
 
     // THEN 顯示錯誤提示，並包含 repo / read:user 字樣
-    await expect(page.getByTestId(G.toastError)).toBeVisible();
-    // toast 或 banner 應提及所需 scopes
-    const errorText = await page.getByTestId(G.toastError).textContent();
+    await expect(page.getByTestId(G.errorMessage)).toBeVisible();
+    const errorText = await page.getByTestId(G.errorMessage).textContent();
     expect(errorText).toMatch(/repo|read:user/i);
     // 仍維持未連接
-    await expect(page.getByTestId(G.notConnectedState)).toBeVisible();
+    await expect(page.getByTestId(G.usernameLabel)).toBeHidden();
   });
 
   // ---------------------------------------------------------------------------
@@ -199,12 +197,12 @@ test.describe("GitHub 設定頁面 — 連線與中斷流程（F-034c）", () =>
 
     // WHEN 進設定頁
     await page.goto(SETTINGS_PATH);
-    await expect(page.getByTestId(G.connectedState)).toBeVisible();
+    await expect(page.getByTestId(G.usernameLabel)).toBeVisible();
     await expect(page.getByTestId(G.usernameLabel)).toContainText("gpwork4u");
 
-    // WHEN 點中斷按鈕 → 跳出確認 dialog
+    // WHEN 點中斷按鈕 → AlertDialog 的確認按鈕出現
     await page.getByTestId(G.disconnectButton).click();
-    await expect(page.getByTestId(G.disconnectDialog)).toBeVisible();
+    await expect(page.getByTestId(G.disconnectDialogConfirm)).toBeVisible();
 
     // WHEN 點確認中斷
     await page.getByTestId(G.disconnectDialogConfirm).click();
@@ -214,14 +212,13 @@ test.describe("GitHub 設定頁面 — 連線與中斷流程（F-034c）", () =>
       .poll(() => recorder.requests.some((r) => r.method === "DELETE"))
       .toBeTruthy();
 
-    // THEN 顯示成功 toast + 切回未連接狀態
-    await expect(page.getByTestId(G.toastDisconnected)).toBeVisible();
-    await expect(page.getByTestId(G.notConnectedState)).toBeVisible();
-    await expect(page.getByTestId(G.connectedState)).toBeHidden();
+    // THEN 切回未連接狀態（PAT 輸入欄重新顯示，username 隱藏）
+    await expect(page.getByTestId(G.patInput)).toBeVisible();
+    await expect(page.getByTestId(G.usernameLabel)).toBeHidden();
   });
 
   // ---------------------------------------------------------------------------
-  // 附加：點中斷後在 dialog 取消 → 仍維持已連接
+  // Scenario 6: 已連接 → 點中斷後在 dialog 取消 → 仍維持已連接
   // ---------------------------------------------------------------------------
   test("Scenario: 已連接 → 點中斷 → 在 dialog 取消 → 仍維持已連接狀態", async ({ page }) => {
     test.skip(true, "Wave 0 — 等 F-034c dialog 取消流程完成再啟用");
@@ -237,13 +234,96 @@ test.describe("GitHub 設定頁面 — 連線與中斷流程（F-034c）", () =>
 
     await page.goto(SETTINGS_PATH);
     await page.getByTestId(G.disconnectButton).click();
-    await expect(page.getByTestId(G.disconnectDialog)).toBeVisible();
+    await expect(page.getByTestId(G.disconnectDialogConfirm)).toBeVisible();
 
-    // WHEN 取消
-    await page.getByTestId(G.disconnectDialogCancel).click();
+    // WHEN 取消（按 Escape 關閉 AlertDialog）
+    await page.keyboard.press("Escape");
 
-    // THEN dialog 關閉，仍顯示已連接
-    await expect(page.getByTestId(G.disconnectDialog)).toBeHidden();
-    await expect(page.getByTestId(G.connectedState)).toBeVisible();
+    // THEN dialog 關閉，仍顯示已連接 username
+    await expect(page.getByTestId(G.disconnectDialogConfirm)).toBeHidden();
+    await expect(page.getByTestId(G.usernameLabel)).toBeVisible();
+  });
+
+  // ---------------------------------------------------------------------------
+  // Scenario 7: 未認證 → POST /connect without X-API-Key → 401 UNAUTHORIZED
+  // ---------------------------------------------------------------------------
+  test("Scenario: 未認證 → POST /connect without X-API-Key → 401 UNAUTHORIZED → 顯示錯誤", async ({
+    page,
+  }) => {
+    test.skip(true, "Wave 0 — 等 F-034a auth middleware 整合完成再啟用");
+
+    // GIVEN POST /connect mock 回應 401 auth error
+    await installGithubMock(page, {
+      status: { connected: false },
+      connectResponse: {
+        status: 422,
+        body: {
+          code: "UNAUTHORIZED",
+          message: "API Key 無效或缺失",
+        },
+      },
+    });
+
+    // WHEN 填入 PAT 並送出（模擬無有效 API Key）
+    await page.goto(SETTINGS_PATH);
+    await page.getByTestId(G.patInput).fill("ghp_sometoken");
+    await page.getByTestId(G.connectButton).click();
+
+    // THEN 顯示錯誤訊息，仍維持未連接狀態
+    await expect(page.getByTestId(G.errorMessage)).toBeVisible();
+    await expect(page.getByTestId(G.usernameLabel)).toBeHidden();
+  });
+
+  // ---------------------------------------------------------------------------
+  // Scenario 8: 重新連接（覆蓋既有 token）
+  //   GIVEN 已連接 username = "alice"，token T1
+  //   WHEN POST /connect with token T2（同帳號 alice）
+  //   THEN response 201，username 仍為 alice，row 數量仍 1
+  // ---------------------------------------------------------------------------
+  test("Scenario: 已連接 alice → 更新 PAT（T2）→ POST /connect 201 → username 不變", async ({
+    page,
+  }) => {
+    test.skip(true, "Wave 0 — 等 F-034c 更新 PAT 流程（UPDATE_PAT_BUTTON）實作完成再啟用");
+
+    const recorder = { requests: [] as Array<{ url: string; method: string; body?: unknown }> };
+
+    // GIVEN 已連接 alice，提供新 token T2
+    await installGithubMock(page, {
+      status: {
+        connected: true,
+        username: "alice",
+        scopes: ["repo", "read:user"],
+        token_set: true,
+      },
+      connectResponse: {
+        status: 201,
+        body: {
+          connected: true,
+          id: "mock-uuid-002",
+          username: "alice",
+          scopes: ["repo", "read:user"],
+          token_set: true,
+          last_synced_at: null,
+          created_at: "2026-04-26T10:00:00Z",
+          updated_at: "2026-04-26T11:00:00Z",
+        },
+      },
+      recorder,
+    });
+
+    await page.goto(SETTINGS_PATH);
+    await expect(page.getByTestId(G.usernameLabel)).toContainText("alice");
+
+    // WHEN 填入新 PAT 並點更新按鈕
+    await page.getByTestId(G.patInput).fill("ghp_newtoken_T2");
+    await page.getByTestId(G.updatePatButton).click();
+
+    // THEN POST /connect 被呼叫（覆蓋 token）
+    await expect
+      .poll(() => recorder.requests.some((r) => r.method === "POST" && /connect/.test(r.url)))
+      .toBeTruthy();
+
+    // THEN username 仍為 alice（row 被覆蓋，不新增）
+    await expect(page.getByTestId(G.usernameLabel)).toContainText("alice");
   });
 });


### PR DESCRIPTION
## Summary

F-034 GitHub Commit 整合的 Playwright e2e mock 測試骨架（Wave 0）。

所有 GitHub API 與後端都用 `page.route()` 攔截，不需真實環境即可跑。

## 測試涵蓋

| Spec 檔 | Scenarios | 狀態 |
|---------|-----------|------|
| `test/browser/specs/github-settings.spec.ts` | 5 | test.skip（Wave 0） |
| `test/browser/specs/github-commits-api.spec.ts` | 5 | test.skip（Wave 0） |
| `test/browser/specs/github-journal-integration.spec.ts` | 3 | test.skip（Wave 0） |
| 合計 | **13** | Wave 0 骨架 |

> 原始 issue 17 scenarios 中，4 個 backend-only 場景（連接 GitHub 成功 API / 查詢狀態 / 中斷 / 重新連接覆蓋）涵蓋在前端流程 spec 的 mock 驗證中；edge case「跨日邊界時區」與「Events API fallback」屬後端純邏輯，由 API test 覆蓋，不在 browser spec 範圍。

## Fixtures

- `test/browser/fixtures/github.ts`
  - `installGithubMock(page, opts)` — 攔截 `/api/v1/integrations/github/*`（status / connect / commits / delete）
  - `installJournalAutoMock(page, opts)` — 攔截 `/api/v1/journal/*/auto`
  - `makeCommit(overrides)` / `makeCommitsResponse(commits, overrides)` — 快速建立 fixture 資料

## 下一步

F-034a/b/c/d 實作完成後，逐步解除各 spec 的 `test.skip`，確認 testid 與 `dev/frontend/lib/github/testids.ts` 對齊。

Closes #181