### PR TITLE
feat(api): F-034a GitHub integration table + connect/status/disconnect

### DIFF
--- a/dev/src/dto/github_integration.go
+++ b/dev/src/dto/github_integration.go
@@ -1,0 +1,45 @@
+package dto
+
+import "time"
+
+// GitHubConnectRequest POST /api/v1/integrations/github/connect 的請求 body
+type GitHubConnectRequest struct {
+	// Token GitHub Personal Access Token（PAT）；不得出現在回應或日誌中
+	Token string `json:"token" binding:"required"`
+}
+
+// GitHubIntegrationDTO GitHub 整合資訊（不含 token 明文）
+type GitHubIntegrationDTO struct {
+	// Username GitHub 使用者名稱（由 GET /user API 回傳）
+	Username string `json:"username"`
+
+	// Scopes 此 PAT 擁有的 scope 清單（由 X-OAuth-Scopes header 解析）
+	Scopes []string `json:"scopes"`
+
+	// TokenSet 固定為 true，代表 token 已存在（不回傳明文）
+	TokenSet bool `json:"token_set"`
+
+	// LastSyncedAt 最後一次成功同步的時間
+	LastSyncedAt *time.Time `json:"last_synced_at,omitempty"`
+
+	// LastError 最後一次同步的錯誤訊息（無錯誤時省略）
+	LastError *string `json:"last_error,omitempty"`
+}
+
+// GitHubStatusResponse GET /api/v1/integrations/github/status 的回應 body
+type GitHubStatusResponse struct {
+	// Connected 是否已連接 GitHub
+	Connected bool `json:"connected"`
+
+	// Integration 連接資訊（connected=false 時為 nil）
+	Integration *GitHubIntegrationDTO `json:"integration,omitempty"`
+}
+
+// GitHubConnectResponse POST /api/v1/integrations/github/connect 的回應 body（201）
+type GitHubConnectResponse struct {
+	// Message 操作結果說明
+	Message string `json:"message"`
+
+	// Integration 連接後的整合資訊
+	Integration GitHubIntegrationDTO `json:"integration"`
+}

--- a/dev/src/dto/github_integration.go
+++ b/dev/src/dto/github_integration.go
@@ -8,38 +8,36 @@ type GitHubConnectRequest struct {
 	Token string `json:"token" binding:"required"`
 }
 
-// GitHubIntegrationDTO GitHub 整合資訊（不含 token 明文）
-type GitHubIntegrationDTO struct {
-	// Username GitHub 使用者名稱（由 GET /user API 回傳）
-	Username string `json:"username"`
-
-	// Scopes 此 PAT 擁有的 scope 清單（由 X-OAuth-Scopes header 解析）
-	Scopes []string `json:"scopes"`
-
-	// TokenSet 固定為 true，代表 token 已存在（不回傳明文）
-	TokenSet bool `json:"token_set"`
-
-	// LastSyncedAt 最後一次成功同步的時間
-	LastSyncedAt *time.Time `json:"last_synced_at,omitempty"`
-
-	// LastError 最後一次同步的錯誤訊息（無錯誤時省略）
-	LastError *string `json:"last_error,omitempty"`
-}
-
-// GitHubStatusResponse GET /api/v1/integrations/github/status 的回應 body
-type GitHubStatusResponse struct {
-	// Connected 是否已連接 GitHub
-	Connected bool `json:"connected"`
-
-	// Integration 連接資訊（connected=false 時為 nil）
-	Integration *GitHubIntegrationDTO `json:"integration,omitempty"`
-}
-
 // GitHubConnectResponse POST /api/v1/integrations/github/connect 的回應 body（201）
+// 扁平結構，符合 spec 要求
 type GitHubConnectResponse struct {
-	// Message 操作結果說明
-	Message string `json:"message"`
+	ID           string     `json:"id"`
+	Username     string     `json:"username"`
+	Scopes       []string   `json:"scopes"`
+	TokenSet     bool       `json:"token_set"`
+	LastSyncedAt *time.Time `json:"last_synced_at,omitempty"`
+	LastError    *string    `json:"last_error,omitempty"`
+	LastErrorAt  *time.Time `json:"last_error_at,omitempty"`
+	CreatedAt    time.Time  `json:"created_at"`
+	UpdatedAt    time.Time  `json:"updated_at"`
+}
 
-	// Integration 連接後的整合資訊
-	Integration GitHubIntegrationDTO `json:"integration"`
+// GitHubStatusConnectedResponse GET /api/v1/integrations/github/status 的回應 body（已連接）
+// 扁平結構，符合 spec 要求
+type GitHubStatusConnectedResponse struct {
+	Connected    bool       `json:"connected"`
+	ID           string     `json:"id"`
+	Username     string     `json:"username"`
+	Scopes       []string   `json:"scopes"`
+	TokenSet     bool       `json:"token_set"`
+	LastSyncedAt *time.Time `json:"last_synced_at,omitempty"`
+	LastError    *string    `json:"last_error,omitempty"`
+	LastErrorAt  *time.Time `json:"last_error_at,omitempty"`
+	CreatedAt    time.Time  `json:"created_at"`
+	UpdatedAt    time.Time  `json:"updated_at"`
+}
+
+// GitHubStatusDisconnectedResponse GET /api/v1/integrations/github/status 的回應 body（未連接）
+type GitHubStatusDisconnectedResponse struct {
+	Connected bool `json:"connected"`
 }

--- a/dev/src/handler/github_integration.go
+++ b/dev/src/handler/github_integration.go
@@ -22,11 +22,11 @@ func NewGitHubIntegrationHandler(svc *service.GitHubIntegrationService) *GitHubI
 // Connect 連接 GitHub（儲存並驗證 PAT）
 // POST /api/v1/integrations/github/connect
 //
-// 成功：201 Created，body 含 username / scopes / token_set=true
+// 成功：201 Created，扁平 body 含 id / username / scopes / token_set / created_at / updated_at
 // 失敗：
 //   - 400 Bad Request：缺少 token 欄位
 //   - 422 GITHUB_TOKEN_INVALID：PAT 無效或已過期
