### PR TITLE
feat(api): F-034d JournalDraftService 整合 GitHub commits

### DIFF
--- a/dev/__tests__/service/journal_draft_test.go
+++ b/dev/__tests__/service/journal_draft_test.go
@@ -67,7 +67,7 @@ var _ service.EntryRepository = (*stubJournalDraftEntryRepo)(nil)
 // 400 INVALID_INPUT：日期格式錯
 // -----------------------------------------------------------------------------
 func TestJournalDraft_InvalidDate(t *testing.T) {
-	svc := service.NewJournalDraftService(nil, &stubJournalDraftEntryRepo{}, nil)
+	svc := service.NewJournalDraftService(nil, &stubJournalDraftEntryRepo{}, nil, nil)
 	_, err := svc.Draft(context.Background(), "2026-13-99", "UTC", "primary")
 	if err == nil {
 		t.Fatal("預期 400 invalid date")
@@ -82,7 +82,7 @@ func TestJournalDraft_InvalidDate(t *testing.T) {
 // 400 INVALID_INPUT：tz 格式錯
 // -----------------------------------------------------------------------------
 func TestJournalDraft_InvalidTimezone(t *testing.T) {
-	svc := service.NewJournalDraftService(nil, &stubJournalDraftEntryRepo{}, nil)
+	svc := service.NewJournalDraftService(nil, &stubJournalDraftEntryRepo{}, nil, nil)
 	_, err := svc.Draft(context.Background(), "2026-04-25", "Mars/Olympus", "primary")
 	if err == nil {
 		t.Fatal("預期 400 invalid tz")
@@ -98,7 +98,7 @@ func TestJournalDraft_InvalidTimezone(t *testing.T) {
 // -----------------------------------------------------------------------------
 func TestJournalDraft_NoData(t *testing.T) {
 	repo := &stubJournalDraftEntryRepo{entries: nil}
-	svc := service.NewJournalDraftService(nil, repo, nil) // gcalSvc nil → 不嘗試 gcal
+	svc := service.NewJournalDraftService(nil, repo, nil, nil) // gcalSvc nil → 不嘗試 gcal
 	_, err := svc.Draft(context.Background(), "2026-04-25", "UTC", "primary")
 	if err == nil {
 		t.Fatal("預期 404 no data")
@@ -114,7 +114,7 @@ func TestJournalDraft_NoData(t *testing.T) {
 // -----------------------------------------------------------------------------
 func TestJournalDraft_RepoError(t *testing.T) {
 	repo := &stubJournalDraftEntryRepo{err: fakeRepoErr("db down")}
-	svc := service.NewJournalDraftService(nil, repo, nil)
+	svc := service.NewJournalDraftService(nil, repo, nil, nil)
 	_, err := svc.Draft(context.Background(), "2026-04-25", "UTC", "primary")
 	if err == nil {
 		t.Fatal("預期錯誤")

--- a/dev/src/handler/journal_auto.go
+++ b/dev/src/handler/journal_auto.go
@@ -124,5 +124,16 @@ func (h *JournalAutoHandler) AutoGenerate(c *gin.Context) {
 		return
 	}
 
-	c.JSON(http.StatusCreated, toJournalResponse(created, createdRefs))
+	journalResp := toJournalResponse(created, createdRefs)
+	if len(draft.Warnings) > 0 {
+		c.JSON(http.StatusCreated, journalAutoResponse{JournalResponse: journalResp, Warnings: draft.Warnings})
+		return
+	}
+	c.JSON(http.StatusCreated, journalResp)
+}
+
+// journalAutoResponse 帶有 warnings 的 auto 生成回應（warnings 欄位向後相容）
+type journalAutoResponse struct {
+	dto.JournalResponse
+	Warnings []string `json:"warnings,omitempty"`
 }

--- a/dev/src/handler/journal_draft.go
+++ b/dev/src/handler/journal_draft.go
@@ -28,6 +28,7 @@ type JournalDraftResponse struct {
 	UsedRefs    []string `json:"used_refs,omitempty"`
 	Mood        string   `json:"mood,omitempty"`
 	GeneratedBy string   `json:"generated_by"`
+	Warnings    []string `json:"warnings,omitempty"`
 }
 
 // Draft POST /api/v1/journal/:date/draft
@@ -75,5 +76,6 @@ func (h *JournalDraftHandler) Draft(c *gin.Context) {
 		UsedRefs:    result.UsedRefs,
 		Mood:        result.Mood,
 		GeneratedBy: result.GeneratedBy,
+		Warnings:    result.Warnings,
 	})
 }

--- a/dev/src/main.go
+++ b/dev/src/main.go
@@ -136,10 +136,19 @@ func main() {
 	calendarSvc := service.NewCalendarService(entryRepo, gcalSvc, true, journalRepo)
 	calendarHandler := handler.NewCalendarHandler(calendarSvc)
 
-	// 初始化日記服務（F-028b：CRUD；F-028c：LLM draft）
+	// 初始化 GitHub 整合服務（F-034a：connect / status / disconnect）
+	githubIntegrationRepo := repository.NewGitHubIntegrationRepository(pool)
+	githubIntegrationSvc := service.NewGitHubIntegrationService(githubIntegrationRepo, aesCrypto)
+	githubIntegrationHandler := handler.NewGitHubIntegrationHandler(githubIntegrationSvc)
+
+	// 初始化 GitHub commits 服務（F-034b：fetch commits + per-repo fallback）
+	githubCommitsSvc := service.NewGitHubCommitsService(githubIntegrationSvc)
+	githubCommitsHandler := handler.NewGitHubCommitsHandler(githubCommitsSvc)
+
+	// 初始化日記服務（F-028b：CRUD；F-028c：LLM draft；F-034d：整合 GitHub commits）
 	journalSvc := service.NewJournalService(journalRepo, entryRepo)
 	journalHandler := handler.NewJournalHandler(journalSvc)
-	journalDraftSvc := service.NewJournalDraftService(llmSvc, entryRepo, gcalSvc)
+	journalDraftSvc := service.NewJournalDraftService(llmSvc, entryRepo, gcalSvc, githubCommitsSvc)
 	journalDraftHandler := handler.NewJournalDraftHandler(journalDraftSvc)
 	journalAutoHandler := handler.NewJournalAutoHandler(journalSvc, journalDraftSvc)
 
@@ -152,15 +161,6 @@ func main() {
 	// 初始化任務服務（F-031c：CRUD + complete + upcoming/overdue）
 	taskSvc := service.NewTaskService(taskRepo, projectRepo, entryRepo, journalRepo, projectSvc)
 	taskHandler := handler.NewTaskHandler(taskSvc, projectSvc)
-
-	// 初始化 GitHub 整合服務（F-034a：connect / status / disconnect）
-	githubIntegrationRepo := repository.NewGitHubIntegrationRepository(pool)
-	githubIntegrationSvc := service.NewGitHubIntegrationService(githubIntegrationRepo, aesCrypto)
-	githubIntegrationHandler := handler.NewGitHubIntegrationHandler(githubIntegrationSvc)
-
-	// 初始化 GitHub commits 服務（F-034b：fetch commits + per-repo fallback）
-	githubCommitsSvc := service.NewGitHubCommitsService(githubIntegrationSvc)
-	githubCommitsHandler := handler.NewGitHubCommitsHandler(githubCommitsSvc)
 
 	// 設定路由
 	r := router.Setup(pool, apiKeySvc, apiKeyHandler, categoryHandler, llmProviderHandler, entryHandler, classifyHandler, searchHandler, gitImportHandler, gcalHandler, confidenceHandler, statsHandler, systemHandler, lifecycleHandler, calendarConvertHandler, calendarHandler, journalHandler, journalDraftHandler, journalAutoHandler, projectHandler, taskHandler, githubIntegrationHandler, githubCommitsHandler)

--- a/dev/src/service/journal_draft.go
+++ b/dev/src/service/journal_draft.go
@@ -3,6 +3,7 @@ package service
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log/slog"
 	"strings"
@@ -17,30 +18,34 @@ import (
 //
 // 不直接寫入 DB；呼叫端拿到 draft 後讓使用者編輯，再透過 PATCH /journal/:date 落地。
 type JournalDraftService struct {
-	llmSvc      *LlmService
-	entryRepo   EntryRepository
-	gcalSvc     *GcalService // optional：gcal 未連時跳過
-	maxContent  int          // entries 內容 char 上限（避免 prompt 爆量）
-	timeoutSecs int          // 預設 60s
+	llmSvc           *LlmService
+	entryRepo        EntryRepository
+	gcalSvc          *GcalService          // optional：gcal 未連時跳過
+	githubCommitsSvc *GitHubCommitsService // optional：github 未連時跳過
+	maxContent       int                   // entries 內容 char 上限（避免 prompt 爆量）
+	timeoutSecs      int                   // 預設 60s
 }
 
 // NewJournalDraftService 建立 JournalDraftService。
-func NewJournalDraftService(llmSvc *LlmService, entryRepo EntryRepository, gcalSvc *GcalService) *JournalDraftService {
+// githubCommitsSvc 可傳 nil（向後相容）。
+func NewJournalDraftService(llmSvc *LlmService, entryRepo EntryRepository, gcalSvc *GcalService, githubCommitsSvc *GitHubCommitsService) *JournalDraftService {
 	return &JournalDraftService{
-		llmSvc:      llmSvc,
-		entryRepo:   entryRepo,
-		gcalSvc:     gcalSvc,
-		maxContent:  4000,
-		timeoutSecs: 60,
+		llmSvc:           llmSvc,
+		entryRepo:        entryRepo,
+		gcalSvc:          gcalSvc,
+		githubCommitsSvc: githubCommitsSvc,
+		maxContent:       4000,
+		timeoutSecs:      60,
 	}
 }
 
 // JournalDraftResult LLM 回傳結果（直接帶 markdown）。
 type JournalDraftResult struct {
-	Draft     string   `json:"draft"`
-	UsedRefs  []string `json:"used_refs,omitempty"` // 來源 entry IDs / event IDs（用於前端 source-refs panel）
-	Mood      string   `json:"mood,omitempty"`      // optional 推測情緒
-	GeneratedBy string `json:"generated_by"`
+	Draft       string   `json:"draft"`
+	UsedRefs    []string `json:"used_refs,omitempty"` // 來源 entry IDs / event IDs（用於前端 source-refs panel）
+	Mood        string   `json:"mood,omitempty"`      // optional 推測情緒
+	GeneratedBy string   `json:"generated_by"`
+	Warnings    []string `json:"warnings,omitempty"` // 非致命性警告（例如 GitHub 無法取得）
 }
 
 // Draft 為指定日期生成日記草稿。
@@ -77,11 +82,23 @@ func (s *JournalDraftService) Draft(ctx context.Context, dateStr, tz, calendarID
 		}
 	}
 
+	// GitHub commits（best-effort，失敗不阻擋主流程）
+	var commits []GithubCommit
+	var warnings []string
+	if s.githubCommitsSvc != nil {
+		githubCommits, githubWarning := s.fetchGitHubCommitsForDate(ctx, dateStr, tz)
+		if githubWarning != "" {
+			warnings = append(warnings, githubWarning)
+		} else {
+			commits = githubCommits
+		}
+	}
+
 	if len(entries) == 0 && len(events) == 0 {
 		return nil, model.NewAppError(404, model.ErrCodeNotFound, "當日無可參考素材，無法生成日記草稿")
 	}
 
-	prompt := s.buildPrompt(dateStr, entries, events)
+	prompt := s.buildPrompt(dateStr, entries, events, commits)
 
 	// 呼叫 LLM（使用 chat completion；非 streaming，依 spec/tech-survey 決策）
 	provider, err := s.llmSvc.providerSvc.GetActiveProvider(ctx)
@@ -138,6 +155,7 @@ func (s *JournalDraftService) Draft(ctx context.Context, dateStr, tz, calendarID
 		parsed.Draft = strings.TrimSpace(raw)
 	}
 	parsed.GeneratedBy = provider.Name + "/" + provider.ModelName
+	parsed.Warnings = warnings
 	return &parsed, nil
 }
 
@@ -207,8 +225,58 @@ func (s *JournalDraftService) fetchGcalEventsForDate(ctx context.Context, dateSt
 	return out, nil
 }
 
+// fetchGitHubCommitsForDate 取得指定日期的 GitHub commits（best-effort）。
+// 成功回傳 commits, ""；失敗回傳 nil, warning 訊息。
+func (s *JournalDraftService) fetchGitHubCommitsForDate(ctx context.Context, dateStr, tz string) ([]GithubCommit, string) {
+	if tz == "" {
+		tz = "UTC"
+	}
+	loc, err := time.LoadLocation(tz)
+	if err != nil {
+		return nil, "GitHub commits 時區解析失敗"
+	}
+	d, err := time.ParseInLocation("2006-01-02", dateStr, loc)
+	if err != nil {
+		return nil, "GitHub commits 日期解析失敗"
+	}
+	sinceUTC := d.UTC()
+	untilUTC := d.AddDate(0, 0, 1).UTC()
+
+	fetchCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	defer cancel()
+
+	commits, _, fetchErr := s.githubCommitsSvc.FetchCommits(fetchCtx, sinceUTC, untilUTC)
+	if fetchErr == nil {
+		return commits, ""
+	}
+
+	// 依錯誤類型產生 warning 訊息
+	slog.Warn("draft: 取 GitHub commits 失敗，跳過", "error", fetchErr)
+
+	// RateLimitError（需先判斷，因為內嵌 AppError）
+	var rateLimitErr *model.RateLimitError
+	if errors.As(fetchErr, &rateLimitErr) {
+		return nil, fmt.Sprintf("GitHub API rate limit 超限，retry_after_seconds=%d", rateLimitErr.RetryAfterSeconds)
+	}
+
+	var appErr *model.AppError
+	if errors.As(fetchErr, &appErr) {
+		switch appErr.Code {
+		case model.ErrCodeGitHubNotConnected:
+			// 未連 GitHub，靜默不警告
+			return nil, ""
+		case model.ErrCodeGitHubTokenInvalid:
+			return nil, "GitHub PAT 失效，請至設定頁更新"
+		case model.ErrCodeGitHubUnavailable:
+			return nil, "GitHub 暫時無法連線"
+		}
+	}
+
+	return nil, "GitHub 暫時無法整合"
+}
+
 // buildPrompt 將當日素材組成 prompt（截斷過長 entry 內容防止 prompt 爆量）。
-func (s *JournalDraftService) buildPrompt(date string, entries []dto.CalendarEntrySummary, events []*gcalEventLike) string {
+func (s *JournalDraftService) buildPrompt(date string, entries []dto.CalendarEntrySummary, events []*gcalEventLike, commits []GithubCommit) string {
 	var b strings.Builder
 	fmt.Fprintf(&b, "請根據下列素材，為日期 %s 撰寫一篇日記草稿。\n\n", date)
 
@@ -237,6 +305,19 @@ func (s *JournalDraftService) buildPrompt(date string, entries []dto.CalendarEnt
 		b.WriteString("## Google Calendar 事件\n")
 		for _, ev := range events {
 			fmt.Fprintf(&b, "- [%s] %s（%s ~ %s）\n", ev.ID, ev.Summary, ev.Start, ev.End)
+		}
+		b.WriteString("\n")
+	}
+
+	if len(commits) > 0 {
+		b.WriteString("## GitHub 推送\n")
+		for _, c := range commits {
+			// 只取 message 第一行，避免 prompt 爆量
+			firstLine := c.Message
+			if idx := strings.Index(firstLine, "\n"); idx >= 0 {
+				firstLine = firstLine[:idx]
+			}
+			fmt.Fprintf(&b, "- %s: %s\n", c.Repo, firstLine)
 		}
 		b.WriteString("\n")
 	}


### PR DESCRIPTION
## Summary
- JournalDraftService 加 githubCommitsSvc 欄位（可 nil）
- NewJournalDraftService 加第 4 參數
- Draft() 呼叫 FetchCommits(sinceUTC, untilUTC) 取當日 commits（10s timeout）
- buildPrompt 加 `## GitHub 推送` 區塊（commit 為空時跳過）
- DraftResult 加 Warnings []string
- handler/journal_draft.go + journal_auto.go response 加 warnings
- degradation：GitHub 失敗（token 失效/rate limit/timeout/unavailable）只加 warning，draft 仍正常生成

## Closes
- Feature: #163
- Tasks: #177 #178 #179 #180

## Test plan
- [x] docker compose build api 通過
- [ ] e2e (#181 已 merged，相關 spec 等本 PR unskip)
- [ ] 手動測試：connect GitHub → 觸發 journal/auto → 含 GitHub 區塊

🤖 Generated with [Claude Code](https://claude.com/claude-code)