### PR TITLE
feat(frontend): F-035 design tokens & theme

### DIFF
--- a/dev/frontend/__tests__/components/theme/theme-provider.test.tsx
+++ b/dev/frontend/__tests__/components/theme/theme-provider.test.tsx
@@ -1,0 +1,213 @@
+/**
+ * F-035 ThemeProvider unit tests
+ *
+ * Scenarios 覆蓋：
+ *   - 預設跟隨系統（無 localStorage 設定 + prefers-color-scheme=dark → resolvedTheme=dark）
+ *   - 手動切換 light：寫入 localStorage + html class 更新
+ *   - 重新載入保留偏好（localStorage.theme=light → 初始即 light）
+ *   - localStorage 被禁用：仍可運作 + storageAvailable=false
+ *   - theme=system 時系統主題變化即時切換
+ *   - useTheme 在 Provider 外使用會 throw
+ */
+import * as React from "react";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { render, screen, act } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import {
+  ThemeProvider,
+  useTheme,
+  __testing__,
+} from "@/components/theme/theme-provider";
+
+/* ---------- matchMedia mock helper ---------- */
+type MQListener = (e: MediaQueryListEvent) => void;
+
+function installMatchMedia(initialDark: boolean) {
+  const listeners = new Set<MQListener>();
+  let matches = initialDark;
+
+  const factory = (query: string): MediaQueryList => {
+    const mql: Partial<MediaQueryList> & {
+      _emit: (next: boolean) => void;
+    } = {
+      media: query,
+      get matches() {
+        return query === "(prefers-color-scheme: dark)" ? matches : false;
+      },
+      onchange: null,
+      addEventListener: (type: string, cb: EventListener) => {
+        if (type === "change") listeners.add(cb as unknown as MQListener);
+      },
+      removeEventListener: (type: string, cb: EventListener) => {
+        if (type === "change") listeners.delete(cb as unknown as MQListener);
+      },
+      addListener: (cb: MQListener) => listeners.add(cb),
+      removeListener: (cb: MQListener) => listeners.delete(cb),
+      dispatchEvent: () => true,
+      _emit: (next: boolean) => {
+        matches = next;
+        const evt = { matches: next, media: query } as MediaQueryListEvent;
+        listeners.forEach((l) => l(evt));
+      },
+    };
+    return mql as MediaQueryList;
+  };
+
+  Object.defineProperty(window, "matchMedia", {
+    configurable: true,
+    writable: true,
+    value: vi.fn(factory),
+  });
+
+  return {
+    setMatches(next: boolean) {
+      matches = next;
+    },
+    emit(next: boolean) {
+      matches = next;
+      const evt = { matches: next, media: "(prefers-color-scheme: dark)" } as MediaQueryListEvent;
+      listeners.forEach((l) => l(evt));
+    },
+  };
+}
+
+function Probe() {
+  const { theme, resolvedTheme, setTheme, storageAvailable } = useTheme();
+  return (
+    <div>
+      <div data-testid="theme">{theme}</div>
+      <div data-testid="resolved">{resolvedTheme}</div>
+      <div data-testid="storage">{String(storageAvailable)}</div>
+      <button data-testid="set-light" onClick={() => setTheme("light")}>L</button>
+      <button data-testid="set-dark" onClick={() => setTheme("dark")}>D</button>
+      <button data-testid="set-system" onClick={() => setTheme("system")}>S</button>
+    </div>
+  );
+}
+
+describe("ThemeProvider / useTheme", () => {
+  beforeEach(() => {
+    document.documentElement.classList.remove("light", "dark");
+    document.documentElement.removeAttribute("data-theme");
+    window.localStorage.clear();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("Scenario: 預設跟隨系統 — prefers-color-scheme=dark → resolvedTheme=dark + html.dark", () => {
+    installMatchMedia(true);
+    render(
+      <ThemeProvider>
+        <Probe />
+      </ThemeProvider>,
+    );
+    expect(screen.getByTestId("theme").textContent).toBe("system");
+    expect(screen.getByTestId("resolved").textContent).toBe("dark");
+    expect(document.documentElement.classList.contains("dark")).toBe(true);
+    expect(document.documentElement.getAttribute("data-theme")).toBe("dark");
+  });
+
+  it("Scenario: 預設跟隨系統 — prefers-color-scheme=light → resolvedTheme=light", () => {
+    installMatchMedia(false);
+    render(
+      <ThemeProvider>
+        <Probe />
+      </ThemeProvider>,
+    );
+    expect(screen.getByTestId("resolved").textContent).toBe("light");
+    expect(document.documentElement.classList.contains("light")).toBe(true);
+  });
+
+  it("Scenario: 手動切換 light — localStorage 寫入 + html class 切換", async () => {
+    installMatchMedia(true);
+    const user = userEvent.setup();
+    render(
+      <ThemeProvider>
+        <Probe />
+      </ThemeProvider>,
+    );
+    expect(screen.getByTestId("resolved").textContent).toBe("dark");
+
+    await user.click(screen.getByTestId("set-light"));
+
+    expect(screen.getByTestId("theme").textContent).toBe("light");
+    expect(screen.getByTestId("resolved").textContent).toBe("light");
+    expect(window.localStorage.getItem("theme")).toBe("light");
+    expect(document.documentElement.classList.contains("light")).toBe(true);
+    expect(document.documentElement.classList.contains("dark")).toBe(false);
+  });
+
+  it("Scenario: 重新載入保留偏好 — localStorage.theme=light → 初始 resolvedTheme=light", async () => {
+    installMatchMedia(true); // 系統 dark，但 stored=light 應勝出
+    window.localStorage.setItem("theme", "light");
+    render(
+      <ThemeProvider>
+        <Probe />
+      </ThemeProvider>,
+    );
+    // useEffect 同步後
+    expect(screen.getByTestId("theme").textContent).toBe("light");
+    expect(screen.getByTestId("resolved").textContent).toBe("light");
+  });
+
+  it("Scenario: localStorage 被禁用 — storageAvailable=false 且仍可運作", () => {
+    installMatchMedia(false);
+    const getItemSpy = vi
+      .spyOn(Storage.prototype, "getItem")
+      .mockImplementation(() => {
+        throw new Error("blocked");
+      });
+    render(
+      <ThemeProvider>
+        <Probe />
+      </ThemeProvider>,
+    );
+    expect(screen.getByTestId("storage").textContent).toBe("false");
+    expect(screen.getByTestId("theme").textContent).toBe("system");
+    expect(screen.getByTestId("resolved").textContent).toBe("light");
+    getItemSpy.mockRestore();
+  });
+
+  it("Scenario: theme=system 時 prefers-color-scheme 變化即時切換", () => {
+    const mq = installMatchMedia(false);
+    render(
+      <ThemeProvider>
+        <Probe />
+      </ThemeProvider>,
+    );
+    expect(screen.getByTestId("resolved").textContent).toBe("light");
+
+    act(() => {
+      mq.emit(true);
+    });
+
+    expect(screen.getByTestId("resolved").textContent).toBe("dark");
+    expect(document.documentElement.classList.contains("dark")).toBe(true);
+  });
+
+  it("useTheme 在 Provider 外使用應 throw", () => {
+    // 抑制預期的 console.error（React 會 log error boundary）
+    const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    function Bare() {
+      useTheme();
+      return null;
+    }
+    expect(() => render(<Bare />)).toThrow(/ThemeProvider/);
+    errSpy.mockRestore();
+  });
+
+  it("internal helpers — applyThemeClass 移除舊 class 並設置新 class", () => {
+    document.documentElement.classList.add("light");
+    __testing__.applyThemeClass("dark");
+    expect(document.documentElement.classList.contains("light")).toBe(false);
+    expect(document.documentElement.classList.contains("dark")).toBe(true);
+    expect(document.documentElement.getAttribute("data-theme")).toBe("dark");
+  });
+
+  it("internal helpers — readStoredTheme 對未知值回傳 system", () => {
+    window.localStorage.setItem("theme", "bogus-value");
+    expect(__testing__.readStoredTheme().theme).toBe("system");
+  });
+});

--- a/dev/frontend/__tests__/components/theme/theme-script.test.tsx
+++ b/dev/frontend/__tests__/components/theme/theme-script.test.tsx
@@ -1,0 +1,106 @@
+/**
+ * F-035 ThemeScript unit tests
+ *
+ * 驗證 inline init script 的 IIFE 行為：
+ *   - localStorage.theme=light → html.classList 含 'light'
+ *   - localStorage.theme=dark → html.classList 含 'dark'
+ *   - localStorage.theme=system + matchMedia dark → html.dark
+ *   - 未設值 + matchMedia light → html.light
+ *   - localStorage 被禁用（throw） → fallback 至 system
+ *   - 未知值 → fallback 至 system
+ *   - 同步在第一次 paint 前執行（透過 React render <ThemeScript /> 確認 inline 字串）
+ */
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { render } from "@testing-library/react";
+import { ThemeScript, __THEME_INIT_SCRIPT__ } from "@/components/theme/theme-script";
+
+/* matchMedia minimal mock */
+function mockMatchMedia(prefersDark: boolean) {
+  Object.defineProperty(window, "matchMedia", {
+    configurable: true,
+    writable: true,
+    value: vi.fn().mockImplementation((query: string) => ({
+      matches: query === "(prefers-color-scheme: dark)" ? prefersDark : false,
+      media: query,
+      onchange: null,
+      addEventListener: () => {},
+      removeEventListener: () => {},
+      addListener: () => {},
+      removeListener: () => {},
+      dispatchEvent: () => true,
+    })),
+  });
+}
+
+function runScript() {
+  // eslint-disable-next-line @typescript-eslint/no-implied-eval, no-new-func
+  new Function(__THEME_INIT_SCRIPT__)();
+}
+
+describe("ThemeScript inline init", () => {
+  beforeEach(() => {
+    document.documentElement.classList.remove("light", "dark");
+    document.documentElement.removeAttribute("data-theme");
+    window.localStorage.clear();
+  });
+
+  it("Scenario: localStorage.theme=light → html.light", () => {
+    mockMatchMedia(true); // 系統 dark，但 stored=light 應勝出
+    window.localStorage.setItem("theme", "light");
+    runScript();
+    expect(document.documentElement.classList.contains("light")).toBe(true);
+    expect(document.documentElement.classList.contains("dark")).toBe(false);
+    expect(document.documentElement.getAttribute("data-theme")).toBe("light");
+  });
+
+  it("Scenario: localStorage.theme=dark → html.dark", () => {
+    mockMatchMedia(false);
+    window.localStorage.setItem("theme", "dark");
+    runScript();
+    expect(document.documentElement.classList.contains("dark")).toBe(true);
+    expect(document.documentElement.getAttribute("data-theme")).toBe("dark");
+  });
+
+  it("Scenario: theme=system + 系統 dark → html.dark", () => {
+    mockMatchMedia(true);
+    window.localStorage.setItem("theme", "system");
+    runScript();
+    expect(document.documentElement.classList.contains("dark")).toBe(true);
+  });
+
+  it("Scenario: 無 stored + 系統 light → html.light（預設跟隨系統）", () => {
+    mockMatchMedia(false);
+    runScript();
+    expect(document.documentElement.classList.contains("light")).toBe(true);
+  });
+
+  it("Scenario: localStorage 被禁用 → fallback system + 仍能套用 class", () => {
+    mockMatchMedia(true);
+    const spy = vi
+      .spyOn(Storage.prototype, "getItem")
+      .mockImplementation(() => {
+        throw new Error("blocked");
+      });
+    runScript();
+    // 因為被 catch，stored 為 null → fallback system → 系統 dark
+    expect(document.documentElement.classList.contains("dark")).toBe(true);
+    spy.mockRestore();
+  });
+
+  it("Scenario: 未知 stored 值 → fallback system", () => {
+    mockMatchMedia(false);
+    window.localStorage.setItem("theme", "purple");
+    runScript();
+    // fallback system → 系統 light
+    expect(document.documentElement.classList.contains("light")).toBe(true);
+  });
+
+  it("<ThemeScript /> render 為含初始化邏輯的 inline <script>", () => {
+    const { container } = render(<ThemeScript />);
+    const script = container.querySelector("script");
+    expect(script).not.toBeNull();
+    expect(script!.innerHTML).toContain("prefers-color-scheme");
+    expect(script!.innerHTML).toContain("localStorage");
+    expect(script!.innerHTML).toContain("data-theme");
+  });
+});

--- a/dev/frontend/__tests__/components/theme/tokens.test.ts
+++ b/dev/frontend/__tests__/components/theme/tokens.test.ts
@@ -1,0 +1,137 @@
+/**
+ * F-035 Design Tokens — globals.css 解析驗證
+ *
+ * 不在 jsdom 中解析整段 CSS（jsdom 對 @layer / @media 支援有限），
+ * 改以正則 + 字串分段驗證 token 完整性：
+ *   - light 主題包含全部 editorial tokens（paper / ink / accent / rule / surface 系列）
+ *   - dark 主題（.dark + @media）也包含相同的 editorial tokens
+ *   - radii / shadows / z-index 變數齊全
+ *   - shadcn 相容層 HSL 變數齊全（保證既有元件不壞）
+ */
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+const CSS_PATH = resolve(__dirname, "../../../app/globals.css");
+const css = readFileSync(CSS_PATH, "utf-8");
+
+/** 取出 :root.dark { ... } block 的內容 */
+function extractBlock(source: string, selector: string): string {
+  const idx = source.indexOf(selector);
+  if (idx < 0) return "";
+  // 從 selector 之後找到第一個 '{'，再做大括號配對
+  const start = source.indexOf("{", idx);
+  if (start < 0) return "";
+  let depth = 1;
+  let i = start + 1;
+  while (i < source.length && depth > 0) {
+    if (source[i] === "{") depth++;
+    else if (source[i] === "}") depth--;
+    i++;
+  }
+  return source.slice(start + 1, i - 1);
+}
+
+const EDITORIAL_TOKENS = [
+  "--paper",
+  "--paper-2",
+  "--paper-3",
+  "--surface",
+  "--ink",
+  "--ink-2",
+  "--ink-3",
+  "--ink-4",
+  "--rule",
+  "--rule-2",
+  "--accent",
+  "--accent-2",
+  "--accent-soft",
+];
+
+const SHADCN_TOKENS = [
+  "--background",
+  "--foreground",
+  "--card",
+  "--popover",
+  "--primary",
+  "--secondary",
+  "--muted",
+  "--destructive",
+  "--warning",
+  "--success",
+  "--border",
+  "--input",
+  "--ring",
+];
+
+describe("F-035 globals.css design tokens", () => {
+  it("light（:root, :root.light）包含所有 editorial tokens", () => {
+    const block = extractBlock(css, ":root,\n  :root.light");
+    expect(block.length).toBeGreaterThan(0);
+    for (const token of EDITORIAL_TOKENS) {
+      expect(block).toContain(`${token}:`);
+    }
+  });
+
+  it("light 包含所有 shadcn 相容 HSL tokens", () => {
+    const block = extractBlock(css, ":root,\n  :root.light");
+    for (const token of SHADCN_TOKENS) {
+      expect(block).toContain(`${token}:`);
+    }
+  });
+
+  it("light 包含 radii / z-index / shadow 變數", () => {
+    const block = extractBlock(css, ":root,\n  :root.light");
+    for (const t of [
+      "--radius-sm",
+      "--radius-md",
+      "--radius-lg",
+      "--radius-xl",
+      "--radius-pill",
+      "--z-base",
+      "--z-dropdown",
+      "--z-modal",
+      "--z-toast",
+      "--shadow-sm",
+      "--shadow-md",
+      "--shadow-lg",
+    ]) {
+      expect(block).toContain(`${t}:`);
+    }
+  });
+
+  it("dark（:root.dark）包含所有 editorial tokens", () => {
+    const block = extractBlock(css, ":root.dark");
+    expect(block.length).toBeGreaterThan(0);
+    for (const token of EDITORIAL_TOKENS) {
+      expect(block).toContain(`${token}:`);
+    }
+  });
+
+  it("dark 包含所有 shadcn 相容 HSL tokens", () => {
+    const block = extractBlock(css, ":root.dark");
+    for (const token of SHADCN_TOKENS) {
+      expect(block).toContain(`${token}:`);
+    }
+  });
+
+  it("@media (prefers-color-scheme: dark) 區塊覆寫 editorial tokens", () => {
+    // 直接抓 @media 區塊內容
+    const idx = css.indexOf("@media (prefers-color-scheme: dark)");
+    expect(idx).toBeGreaterThan(-1);
+    const block = extractBlock(css.slice(idx), ":root:not(.light)");
+    for (const token of EDITORIAL_TOKENS) {
+      expect(block).toContain(`${token}:`);
+    }
+  });
+
+  it("light 與 dark 的 --paper 值不同（確保確實切換）", () => {
+    const lightBlock = extractBlock(css, ":root,\n  :root.light");
+    const darkBlock = extractBlock(css, ":root.dark");
+    const lightPaper = /--paper:\s*([^;]+);/.exec(lightBlock)?.[1].trim();
+    const darkPaper = /--paper:\s*([^;]+);/.exec(darkBlock)?.[1].trim();
+    expect(lightPaper).toBeTruthy();
+    expect(darkPaper).toBeTruthy();
+    expect(lightPaper).not.toBe(darkPaper);
+  });
+});

--- a/dev/frontend/app/globals.css
+++ b/dev/frontend/app/globals.css
@@ -2,8 +2,69 @@
 @tailwind components;
 @tailwind utilities;
 
+/* ============================================================================
+ * F-035 Design Tokens — Editorial 紙本風格
+ *
+ * 三套字體：--sans / --serif / --mono（由 next/font 注入）
+ * 三主題：light（預設）/ dark / system
+ *   - .dark class on <html> → 強制 dark
+ *   - 無 class 時，@media (prefers-color-scheme: dark) 自動套用 dark
+ *
+ * Token 命名（editorial）：
+ *   --paper / --paper-2 / --paper-3   背景紙感層次
+ *   --ink / --ink-2 / --ink-3 / --ink-4  文字 / icon 階層
+ *   --accent / --accent-2 / --accent-soft  品牌色
+ *   --rule / --rule-2  分隔線、邊框
+ *   --surface  卡片表面（sub-paper）
+ *
+ * 同時保留 shadcn HSL 變數作為相容層（既有元件持續可用）。
+ * ========================================================================== */
+
 @layer base {
-  :root {
+  :root,
+  :root.light {
+    /* === Editorial tokens (light) === */
+    --paper: #eef1f6;
+    --paper-2: #e3e8ef;
+    --paper-3: #d3dae4;
+    --surface: #ffffff;
+    --ink: #0b1220;
+    --ink-2: #1c2433;
+    --ink-3: #5a6577;
+    --ink-4: #8a93a3;
+    --rule: rgba(11, 18, 32, 0.06);
+    --rule-2: rgba(11, 18, 32, 0.10);
+    --accent: #3b6dff;
+    --accent-2: #7a9bff;
+    --accent-soft: rgba(59, 109, 255, 0.08);
+    --accent-glow:
+      0 0 0 4px rgba(59, 109, 255, 0.10),
+      0 6px 20px rgba(59, 109, 255, 0.18);
+
+    /* === Radii === */
+    --radius-sm: 4px;
+    --radius-md: 8px;
+    --radius-lg: 12px;
+    --radius-xl: 16px;
+    --radius-pill: 999px;
+
+    /* === Z-index 層級 === */
+    --z-base: 0;
+    --z-dropdown: 1000;
+    --z-sticky: 1100;
+    --z-popover: 1200;
+    --z-modal: 1300;
+    --z-tooltip: 1400;
+    --z-toast: 1500;
+
+    /* === Shadows === */
+    --shadow-sm: 0 1px 2px rgba(11, 18, 32, 0.04);
+    --shadow-md: 0 4px 12px rgba(11, 18, 32, 0.06);
+    --shadow-lg: 0 12px 28px rgba(11, 18, 32, 0.10);
+
+    /* ============================================================
+     * shadcn 相容層（HSL）— 既有元件持續仰賴這些變數
+     * ============================================================ */
     --background: 0 0% 100%;
     --foreground: 240 10% 3.9%;
 
@@ -19,7 +80,6 @@
     --secondary: 240 4.8% 95.9%;
     --secondary-foreground: 240 5.9% 10%;
 
-    --accent: 240 4.8% 95.9%;
     --accent-foreground: 240 5.9% 10%;
 
     --muted: 240 4.8% 95.9%;
@@ -50,41 +110,123 @@
     --sidebar-ring: 240 5.9% 10%;
   }
 
-  .dark {
+  /* ============================================================
+   * Dark theme（透過 .dark class 或系統偏好）
+   * 順序很重要：先寫 system-preference fallback，
+   * 再寫顯式 .dark / .light class 以覆寫之。
+   * ============================================================ */
+  @media (prefers-color-scheme: dark) {
+    :root:not(.light) {
+      --paper: #0b0f17;
+      --paper-2: #131826;
+      --paper-3: #1d2334;
+      --surface: #161c2a;
+      --ink: #e7ecf5;
+      --ink-2: #c8d0de;
+      --ink-3: #8a93a3;
+      --ink-4: #5a6577;
+      --rule: rgba(231, 236, 245, 0.06);
+      --rule-2: rgba(231, 236, 245, 0.12);
+      --accent: #6f93ff;
+      --accent-2: #a3bbff;
+      --accent-soft: rgba(111, 147, 255, 0.14);
+      --accent-glow:
+        0 0 0 4px rgba(111, 147, 255, 0.18),
+        0 6px 20px rgba(111, 147, 255, 0.28);
+
+      --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.40);
+      --shadow-md: 0 4px 12px rgba(0, 0, 0, 0.50);
+      --shadow-lg: 0 12px 28px rgba(0, 0, 0, 0.60);
+
+      --background: 240 10% 3.9%;
+      --foreground: 0 0% 98%;
+
+      --card: 240 10% 3.9%;
+      --card-foreground: 0 0% 98%;
+
+      --popover: 240 10% 3.9%;
+      --popover-foreground: 0 0% 98%;
+
+      --primary: 0 0% 98%;
+      --primary-foreground: 240 5.9% 10%;
+
+      --secondary: 240 3.7% 15.9%;
+      --secondary-foreground: 0 0% 98%;
+
+      --accent-foreground: 0 0% 98%;
+
+      --muted: 240 3.7% 15.9%;
+      --muted-foreground: 240 5% 64.9%;
+
+      --destructive: 0 62.8% 30.6%;
+      --destructive-foreground: 0 0% 98%;
+
+      --warning: 38 92% 50%;
+      --warning-foreground: 38 92% 14%;
+
+      --success: 142 76% 36%;
+      --success-foreground: 0 0% 98%;
+
+      --border: 240 3.7% 15.9%;
+      --input: 240 3.7% 15.9%;
+      --ring: 240 4.9% 83.9%;
+
+      --sidebar-background: 240 5.9% 10%;
+      --sidebar-foreground: 240 4.8% 95.9%;
+      --sidebar-primary: 0 0% 98%;
+      --sidebar-primary-foreground: 240 5.9% 10%;
+      --sidebar-accent: 240 3.7% 15.9%;
+      --sidebar-accent-foreground: 240 4.8% 95.9%;
+      --sidebar-border: 240 3.7% 15.9%;
+      --sidebar-ring: 240 4.9% 83.9%;
+    }
+  }
+
+  /* 顯式 .dark class（覆寫系統偏好） */
+  :root.dark {
+    --paper: #0b0f17;
+    --paper-2: #131826;
+    --paper-3: #1d2334;
+    --surface: #161c2a;
+    --ink: #e7ecf5;
+    --ink-2: #c8d0de;
+    --ink-3: #8a93a3;
+    --ink-4: #5a6577;
+    --rule: rgba(231, 236, 245, 0.06);
+    --rule-2: rgba(231, 236, 245, 0.12);
+    --accent: #6f93ff;
+    --accent-2: #a3bbff;
+    --accent-soft: rgba(111, 147, 255, 0.14);
+    --accent-glow:
+      0 0 0 4px rgba(111, 147, 255, 0.18),
+      0 6px 20px rgba(111, 147, 255, 0.28);
+
+    --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.40);
+    --shadow-md: 0 4px 12px rgba(0, 0, 0, 0.50);
+    --shadow-lg: 0 12px 28px rgba(0, 0, 0, 0.60);
+
     --background: 240 10% 3.9%;
     --foreground: 0 0% 98%;
-
     --card: 240 10% 3.9%;
     --card-foreground: 0 0% 98%;
-
     --popover: 240 10% 3.9%;
     --popover-foreground: 0 0% 98%;
-
     --primary: 0 0% 98%;
     --primary-foreground: 240 5.9% 10%;
-
     --secondary: 240 3.7% 15.9%;
     --secondary-foreground: 0 0% 98%;
-
-    --accent: 240 3.7% 15.9%;
     --accent-foreground: 0 0% 98%;
-
     --muted: 240 3.7% 15.9%;
     --muted-foreground: 240 5% 64.9%;
-
     --destructive: 0 62.8% 30.6%;
     --destructive-foreground: 0 0% 98%;
-
     --warning: 38 92% 50%;
     --warning-foreground: 38 92% 14%;
-
     --success: 142 76% 36%;
     --success-foreground: 0 0% 98%;
-
     --border: 240 3.7% 15.9%;
     --input: 240 3.7% 15.9%;
     --ring: 240 4.9% 83.9%;
-
     --sidebar-background: 240 5.9% 10%;
     --sidebar-foreground: 240 4.8% 95.9%;
     --sidebar-primary: 0 0% 98%;

--- a/dev/frontend/app/layout.tsx
+++ b/dev/frontend/app/layout.tsx
@@ -1,12 +1,18 @@
 import type { Metadata } from "next";
-import { Inter, JetBrains_Mono } from "next/font/google";
+import { Inter, JetBrains_Mono, Lora } from "next/font/google";
 import { Providers } from "@/lib/providers";
-import { Toaster } from "@/components/ui/sonner";
+import { ThemeScript } from "@/components/theme/theme-script";
 import "./globals.css";
 
 const inter = Inter({
   subsets: ["latin"],
   variable: "--font-sans",
+  display: "swap",
+});
+
+const lora = Lora({
+  subsets: ["latin"],
+  variable: "--font-serif",
   display: "swap",
 });
 
@@ -26,11 +32,14 @@ export default function RootLayout({
 }: Readonly<{ children: React.ReactNode }>) {
   return (
     <html lang="zh-Hant" suppressHydrationWarning>
+      <head>
+        {/* F-035：在 hydration 前同步套用 light/dark class，避免 FOUC */}
+        <ThemeScript />
+      </head>
       <body
-        className={`${inter.variable} ${jetbrainsMono.variable} font-sans antialiased`}
+        className={`${inter.variable} ${lora.variable} ${jetbrainsMono.variable} font-sans antialiased`}
       >
         <Providers>{children}</Providers>
-        <Toaster />
       </body>
     </html>
   );

--- a/dev/frontend/components/app-header.tsx
+++ b/dev/frontend/components/app-header.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { Menu, Moon, Sun } from "lucide-react";
-import { useTheme } from "next-themes";
+import { useTheme } from "@/components/theme/theme-provider";
 import { Button } from "@/components/ui/button";
 
 interface AppHeaderProps {

--- a/dev/frontend/components/theme/theme-provider.tsx
+++ b/dev/frontend/components/theme/theme-provider.tsx
@@ -1,0 +1,145 @@
+"use client";
+
+/**
+ * F-035 ThemeProvider — 自製輕量 theme context（不依賴 next-themes）。
+ *
+ * 為何不直接用 next-themes？
+ *   - F-035 spec 要求 useTheme hook 與 localStorage 持久化邏輯為專案所有，
+ *     避免外部套件 lock-in；同時讓 unit test 直接驗證行為。
+ *
+ * 提供：
+ *   - <ThemeProvider> wrapper
+ *   - useTheme() hook → { theme, resolvedTheme, setTheme }
+ *
+ * 行為：
+ *   - theme: "light" | "dark" | "system"（使用者選擇）
+ *   - resolvedTheme: "light" | "dark"（實際生效）
+ *   - setTheme(t) 寫入 localStorage 並更新 <html> class
+ *   - 監聽 prefers-color-scheme，theme="system" 時即時切換
+ *   - SSR safe：初始 render 不存取 window/localStorage
+ */
+import * as React from "react";
+
+export type Theme = "light" | "dark" | "system";
+export type ResolvedTheme = "light" | "dark";
+
+const STORAGE_KEY = "theme";
+
+interface ThemeContextValue {
+  theme: Theme;
+  resolvedTheme: ResolvedTheme;
+  setTheme: (theme: Theme) => void;
+  /** localStorage 是否可用（被禁用時為 false） */
+  storageAvailable: boolean;
+}
+
+const ThemeContext = React.createContext<ThemeContextValue | null>(null);
+
+function readStoredTheme(): { theme: Theme; storageAvailable: boolean } {
+  if (typeof window === "undefined") {
+    return { theme: "system", storageAvailable: true };
+  }
+  try {
+    const v = window.localStorage.getItem(STORAGE_KEY);
+    if (v === "light" || v === "dark" || v === "system") {
+      return { theme: v, storageAvailable: true };
+    }
+    return { theme: "system", storageAvailable: true };
+  } catch {
+    return { theme: "system", storageAvailable: false };
+  }
+}
+
+function getSystemTheme(): ResolvedTheme {
+  if (typeof window === "undefined" || !window.matchMedia) return "light";
+  return window.matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light";
+}
+
+function applyThemeClass(resolved: ResolvedTheme) {
+  if (typeof document === "undefined") return;
+  const root = document.documentElement;
+  root.classList.remove("light", "dark");
+  root.classList.add(resolved);
+  root.setAttribute("data-theme", resolved);
+}
+
+interface ThemeProviderProps {
+  children: React.ReactNode;
+  /** 預設值：未在 localStorage 找到時使用，預設 "system" */
+  defaultTheme?: Theme;
+}
+
+export function ThemeProvider({
+  children,
+  defaultTheme = "system",
+}: ThemeProviderProps) {
+  // SSR-safe lazy init：first render 用 defaultTheme，避免 hydration mismatch；
+  // 真正的 stored 值在 useEffect 內補。
+  const [theme, setThemeState] = React.useState<Theme>(defaultTheme);
+  const [resolvedTheme, setResolvedTheme] = React.useState<ResolvedTheme>("light");
+  const [storageAvailable, setStorageAvailable] = React.useState<boolean>(true);
+
+  // 掛載後從 localStorage 同步
+  React.useEffect(() => {
+    const { theme: stored, storageAvailable: ok } = readStoredTheme();
+    setStorageAvailable(ok);
+    setThemeState(stored);
+  }, []);
+
+  // 計算 resolvedTheme 並套用 class
+  React.useEffect(() => {
+    if (typeof window === "undefined") return;
+    const compute = () => {
+      const next: ResolvedTheme = theme === "system" ? getSystemTheme() : theme;
+      setResolvedTheme(next);
+      applyThemeClass(next);
+    };
+    compute();
+
+    // 若 theme=system，監聽 prefers-color-scheme 變化
+    if (theme === "system" && window.matchMedia) {
+      const mq = window.matchMedia("(prefers-color-scheme: dark)");
+      const handler = () => compute();
+      // 兼容舊版 Safari
+      if (mq.addEventListener) {
+        mq.addEventListener("change", handler);
+        return () => mq.removeEventListener("change", handler);
+      } else if (mq.addListener) {
+        mq.addListener(handler);
+        return () => mq.removeListener(handler);
+      }
+    }
+  }, [theme]);
+
+  const setTheme = React.useCallback((next: Theme) => {
+    setThemeState(next);
+    try {
+      window.localStorage.setItem(STORAGE_KEY, next);
+    } catch {
+      /* storage 被禁用：仍可運作，僅無法持久化 */
+    }
+  }, []);
+
+  const value = React.useMemo<ThemeContextValue>(
+    () => ({ theme, resolvedTheme, setTheme, storageAvailable }),
+    [theme, resolvedTheme, setTheme, storageAvailable],
+  );
+
+  return <ThemeContext.Provider value={value}>{children}</ThemeContext.Provider>;
+}
+
+export function useTheme(): ThemeContextValue {
+  const ctx = React.useContext(ThemeContext);
+  if (!ctx) {
+    throw new Error("useTheme must be used within <ThemeProvider>");
+  }
+  return ctx;
+}
+
+/** 內部 helpers 暴露給 unit test */
+export const __testing__ = {
+  STORAGE_KEY,
+  readStoredTheme,
+  getSystemTheme,
+  applyThemeClass,
+};

--- a/dev/frontend/components/theme/theme-script.tsx
+++ b/dev/frontend/components/theme/theme-script.tsx
@@ -1,0 +1,45 @@
+/**
+ * F-035 ThemeScript — 在第一次 paint 前同步套用 light/dark class，避免 FOUC。
+ *
+ * 注入策略：使用原生 <script> 並透過 dangerouslySetInnerHTML，因為 next/script
+ * 即使 strategy="beforeInteractive" 也會在 hydration 時執行，無法早於 paint。
+ *
+ * 行為：
+ *   1. 嘗試讀 localStorage.theme （可能為 "light" | "dark" | "system" | null）
+ *   2. 若禁用 localStorage（try/catch 捕獲），預設 system
+ *   3. system → 用 matchMedia('(prefers-color-scheme: dark)') 決定
+ *   4. 把對應 class 加到 <html>（'.dark' 或 '.light'）
+ *
+ * 注意：此 script 需 SSR 輸出 inline、放在 <head> 或 <body> 開頭。
+ */
+const themeInitScript = `
+(function () {
+  try {
+    var stored = null;
+    try { stored = window.localStorage.getItem('theme'); } catch (e) { stored = null; }
+    var theme = stored === 'light' || stored === 'dark' || stored === 'system' ? stored : 'system';
+    var resolved = theme;
+    if (theme === 'system') {
+      resolved = window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+    }
+    var root = document.documentElement;
+    root.classList.remove('light', 'dark');
+    root.classList.add(resolved);
+    root.setAttribute('data-theme', resolved);
+  } catch (e) {
+    /* 任何錯誤都靜默 fallback：什麼都不做，CSS 會以 prefers-color-scheme 為準 */
+  }
+})();
+`;
+
+export function ThemeScript() {
+  return (
+    <script
+      // eslint-disable-next-line react/no-danger
+      dangerouslySetInnerHTML={{ __html: themeInitScript }}
+    />
+  );
+}
+
+/** 匯出 raw script 字串供 unit test 驗證 */
+export const __THEME_INIT_SCRIPT__ = themeInitScript;

--- a/dev/frontend/components/theme/theme-toggle.tsx
+++ b/dev/frontend/components/theme/theme-toggle.tsx
@@ -1,0 +1,56 @@
+"use client";
+
+/**
+ * F-035 ThemeToggle — 使用 shadcn DropdownMenu 切換 light/dark/system。
+ *
+ * 此元件僅提供互動入口，不處理樣式 token；視覺由各 token 驅動。
+ */
+import * as React from "react";
+import { Moon, Sun, Monitor } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { useTheme } from "@/components/theme/theme-provider";
+
+export function ThemeToggle() {
+  const { theme, resolvedTheme, setTheme, storageAvailable } = useTheme();
+
+  const Icon = resolvedTheme === "dark" ? Moon : Sun;
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button
+          variant="ghost"
+          size="icon"
+          aria-label="切換主題"
+          title={
+            storageAvailable
+              ? `當前主題：${theme}`
+              : "localStorage 已停用，主題偏好無法保存"
+          }
+        >
+          <Icon className="h-4 w-4" />
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end">
+        <DropdownMenuItem onClick={() => setTheme("light")}>
+          <Sun className="mr-2 h-4 w-4" />
+          Light{theme === "light" ? " ✓" : ""}
+        </DropdownMenuItem>
+        <DropdownMenuItem onClick={() => setTheme("dark")}>
+          <Moon className="mr-2 h-4 w-4" />
+          Dark{theme === "dark" ? " ✓" : ""}
+        </DropdownMenuItem>
+        <DropdownMenuItem onClick={() => setTheme("system")}>
+          <Monitor className="mr-2 h-4 w-4" />
+          System{theme === "system" ? " ✓" : ""}
+        </DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}

--- a/dev/frontend/components/ui/sonner.tsx
+++ b/dev/frontend/components/ui/sonner.tsx
@@ -1,12 +1,12 @@
 "use client";
 
-import { useTheme } from "next-themes";
+import { useTheme } from "@/components/theme/theme-provider";
 import { Toaster as Sonner } from "sonner";
 
 type ToasterProps = React.ComponentProps<typeof Sonner>;
 
 const Toaster = ({ ...props }: ToasterProps) => {
-  const { theme = "system" } = useTheme();
+  const { theme } = useTheme();
   return (
     <Sonner
       theme={theme as ToasterProps["theme"]}

--- a/dev/frontend/lib/providers.tsx
+++ b/dev/frontend/lib/providers.tsx
@@ -2,10 +2,11 @@
 
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { ReactQueryDevtools } from "@tanstack/react-query-devtools";
-import { ThemeProvider } from "next-themes";
+import { ThemeProvider } from "@/components/theme/theme-provider";
 import { useRouter } from "next/navigation";
 import { useEffect, useState } from "react";
 import { toast } from "sonner";
+import { Toaster } from "@/components/ui/sonner";
 import { UNAUTHORIZED_EVENT } from "@/lib/api/client";
 
 export function Providers({ children }: { children: React.ReactNode }) {
@@ -35,9 +36,10 @@ export function Providers({ children }: { children: React.ReactNode }) {
   }, [router]);
 
   return (
-    <ThemeProvider attribute="class" defaultTheme="system" enableSystem>
+    <ThemeProvider defaultTheme="system">
       <QueryClientProvider client={client}>
         {children}
+        <Toaster />
         {process.env.NODE_ENV === "development" && <ReactQueryDevtools initialIsOpen={false} />}
       </QueryClientProvider>
     </ThemeProvider>

--- a/dev/frontend/tailwind.config.ts
+++ b/dev/frontend/tailwind.config.ts
@@ -16,9 +16,29 @@ const config: Config = {
     extend: {
       fontFamily: {
         sans: ["var(--font-sans)"],
+        serif: ["var(--font-serif)"],
         mono: ["var(--font-mono)"],
       },
       colors: {
+        /* === F-035 Editorial tokens === */
+        paper: {
+          DEFAULT: "var(--paper)",
+          2: "var(--paper-2)",
+          3: "var(--paper-3)",
+        },
+        surface: "var(--surface)",
+        ink: {
+          DEFAULT: "var(--ink)",
+          2: "var(--ink-2)",
+          3: "var(--ink-3)",
+          4: "var(--ink-4)",
+        },
+        rule: {
+          DEFAULT: "var(--rule)",
+          2: "var(--rule-2)",
+        },
+        "accent-soft": "var(--accent-soft)",
+        "accent-2": "var(--accent-2)",
         border: "hsl(var(--border))",
         input: "hsl(var(--input))",
         ring: "hsl(var(--ring))",
@@ -75,6 +95,27 @@ const config: Config = {
         lg: "var(--radius)",
         md: "calc(var(--radius) - 2px)",
         sm: "calc(var(--radius) - 4px)",
+        /* F-035 editorial radii */
+        "ed-sm": "var(--radius-sm)",
+        "ed-md": "var(--radius-md)",
+        "ed-lg": "var(--radius-lg)",
+        "ed-xl": "var(--radius-xl)",
+        pill: "var(--radius-pill)",
+      },
+      boxShadow: {
+        "ed-sm": "var(--shadow-sm)",
+        "ed-md": "var(--shadow-md)",
+        "ed-lg": "var(--shadow-lg)",
+        glow: "var(--accent-glow)",
+      },
+      zIndex: {
+        base: "var(--z-base)",
+        dropdown: "var(--z-dropdown)",
+        sticky: "var(--z-sticky)",
+        popover: "var(--z-popover)",
+        modal: "var(--z-modal)",
+        tooltip: "var(--z-tooltip)",
+        toast: "var(--z-toast)",
       },
       keyframes: {
         "accordion-down": {


### PR DESCRIPTION
Closes #192

## Summary
F-035 設計系統第一版：editorial「紙本」風格 design tokens 與 light/dark/system 主題系統。前端純樣式 + Provider，無 API/DB 變更。

## Changes
- `dev/frontend/app/globals.css` — 新增 editorial tokens（paper/ink/accent/rule/surface 系列）+ radii/shadow/z-index；保留 shadcn HSL 相容層；同時支援 `:root.dark` class 與 `@media (prefers-color-scheme: dark)`。
- `dev/frontend/app/layout.tsx` — 注入 `next/font`（Inter/Lora/JetBrains Mono）+ `<ThemeScript />` 於 `<head>` 內，避免 FOUC。
- `dev/frontend/components/theme/theme-provider.tsx` — 自製 ThemeProvider + `useTheme` hook（避免 next-themes lock-in），含 `storageAvailable`、prefers-color-scheme 監聽、SSR safe。
- `dev/frontend/components/theme/theme-script.tsx` — inline IIFE 在第一次 paint 前讀 localStorage / matchMedia 套用 class。
- `dev/frontend/components/theme/theme-toggle.tsx` — DropdownMenu 三選項（light/dark/system）+ 禁用 localStorage 警告 tooltip。
- `dev/frontend/components/app-header.tsx` / `components/ui/sonner.tsx` / `lib/providers.tsx` — 改用新的 `useTheme`。
- `dev/frontend/tailwind.config.ts` — 暴露 editorial color / radii / shadow / z-index utility。
- `dev/frontend/__tests__/components/theme/*.test.{ts,tsx}` — 新增 23 個 unit test。

## Scenario 覆蓋
- [x] 預設跟隨系統（無 stored + prefers-color-scheme=dark → resolvedTheme=dark）
- [x] 手動切換 light（localStorage 寫入 + html class 切換）
- [x] 重新載入保留偏好（localStorage.theme=light → 第一個 paint 即 light，無 dark flash — 由 ThemeScript 保證）
- [x] localStorage 被禁用 → 仍可運作 + storageAvailable=false + ThemeToggle 顯示警告 tooltip
- [x] theme=system 時系統 prefers-color-scheme 變化即時切換

## 測試
```
$ npx vitest run __tests__/components/theme/
PASS (23) FAIL (0)
```

3 個測試檔（theme-provider 9 cases、theme-script 7 cases、tokens.css 7 cases）全部通過。

## 備註
- spec 提到 `design/tokens/*.json` 為 source of truth，本 PR 先以手寫 CSS tokens 為主（一致對齊 spec 命名），後續可由 ui-designer / build pipeline 從 JSON 產生 CSS（CI 可加 lint 比對）。
- 仍保留 `next-themes` 依賴於 package.json，待後續 PR 移除（避免擴大 diff）。