-//   - 422 GITHUB_INSUFFICIENT_SCOPE：PAT 缺少必要 scopes
+//   - 422 GITHUB_TOKEN_INSUFFICIENT_SCOPE：PAT 缺少必要 scopes
 //   - 503 GITHUB_UNAVAILABLE：GitHub API 無法連線
 func (h *GitHubIntegrationHandler) Connect(c *gin.Context) {
 	var req dto.GitHubConnectRequest
@@ -48,13 +48,17 @@ func (h *GitHubIntegrationHandler) Connect(c *gin.Context) {
 		return
 	}
 
+	gi := result.Integration
 	c.JSON(http.StatusCreated, dto.GitHubConnectResponse{
-		Message: "GitHub 整合連接成功",
-		Integration: dto.GitHubIntegrationDTO{
-			Username: result.Username,
-			Scopes:   result.Scopes,
-			TokenSet: true,
-		},
+		ID:           gi.ID.String(),
+		Username:     gi.Username,
+		Scopes:       gi.Scopes,
+		TokenSet:     true,
+		LastSyncedAt: gi.LastSyncedAt,
+		LastError:    gi.LastError,
+		LastErrorAt:  gi.LastErrorAt,
+		CreatedAt:    gi.CreatedAt,
+		UpdatedAt:    gi.UpdatedAt,
 	})
 }
 
@@ -62,7 +66,7 @@ func (h *GitHubIntegrationHandler) Connect(c *gin.Context) {
 // GET /api/v1/integrations/github/status
 //
 // 未連接：200 { "connected": false }
-// 已連接：200 { "connected": true, "integration": { username, scopes, token_set, last_synced_at, last_error } }
+// 已連接：200 扁平結構含 connected / id / username / scopes / token_set / last_synced_at / last_error / last_error_at / created_at / updated_at
 func (h *GitHubIntegrationHandler) GetStatus(c *gin.Context) {
 	connected, gi, err := h.svc.GetStatus(c.Request.Context())
 	if err != nil {
@@ -71,23 +75,23 @@ func (h *GitHubIntegrationHandler) GetStatus(c *gin.Context) {
 	}
 
 	if !connected {
-		c.JSON(http.StatusOK, dto.GitHubStatusResponse{
+		c.JSON(http.StatusOK, dto.GitHubStatusDisconnectedResponse{
 			Connected: false,
 		})
 		return
 	}
 
-	integration := &dto.GitHubIntegrationDTO{
+	c.JSON(http.StatusOK, dto.GitHubStatusConnectedResponse{
+		Connected:    true,
+		ID:           gi.ID.String(),
 		Username:     gi.Username,
 		Scopes:       gi.Scopes,
 		TokenSet:     true,
 		LastSyncedAt: gi.LastSyncedAt,
 		LastError:    gi.LastError,
-	}
-
-	c.JSON(http.StatusOK, dto.GitHubStatusResponse{
-		Connected:   true,
-		Integration: integration,
+		LastErrorAt:  gi.LastErrorAt,
+		CreatedAt:    gi.CreatedAt,
+		UpdatedAt:    gi.UpdatedAt,
 	})
 }
 

--- a/dev/src/handler/github_integration.go
+++ b/dev/src/handler/github_integration.go
@@ -1,0 +1,109 @@
+package handler
+
+import (
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+	"github.com/gpwork4u/aibo/dto"
+	"github.com/gpwork4u/aibo/model"
+	"github.com/gpwork4u/aibo/service"
+)
+
+// GitHubIntegrationHandler GitHub 整合相關 HTTP handler
+type GitHubIntegrationHandler struct {
+	svc *service.GitHubIntegrationService
+}
+
+// NewGitHubIntegrationHandler 建立新的 GitHubIntegrationHandler
+func NewGitHubIntegrationHandler(svc *service.GitHubIntegrationService) *GitHubIntegrationHandler {
+	return &GitHubIntegrationHandler{svc: svc}
+}
+
+// Connect 連接 GitHub（儲存並驗證 PAT）
+// POST /api/v1/integrations/github/connect
+//
+// 成功：201 Created，body 含 username / scopes / token_set=true
+// 失敗：
+//   - 400 Bad Request：缺少 token 欄位
+//   - 422 GITHUB_TOKEN_INVALID：PAT 無效或已過期
+//   - 422 GITHUB_INSUFFICIENT_SCOPE：PAT 缺少必要 scopes
+//   - 503 GITHUB_UNAVAILABLE：GitHub API 無法連線
+func (h *GitHubIntegrationHandler) Connect(c *gin.Context) {
+	var req dto.GitHubConnectRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, dto.ErrorResponse{
+			Code:    model.ErrCodeInvalidInput,
+			Message: "token 欄位為必填",
+		})
+		return
+	}
+
+	result, err := h.svc.Connect(c.Request.Context(), req.Token)
+	if err != nil {
+		if appErr, ok := err.(*model.AppError); ok {
+			c.JSON(appErr.Status, dto.ErrorResponse{Code: appErr.Code, Message: appErr.Message})
+			return
+		}
+		c.JSON(http.StatusInternalServerError, dto.ErrorResponse{Code: "INTERNAL_ERROR", Message: "伺服器內部錯誤"})
+		return
+	}
+
+	c.JSON(http.StatusCreated, dto.GitHubConnectResponse{
+		Message: "GitHub 整合連接成功",
+		Integration: dto.GitHubIntegrationDTO{
+			Username: result.Username,
+			Scopes:   result.Scopes,
+			TokenSet: true,
+		},
+	})
+}
+
+// GetStatus 取得 GitHub 整合狀態
+// GET /api/v1/integrations/github/status
+//
+// 未連接：200 { "connected": false }
+// 已連接：200 { "connected": true, "integration": { username, scopes, token_set, last_synced_at, last_error } }
+func (h *GitHubIntegrationHandler) GetStatus(c *gin.Context) {
+	connected, gi, err := h.svc.GetStatus(c.Request.Context())
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, dto.ErrorResponse{Code: "INTERNAL_ERROR", Message: "伺服器內部錯誤"})
+		return
+	}
+
+	if !connected {
+		c.JSON(http.StatusOK, dto.GitHubStatusResponse{
+			Connected: false,
+		})
+		return
+	}
+
+	integration := &dto.GitHubIntegrationDTO{
+		Username:     gi.Username,
+		Scopes:       gi.Scopes,
+		TokenSet:     true,
+		LastSyncedAt: gi.LastSyncedAt,
+		LastError:    gi.LastError,
+	}
+
+	c.JSON(http.StatusOK, dto.GitHubStatusResponse{
+		Connected:   true,
+		Integration: integration,
+	})
+}
+
+// Disconnect 中斷 GitHub 整合（刪除儲存的 PAT）
+// DELETE /api/v1/integrations/github
+//
+// 成功：204 No Content
+// 失敗：404 GITHUB_NOT_CONNECTED（尚未設定）
+func (h *GitHubIntegrationHandler) Disconnect(c *gin.Context) {
+	if err := h.svc.Disconnect(c.Request.Context()); err != nil {
+		if appErr, ok := err.(*model.AppError); ok {
+			c.JSON(appErr.Status, dto.ErrorResponse{Code: appErr.Code, Message: appErr.Message})
+			return
+		}
+		c.JSON(http.StatusInternalServerError, dto.ErrorResponse{Code: "INTERNAL_ERROR", Message: "伺服器內部錯誤"})
+		return
+	}
+	c.Status(http.StatusNoContent)
+}

--- a/dev/src/main.go
+++ b/dev/src/main.go
@@ -153,8 +153,13 @@ func main() {
 	taskSvc := service.NewTaskService(taskRepo, projectRepo, entryRepo, journalRepo, projectSvc)
 	taskHandler := handler.NewTaskHandler(taskSvc, projectSvc)
 
+	// 初始化 GitHub 整合服務（F-034a：connect / status / disconnect）
+	githubIntegrationRepo := repository.NewGitHubIntegrationRepository(pool)
+	githubIntegrationSvc := service.NewGitHubIntegrationService(githubIntegrationRepo, aesCrypto)
+	githubIntegrationHandler := handler.NewGitHubIntegrationHandler(githubIntegrationSvc)
+
 	// 設定路由
-	r := router.Setup(pool, apiKeySvc, apiKeyHandler, categoryHandler, llmProviderHandler, entryHandler, classifyHandler, searchHandler, gitImportHandler, gcalHandler, confidenceHandler, statsHandler, systemHandler, lifecycleHandler, calendarConvertHandler, calendarHandler, journalHandler, journalDraftHandler, journalAutoHandler, projectHandler, taskHandler)
+	r := router.Setup(pool, apiKeySvc, apiKeyHandler, categoryHandler, llmProviderHandler, entryHandler, classifyHandler, searchHandler, gitImportHandler, gcalHandler, confidenceHandler, statsHandler, systemHandler, lifecycleHandler, calendarConvertHandler, calendarHandler, journalHandler, journalDraftHandler, journalAutoHandler, projectHandler, taskHandler, githubIntegrationHandler)
 
 	// 啟動 HTTP server（graceful shutdown）
 	srv := &http.Server{

--- a/dev/src/migration/016_create_github_integrations.down.sql
+++ b/dev/src/migration/016_create_github_integrations.down.sql
@@ -1,0 +1,2 @@
+-- F-034a rollback：移除 github_integrations 資料表
+DROP TABLE IF EXISTS github_integrations;

--- a/dev/src/migration/016_create_github_integrations.up.sql
+++ b/dev/src/migration/016_create_github_integrations.up.sql
@@ -1,0 +1,28 @@
+-- F-034a GitHub Commit 整合（連接/狀態/中斷）
+--
+-- 本 migration 建立 github_integrations 資料表，用於存放：
+--   * GitHub 使用者名稱（以 LOWER(username) 做唯一約束，確保同一帳號只有一筆）
+--   * 加密後的 Personal Access Token（AES-256-GCM）
+--   * 授權 scopes 清單
+--   * 最後同步時間與錯誤訊息（供狀態顯示用）
+--
+-- 設計重點：
+--   * token_encrypted TEXT — 明文 PAT 在 service 層加密後才落地；DB 內永不存明文
+--   * UNIQUE INDEX ON LOWER(username) — MVP 僅支援單一 GitHub 帳號，避免重複新增
+--   * scopes TEXT[] DEFAULT '{}' — 存放從 X-OAuth-Scopes header 解析出的 scope 清單
+--   * last_synced_at / last_error — 由 sync job 更新；connect 時清空 last_error
+
+CREATE TABLE github_integrations (
+  id               UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
+  username         VARCHAR(255) NOT NULL,
+  token_encrypted  TEXT         NOT NULL,
+  scopes           TEXT[]       NOT NULL DEFAULT '{}',
+  last_synced_at   TIMESTAMPTZ,
+  last_error       TEXT,
+  created_at       TIMESTAMPTZ  NOT NULL DEFAULT NOW(),
+  updated_at       TIMESTAMPTZ  NOT NULL DEFAULT NOW()
+);
+
+-- UNIQUE constraint 以小寫 username 為鍵（case-insensitive）
+CREATE UNIQUE INDEX idx_github_integrations_username_lower
+  ON github_integrations (LOWER(username));

--- a/dev/src/migration/016_create_github_integrations.up.sql
+++ b/dev/src/migration/016_create_github_integrations.up.sql
@@ -19,6 +19,7 @@ CREATE TABLE github_integrations (
   scopes           TEXT[]       NOT NULL DEFAULT '{}',
   last_synced_at   TIMESTAMPTZ,
   last_error       TEXT,
+  last_error_at    TIMESTAMPTZ,
   created_at       TIMESTAMPTZ  NOT NULL DEFAULT NOW(),
   updated_at       TIMESTAMPTZ  NOT NULL DEFAULT NOW()
 );

--- a/dev/src/model/github_integration.go
+++ b/dev/src/model/github_integration.go
@@ -17,6 +17,7 @@ type GitHubIntegration struct {
 	Scopes         []string   `json:"scopes"`
 	LastSyncedAt   *time.Time `json:"last_synced_at,omitempty"`
 	LastError      *string    `json:"last_error,omitempty"`
+	LastErrorAt    *time.Time `json:"last_error_at,omitempty"`
 	CreatedAt      time.Time  `json:"created_at"`
 	UpdatedAt      time.Time  `json:"updated_at"`
 }

--- a/dev/src/model/github_integration.go
+++ b/dev/src/model/github_integration.go
@@ -1,0 +1,37 @@
+package model
+
+import (
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// GitHubIntegration GitHub PAT 整合資料庫模型
+//
+// token_encrypted 欄位：service 層使用 AES-256-GCM 加密後才落地；
+// 任何程式碼路徑都不得將明文 PAT 寫入此欄位或印到日誌。
+type GitHubIntegration struct {
+	ID             uuid.UUID  `json:"id"`
+	Username       string     `json:"username"`
+	TokenEncrypted string     `json:"-"` // 加密後的 PAT，json 序列化時省略
+	Scopes         []string   `json:"scopes"`
+	LastSyncedAt   *time.Time `json:"last_synced_at,omitempty"`
+	LastError      *string    `json:"last_error,omitempty"`
+	CreatedAt      time.Time  `json:"created_at"`
+	UpdatedAt      time.Time  `json:"updated_at"`
+}
+
+// 錯誤碼常數（GitHub 整合相關）
+const (
+	// ErrCodeGitHubTokenInvalid PAT 無效或已過期（GitHub API 回 401）
+	ErrCodeGitHubTokenInvalid = "GITHUB_TOKEN_INVALID"
+
+	// ErrCodeGitHubInsufficientScope PAT 缺少必要 scopes
+	ErrCodeGitHubInsufficientScope = "GITHUB_INSUFFICIENT_SCOPE"
+
+	// ErrCodeGitHubUnavailable GitHub API 無法連線（503）
+	ErrCodeGitHubUnavailable = "GITHUB_UNAVAILABLE"
+
+	// ErrCodeGitHubNotConnected 尚未設定 GitHub 整合
+	ErrCodeGitHubNotConnected = "GITHUB_NOT_CONNECTED"
+)

--- a/dev/src/model/github_integration.go
+++ b/dev/src/model/github_integration.go
@@ -28,7 +28,7 @@ const (
 	ErrCodeGitHubTokenInvalid = "GITHUB_TOKEN_INVALID"
 
 	// ErrCodeGitHubInsufficientScope PAT 缺少必要 scopes
-	ErrCodeGitHubInsufficientScope = "GITHUB_INSUFFICIENT_SCOPE"
+	ErrCodeGitHubInsufficientScope = "GITHUB_TOKEN_INSUFFICIENT_SCOPE"
 
 	// ErrCodeGitHubUnavailable GitHub API 無法連線（503）
 	ErrCodeGitHubUnavailable = "GITHUB_UNAVAILABLE"

--- a/dev/src/repository/github_integration.go
+++ b/dev/src/repository/github_integration.go
@@ -1,0 +1,113 @@
+package repository
+
+import (
+	"context"
+	"errors"
+
+	"github.com/google/uuid"
+	"github.com/gpwork4u/aibo/model"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+// GitHubIntegrationRepository GitHub 整合資料庫操作
+type GitHubIntegrationRepository struct {
+	pool *pgxpool.Pool
+}
+
+// NewGitHubIntegrationRepository 建立新的 GitHubIntegrationRepository
+func NewGitHubIntegrationRepository(pool *pgxpool.Pool) *GitHubIntegrationRepository {
+	return &GitHubIntegrationRepository{pool: pool}
+}
+
+// Get 取得目前唯一的 GitHubIntegration 記錄（MVP 僅支援單一帳號）
+// 若尚未設定則回傳 nil, nil
+func (r *GitHubIntegrationRepository) Get(ctx context.Context) (*model.GitHubIntegration, error) {
+	integration := &model.GitHubIntegration{}
+	err := r.pool.QueryRow(ctx,
+		`SELECT id, username, token_encrypted, scopes,
+		        last_synced_at, last_error, created_at, updated_at
+		 FROM github_integrations
+		 ORDER BY created_at DESC
+		 LIMIT 1`,
+	).Scan(
+		&integration.ID,
+		&integration.Username,
+		&integration.TokenEncrypted,
+		&integration.Scopes,
+		&integration.LastSyncedAt,
+		&integration.LastError,
+		&integration.CreatedAt,
+		&integration.UpdatedAt,
+	)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	return integration, nil
+}
+
+// Upsert 依 LOWER(username) 覆蓋更新（若存在則更新，否則插入）
+// 確保 DB 內永遠只有一筆同 username 的記錄
+func (r *GitHubIntegrationRepository) Upsert(ctx context.Context, integration *model.GitHubIntegration) error {
+	if integration.ID == uuid.Nil {
+		integration.ID = uuid.New()
+	}
+
+	_, err := r.pool.Exec(ctx,
+		`INSERT INTO github_integrations
+		   (id, username, token_encrypted, scopes, last_synced_at, last_error, created_at, updated_at)
+		 VALUES ($1, $2, $3, $4, $5, $6, NOW(), NOW())
+		 ON CONFLICT (LOWER(username))
+		 DO UPDATE SET
+		   token_encrypted = EXCLUDED.token_encrypted,
+		   scopes          = EXCLUDED.scopes,
+		   last_synced_at  = EXCLUDED.last_synced_at,
+		   last_error      = NULL,
+		   updated_at      = NOW()`,
+		integration.ID,
+		integration.Username,
+		integration.TokenEncrypted,
+		integration.Scopes,
+		integration.LastSyncedAt,
+		integration.LastError,
+	)
+	return err
+}
+
+// Delete 刪除所有 github_integrations 記錄（中斷連線語意）
+// 若無記錄則回傳 pgx.ErrNoRows
+func (r *GitHubIntegrationRepository) Delete(ctx context.Context) error {
+	result, err := r.pool.Exec(ctx, `DELETE FROM github_integrations`)
+	if err != nil {
+		return err
+	}
+	if result.RowsAffected() == 0 {
+		return pgx.ErrNoRows
+	}
+	return nil
+}
+
+// UpdateLastSyncedAt 更新最後同步時間（供 sync job 使用）
+func (r *GitHubIntegrationRepository) UpdateLastSyncedAt(ctx context.Context, id uuid.UUID) error {
+	_, err := r.pool.Exec(ctx,
+		`UPDATE github_integrations
+		 SET last_synced_at = NOW(), last_error = NULL, updated_at = NOW()
+		 WHERE id = $1`,
+		id,
+	)
+	return err
+}
+
+// UpdateLastError 記錄最後一次同步錯誤（供 sync job 使用）
+func (r *GitHubIntegrationRepository) UpdateLastError(ctx context.Context, id uuid.UUID, errMsg string) error {
+	_, err := r.pool.Exec(ctx,
+		`UPDATE github_integrations
+		 SET last_error = $1, updated_at = NOW()
+		 WHERE id = $2`,
+		errMsg, id,
+	)
+	return err
+}

--- a/dev/src/repository/github_integration.go
+++ b/dev/src/repository/github_integration.go
@@ -26,7 +26,7 @@ func (r *GitHubIntegrationRepository) Get(ctx context.Context) (*model.GitHubInt
 	integration := &model.GitHubIntegration{}
 	err := r.pool.QueryRow(ctx,
 		`SELECT id, username, token_encrypted, scopes,
-		        last_synced_at, last_error, created_at, updated_at
+		        last_synced_at, last_error, last_error_at, created_at, updated_at
 		 FROM github_integrations
 		 ORDER BY created_at DESC
 		 LIMIT 1`,
@@ -37,6 +37,7 @@ func (r *GitHubIntegrationRepository) Get(ctx context.Context) (*model.GitHubInt
 		&integration.Scopes,
 		&integration.LastSyncedAt,
 		&integration.LastError,
+		&integration.LastErrorAt,
 		&integration.CreatedAt,
 		&integration.UpdatedAt,
 	)
@@ -51,28 +52,53 @@ func (r *GitHubIntegrationRepository) Get(ctx context.Context) (*model.GitHubInt
 
 // Upsert 依 LOWER(username) 覆蓋更新（若存在則更新，否則插入）
 // 確保 DB 內永遠只有一筆同 username 的記錄
+// 採用 query-then-insert-or-update 策略，規避 ON CONFLICT expression 限制
 func (r *GitHubIntegrationRepository) Upsert(ctx context.Context, integration *model.GitHubIntegration) error {
 	if integration.ID == uuid.Nil {
 		integration.ID = uuid.New()
 	}
 
-	_, err := r.pool.Exec(ctx,
-		`INSERT INTO github_integrations
-		   (id, username, token_encrypted, scopes, last_synced_at, last_error, created_at, updated_at)
-		 VALUES ($1, $2, $3, $4, $5, $6, NOW(), NOW())
-		 ON CONFLICT (LOWER(username))
-		 DO UPDATE SET
-		   token_encrypted = EXCLUDED.token_encrypted,
-		   scopes          = EXCLUDED.scopes,
-		   last_synced_at  = EXCLUDED.last_synced_at,
-		   last_error      = NULL,
-		   updated_at      = NOW()`,
-		integration.ID,
+	// 先查是否存在相同（case-insensitive）username
+	var existingID uuid.UUID
+	err := r.pool.QueryRow(ctx,
+		`SELECT id FROM github_integrations WHERE LOWER(username) = LOWER($1) LIMIT 1`,
 		integration.Username,
+	).Scan(&existingID)
+
+	if errors.Is(err, pgx.ErrNoRows) {
+		// 不存在 → INSERT
+		_, err = r.pool.Exec(ctx,
+			`INSERT INTO github_integrations
+			   (id, username, token_encrypted, scopes, last_synced_at, last_error, last_error_at, created_at, updated_at)
+			 VALUES ($1, $2, $3, $4, $5, $6, $7, NOW(), NOW())`,
+			integration.ID,
+			integration.Username,
+			integration.TokenEncrypted,
+			integration.Scopes,
+			integration.LastSyncedAt,
+			integration.LastError,
+			integration.LastErrorAt,
+		)
+		return err
+	}
+	if err != nil {
+		return err
+	}
+
+	// 存在 → UPDATE（清空 last_error / last_error_at）
+	_, err = r.pool.Exec(ctx,
+		`UPDATE github_integrations
+		 SET token_encrypted = $1,
+		     scopes          = $2,
+		     last_synced_at  = $3,
+		     last_error      = NULL,
+		     last_error_at   = NULL,
+		     updated_at      = NOW()
+		 WHERE id = $4`,
 		integration.TokenEncrypted,
 		integration.Scopes,
 		integration.LastSyncedAt,
-		integration.LastError,
+		existingID,
 	)
 	return err
 }
@@ -94,7 +120,7 @@ func (r *GitHubIntegrationRepository) Delete(ctx context.Context) error {
 func (r *GitHubIntegrationRepository) UpdateLastSyncedAt(ctx context.Context, id uuid.UUID) error {
 	_, err := r.pool.Exec(ctx,
 		`UPDATE github_integrations
-		 SET last_synced_at = NOW(), last_error = NULL, updated_at = NOW()
+		 SET last_synced_at = NOW(), last_error = NULL, last_error_at = NULL, updated_at = NOW()
 		 WHERE id = $1`,
 		id,
 	)
@@ -102,10 +128,11 @@ func (r *GitHubIntegrationRepository) UpdateLastSyncedAt(ctx context.Context, id
 }
 
 // UpdateLastError 記錄最後一次同步錯誤（供 sync job 使用）
+// 同步寫入 last_error_at = NOW()
 func (r *GitHubIntegrationRepository) UpdateLastError(ctx context.Context, id uuid.UUID, errMsg string) error {
 	_, err := r.pool.Exec(ctx,
 		`UPDATE github_integrations
-		 SET last_error = $1, updated_at = NOW()
+		 SET last_error = $1, last_error_at = NOW(), updated_at = NOW()
 		 WHERE id = $2`,
 		errMsg, id,
 	)

--- a/dev/src/router/router.go
+++ b/dev/src/router/router.go
@@ -12,7 +12,7 @@ import (
 )
 
 // Setup 設定路由
-func Setup(pool *pgxpool.Pool, apiKeySvc *service.ApiKeyService, apiKeyHandler *handler.ApiKeyHandler, categoryHandler *handler.CategoryHandler, llmProviderHandler *handler.LlmProviderHandler, entryHandler *handler.EntryHandler, classifyHandler *handler.ClassifyHandler, searchHandler *handler.SearchHandler, gitImportHandler *handler.GitImportHandler, gcalHandler *handler.GcalHandler, confidenceHandler *handler.ConfidenceHandler, statsHandler *handler.StatsHandler, systemHandler *handler.SystemHandler, lifecycleHandler *handler.LifecycleHandler, calendarConvertHandler *handler.CalendarConvertHandler, calendarHandler *handler.CalendarHandler, journalHandler *handler.JournalHandler, journalDraftHandler *handler.JournalDraftHandler, journalAutoHandler *handler.JournalAutoHandler, projectHandler *handler.ProjectHandler, taskHandler *handler.TaskHandler) *gin.Engine {
+func Setup(pool *pgxpool.Pool, apiKeySvc *service.ApiKeyService, apiKeyHandler *handler.ApiKeyHandler, categoryHandler *handler.CategoryHandler, llmProviderHandler *handler.LlmProviderHandler, entryHandler *handler.EntryHandler, classifyHandler *handler.ClassifyHandler, searchHandler *handler.SearchHandler, gitImportHandler *handler.GitImportHandler, gcalHandler *handler.GcalHandler, confidenceHandler *handler.ConfidenceHandler, statsHandler *handler.StatsHandler, systemHandler *handler.SystemHandler, lifecycleHandler *handler.LifecycleHandler, calendarConvertHandler *handler.CalendarConvertHandler, calendarHandler *handler.CalendarHandler, journalHandler *handler.JournalHandler, journalDraftHandler *handler.JournalDraftHandler, journalAutoHandler *handler.JournalAutoHandler, projectHandler *handler.ProjectHandler, taskHandler *handler.TaskHandler, githubIntegrationHandler *handler.GitHubIntegrationHandler) *gin.Engine {
 	r := gin.Default()
 
 	// CORS middleware — 允許跨網域（前端 localhost:3000 呼叫 API localhost:8080）
@@ -106,6 +106,11 @@ func Setup(pool *pgxpool.Pool, apiKeySvc *service.ApiKeyService, apiKeyHandler *
 			integrations.GET("/gcal/calendars", gcalHandler.ListCalendars)
 			integrations.PUT("/gcal/settings", gcalHandler.UpdateSettings)
 			integrations.DELETE("/gcal", gcalHandler.Disconnect)
+
+			// F-034a：GitHub PAT 整合（connect / status / disconnect）
+			integrations.POST("/github/connect", githubIntegrationHandler.Connect)
+			integrations.GET("/github/status", githubIntegrationHandler.GetStatus)
+			integrations.DELETE("/github", githubIntegrationHandler.Disconnect)
 		}
 
 		// 匯入

--- a/dev/src/service/github_integration.go
+++ b/dev/src/service/github_integration.go
@@ -1,0 +1,265 @@
+package service
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/gpwork4u/aibo/crypto"
+	"github.com/gpwork4u/aibo/model"
+	"github.com/gpwork4u/aibo/repository"
+)
+
+const (
+	// githubAPIBase GitHub REST API 基礎 URL
+	githubAPIBase = "https://api.github.com"
+
+	// githubAPITimeout GitHub API 呼叫最大等待時間（spec 規定 10s）
+	githubAPITimeout = 10 * time.Second
+
+	// redactPrefixLen PAT redact 時保留的前段字元數
+	redactPrefixLen = 4
+
+	// redactSuffixLen PAT redact 時保留的後段字元數
+	redactSuffixLen = 4
+)
+
+// GitHubIntegrationService GitHub PAT 整合業務邏輯
+type GitHubIntegrationService struct {
+	repo       *repository.GitHubIntegrationRepository
+	crypto     *crypto.AESCrypto
+	httpClient *http.Client
+}
+
+// NewGitHubIntegrationService 建立新的 GitHubIntegrationService
+func NewGitHubIntegrationService(
+	repo *repository.GitHubIntegrationRepository,
+	aesCrypto *crypto.AESCrypto,
+) *GitHubIntegrationService {
+	return &GitHubIntegrationService{
+		repo:   repo,
+		crypto: aesCrypto,
+		httpClient: &http.Client{
+			Timeout: githubAPITimeout,
+		},
+	}
+}
+
+// githubUserResponse GitHub GET /user API 回應結構
+type githubUserResponse struct {
+	Login string `json:"login"`
+}
+
+// ConnectResult Connect() 成功時的回傳資料
+type ConnectResult struct {
+	Username string
+	Scopes   []string
+}
+
+// Connect 驗證 PAT 並儲存整合設定
+//
+// 流程：
+//  1. 用 PAT 呼叫 GitHub GET /user 驗證有效性並取得 username
+//  2. 從 X-OAuth-Scopes header 解析 scopes
+//  3. 加密 PAT 後 Upsert 到 DB
+//
+// 錯誤：
+//   - 401 → model.AppError{Code: ErrCodeGitHubTokenInvalid}
+//   - 403（scope 不足）→ model.AppError{Code: ErrCodeGitHubInsufficientScope}
+//   - GitHub 不可達 → model.AppError{Code: ErrCodeGitHubUnavailable}
+func (s *GitHubIntegrationService) Connect(ctx context.Context, pat string) (*ConnectResult, error) {
+	// 安全日誌：PAT 只印 redacted 版本
+	slog.Info("GitHub PAT 連接請求", "token", redactToken(pat))
+
+	// 呼叫 GitHub GET /user
+	user, scopes, err := s.fetchGitHubUser(ctx, pat)
+	if err != nil {
+		return nil, err
+	}
+
+	slog.Info("GitHub 使用者驗證成功", "username", user.Login, "scopes", scopes)
+
+	// 加密 PAT
+	encrypted, err := s.crypto.Encrypt(pat)
+	if err != nil {
+		return nil, fmt.Errorf("加密 PAT 失敗: %w", err)
+	}
+
+	// 準備 model
+	integration := &model.GitHubIntegration{
+		ID:             uuid.New(),
+		Username:       user.Login,
+		TokenEncrypted: encrypted,
+		Scopes:         scopes,
+	}
+
+	// Upsert（覆蓋同一 username 的舊記錄）
+	if err := s.repo.Upsert(ctx, integration); err != nil {
+		return nil, fmt.Errorf("儲存 GitHub 整合設定失敗: %w", err)
+	}
+
+	return &ConnectResult{
+		Username: user.Login,
+		Scopes:   scopes,
+	}, nil
+}
+
+// GetStatus 取得目前 GitHub 整合狀態
+//
+// 若尚未連接，回傳 connected=false 且 integration=nil。
+// 若已連接，回傳 connected=true 及整合資訊（不含明文 token）。
+func (s *GitHubIntegrationService) GetStatus(ctx context.Context) (connected bool, integration *model.GitHubIntegration, err error) {
+	gi, err := s.repo.Get(ctx)
+	if err != nil {
+		return false, nil, fmt.Errorf("查詢 GitHub 整合狀態失敗: %w", err)
+	}
+	if gi == nil {
+		return false, nil, nil
+	}
+	return true, gi, nil
+}
+
+// Disconnect 刪除 GitHub 整合設定（中斷連線）
+//
+// 若尚未設定則回傳 model.AppError{Code: ErrCodeGitHubNotConnected}。
+func (s *GitHubIntegrationService) Disconnect(ctx context.Context) error {
+	err := s.repo.Delete(ctx)
+	if err != nil {
+		// pgx.ErrNoRows 對應「尚未連接」
+		if err.Error() == "no rows in result set" {
+			return &model.AppError{
+				Status:  http.StatusNotFound,
+				Code:    model.ErrCodeGitHubNotConnected,
+				Message: "尚未設定 GitHub 整合",
+			}
+		}
+		return fmt.Errorf("刪除 GitHub 整合設定失敗: %w", err)
+	}
+	slog.Info("GitHub 整合已中斷連線")
+	return nil
+}
+
+// DecryptToken 解密儲存的 PAT（供其他 service 使用，例如 commit sync）
+//
+// 若尚未連接回傳 ErrCodeGitHubNotConnected。
+func (s *GitHubIntegrationService) DecryptToken(ctx context.Context) (string, error) {
+	gi, err := s.repo.Get(ctx)
+	if err != nil {
+		return "", fmt.Errorf("查詢 GitHub 整合失敗: %w", err)
+	}
+	if gi == nil {
+		return "", &model.AppError{
+			Status:  http.StatusNotFound,
+			Code:    model.ErrCodeGitHubNotConnected,
+			Message: "尚未設定 GitHub 整合",
+		}
+	}
+
+	plaintext, err := s.crypto.Decrypt(gi.TokenEncrypted)
+	if err != nil {
+		return "", fmt.Errorf("解密 PAT 失敗: %w", err)
+	}
+	return plaintext, nil
+}
+
+// fetchGitHubUser 呼叫 GitHub GET /user，回傳使用者資訊與 scopes
+func (s *GitHubIntegrationService) fetchGitHubUser(ctx context.Context, pat string) (*githubUserResponse, []string, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, githubAPIBase+"/user", nil)
+	if err != nil {
+		return nil, nil, fmt.Errorf("建立 GitHub API 請求失敗: %w", err)
+	}
+
+	req.Header.Set("Authorization", "Bearer "+pat)
+	req.Header.Set("Accept", "application/vnd.github+json")
+	req.Header.Set("X-GitHub-Api-Version", "2022-11-28")
+
+	resp, err := s.httpClient.Do(req)
+	if err != nil {
+		slog.Error("GitHub API 連線失敗", "error", err)
+		return nil, nil, &model.AppError{
+			Status:  http.StatusServiceUnavailable,
+			Code:    model.ErrCodeGitHubUnavailable,
+			Message: "無法連線到 GitHub API，請稍後再試",
+		}
+	}
+	defer resp.Body.Close()
+
+	// 處理錯誤狀態碼
+	switch resp.StatusCode {
+	case http.StatusOK:
+		// 繼續處理
+	case http.StatusUnauthorized:
+		slog.Warn("GitHub PAT 無效", "status", resp.StatusCode, "token", redactToken(pat))
+		return nil, nil, &model.AppError{
+			Status:  http.StatusUnprocessableEntity,
+			Code:    model.ErrCodeGitHubTokenInvalid,
+			Message: "GitHub Personal Access Token 無效或已過期",
+		}
+	case http.StatusForbidden:
+		slog.Warn("GitHub PAT scope 不足", "status", resp.StatusCode, "token", redactToken(pat))
+		return nil, nil, &model.AppError{
+			Status:  http.StatusUnprocessableEntity,
+			Code:    model.ErrCodeGitHubInsufficientScope,
+			Message: "GitHub Personal Access Token 缺少必要的存取權限",
+		}
+	default:
+		slog.Error("GitHub API 回傳非預期狀態碼", "status", resp.StatusCode)
+		return nil, nil, &model.AppError{
+			Status:  http.StatusServiceUnavailable,
+			Code:    model.ErrCodeGitHubUnavailable,
+			Message: fmt.Sprintf("GitHub API 回傳錯誤狀態: %d", resp.StatusCode),
+		}
+	}
+
+	// 解析 scopes（X-OAuth-Scopes: "repo, user, read:org"）
+	scopes := parseScopes(resp.Header.Get("X-OAuth-Scopes"))
+
+	// 解析回應 body
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, nil, fmt.Errorf("讀取 GitHub API 回應失敗: %w", err)
+	}
+
+	var user githubUserResponse
+	if err := json.Unmarshal(body, &user); err != nil {
+		return nil, nil, fmt.Errorf("解析 GitHub API 回應失敗: %w", err)
+	}
+
+	if user.Login == "" {
+		return nil, nil, fmt.Errorf("GitHub API 回應缺少 login 欄位")
+	}
+
+	return &user, scopes, nil
+}
+
+// parseScopes 解析 X-OAuth-Scopes header 成字串陣列
+// 例："repo, user, read:org" → ["repo", "user", "read:org"]
+func parseScopes(scopeHeader string) []string {
+	if scopeHeader == "" {
+		return []string{}
+	}
+	parts := strings.Split(scopeHeader, ",")
+	scopes := make([]string, 0, len(parts))
+	for _, p := range parts {
+		trimmed := strings.TrimSpace(p)
+		if trimmed != "" {
+			scopes = append(scopes, trimmed)
+		}
+	}
+	return scopes
+}
+
+// redactToken 將 PAT 轉成 redacted 格式（前 4 + *** + 後 4）
+// 例："ghp_abcdefghij1234" → "ghp_***1234"
+func redactToken(token string) string {
+	if len(token) <= redactPrefixLen+redactSuffixLen {
+		return "***"
+	}
+	return token[:redactPrefixLen] + "***" + token[len(token)-redactSuffixLen:]
+}

--- a/dev/src/service/github_integration.go
+++ b/dev/src/service/github_integration.go
@@ -3,6 +3,7 @@ package service
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"log/slog"
@@ -14,6 +15,7 @@ import (
 	"github.com/gpwork4u/aibo/crypto"
 	"github.com/gpwork4u/aibo/model"
 	"github.com/gpwork4u/aibo/repository"
+	"github.com/jackc/pgx/v5"
 )
 
 const (
@@ -29,6 +31,9 @@ const (
 	// redactSuffixLen PAT redact 時保留的後段字元數
 	redactSuffixLen = 4
 )
+
+// requiredScopes 連接 GitHub 所需的最小 scope 集合
+var requiredScopes = []string{"repo", "read:user"}
 
 // GitHubIntegrationService GitHub PAT 整合業務邏輯
 type GitHubIntegrationService struct {
@@ -58,20 +63,19 @@ type githubUserResponse struct {
 
 // ConnectResult Connect() 成功時的回傳資料
 type ConnectResult struct {
-	Username string
-	Scopes   []string
+	Integration *model.GitHubIntegration
 }
 
 // Connect 驗證 PAT 並儲存整合設定
 //
 // 流程：
 //  1. 用 PAT 呼叫 GitHub GET /user 驗證有效性並取得 username
-//  2. 從 X-OAuth-Scopes header 解析 scopes
+//  2. 從 X-OAuth-Scopes header 解析 scopes，驗證是否包含 repo + read:user
 //  3. 加密 PAT 後 Upsert 到 DB
 //
 // 錯誤：
 //   - 401 → model.AppError{Code: ErrCodeGitHubTokenInvalid}
-//   - 403（scope 不足）→ model.AppError{Code: ErrCodeGitHubInsufficientScope}
+//   - 缺少必要 scope → model.AppError{Code: ErrCodeGitHubInsufficientScope}
 //   - GitHub 不可達 → model.AppError{Code: ErrCodeGitHubUnavailable}
 func (s *GitHubIntegrationService) Connect(ctx context.Context, pat string) (*ConnectResult, error) {
 	// 安全日誌：PAT 只印 redacted 版本
@@ -104,9 +108,14 @@ func (s *GitHubIntegrationService) Connect(ctx context.Context, pat string) (*Co
 		return nil, fmt.Errorf("儲存 GitHub 整合設定失敗: %w", err)
 	}
 
+	// 讀回 DB 中的完整記錄（取得 id / created_at / updated_at）
+	saved, err := s.repo.Get(ctx)
+	if err != nil || saved == nil {
+		return nil, fmt.Errorf("讀取已儲存的 GitHub 整合設定失敗: %w", err)
+	}
+
 	return &ConnectResult{
-		Username: user.Login,
-		Scopes:   scopes,
+		Integration: saved,
 	}, nil
 }
 
@@ -131,8 +140,7 @@ func (s *GitHubIntegrationService) GetStatus(ctx context.Context) (connected boo
 func (s *GitHubIntegrationService) Disconnect(ctx context.Context) error {
 	err := s.repo.Delete(ctx)
 	if err != nil {
-		// pgx.ErrNoRows 對應「尚未連接」
-		if err.Error() == "no rows in result set" {
+		if errors.Is(err, pgx.ErrNoRows) {
 			return &model.AppError{
 				Status:  http.StatusNotFound,
 				Code:    model.ErrCodeGitHubNotConnected,
@@ -169,6 +177,7 @@ func (s *GitHubIntegrationService) DecryptToken(ctx context.Context) (string, er
 }
 
 // fetchGitHubUser 呼叫 GitHub GET /user，回傳使用者資訊與 scopes
+// 並驗證 X-OAuth-Scopes header 中是否含有必要的 scope
 func (s *GitHubIntegrationService) fetchGitHubUser(ctx context.Context, pat string) (*githubUserResponse, []string, error) {
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, githubAPIBase+"/user", nil)
 	if err != nil {
@@ -201,13 +210,6 @@ func (s *GitHubIntegrationService) fetchGitHubUser(ctx context.Context, pat stri
 			Code:    model.ErrCodeGitHubTokenInvalid,
 			Message: "GitHub Personal Access Token 無效或已過期",
 		}
-	case http.StatusForbidden:
-		slog.Warn("GitHub PAT scope 不足", "status", resp.StatusCode, "token", redactToken(pat))
-		return nil, nil, &model.AppError{
-			Status:  http.StatusUnprocessableEntity,
-			Code:    model.ErrCodeGitHubInsufficientScope,
-			Message: "GitHub Personal Access Token 缺少必要的存取權限",
-		}
 	default:
 		slog.Error("GitHub API 回傳非預期狀態碼", "status", resp.StatusCode)
 		return nil, nil, &model.AppError{
@@ -218,7 +220,14 @@ func (s *GitHubIntegrationService) fetchGitHubUser(ctx context.Context, pat stri
 	}
 
 	// 解析 scopes（X-OAuth-Scopes: "repo, user, read:org"）
+	// 注意：GitHub GET /user 對任何有效 PAT 都回 200，scope 驗證必須看 header
 	scopes := parseScopes(resp.Header.Get("X-OAuth-Scopes"))
+
+	// 驗證必要 scopes
+	if err := validateRequiredScopes(scopes); err != nil {
+		slog.Warn("GitHub PAT scope 不足", "actual_scopes", scopes, "required", requiredScopes, "token", redactToken(pat))
+		return nil, nil, err
+	}
 
 	// 解析回應 body
 	body, err := io.ReadAll(resp.Body)
@@ -236,6 +245,29 @@ func (s *GitHubIntegrationService) fetchGitHubUser(ctx context.Context, pat stri
 	}
 
 	return &user, scopes, nil
+}
+
+// validateRequiredScopes 驗證 scopes 清單是否包含所有必要的 scope
+// 若缺少任何必要 scope，回傳 AppError{Code: ErrCodeGitHubInsufficientScope}
+func validateRequiredScopes(actual []string) error {
+	scopeSet := make(map[string]bool, len(actual))
+	for _, s := range actual {
+		scopeSet[s] = true
+	}
+	var missing []string
+	for _, required := range requiredScopes {
+		if !scopeSet[required] {
+			missing = append(missing, required)
+		}
+	}
+	if len(missing) > 0 {
+		return &model.AppError{
+			Status:  http.StatusUnprocessableEntity,
+			Code:    model.ErrCodeGitHubInsufficientScope,
+			Message: fmt.Sprintf("GitHub Personal Access Token 缺少必要的存取權限：%s", strings.Join(missing, ", ")),
+		}
+	}
+	return nil
 }
 
 // parseScopes 解析 X-OAuth-Scopes header 成字串陣列


### PR DESCRIPTION
## Summary
- Migration 016 `github_integrations` table (unique LOWER(username))
- Connect endpoint：用 PAT 打 GitHub `GET /user` 驗證 → 加密 store
- Status / Disconnect endpoints
- Token 加密用既有 AESCrypto（同 LLM provider）
- Log redact PAT（前 4 + *** + 後 4）

## Closes
- Feature: #160
- Tasks: #164 #165 #166 #167 #168

## Test plan
- [x] docker compose build api → 通過
- [ ] e2e（QA #181）
- [ ] 手動測試 connect → status → disconnect

🤖 Generated with [Claude Code](https://claude.com/claude-code)