### PR TITLE
test(e2e): Sprint 13 41 scenarios skeleton

### DIFF
--- a/test/browser/helpers/a11y.ts
+++ b/test/browser/helpers/a11y.ts
@@ -1,0 +1,82 @@
+/**
+ * a11y Helper - 基於 axe-core 的 accessibility 掃描
+ *
+ * 用法：
+ *   import { runA11yScan } from "../helpers/a11y";
+ *   const violations = await runA11yScan(page, { tags: ["wcag2a", "wcag2aa"] });
+ *   expect(violations.filter((v) => ["critical", "serious"].includes(v.impact ?? ""))).toEqual([]);
+ *
+ * 注意：require axe-core/playwright 為 dev dependency；測試前請先 `npm install`。
+ */
+
+import type { Page } from "@playwright/test";
+
+export interface A11yViolation {
+  id: string;
+  impact?: string | null;
+  description: string;
+  help: string;
+  helpUrl: string;
+  nodes: Array<{ html: string; target: string[] }>;
+}
+
+export interface A11yScanOptions {
+  tags?: string[];
+  include?: string[];
+  exclude?: string[];
+  /**
+   * 容許的 violation rule id（暫時 known issue 想跳過時使用，請附上 issue 連結）
+   */
+  allowlist?: string[];
+}
+
+/**
+ * 在當前 page 執行 axe-core 掃描，回傳 violations 陣列。
+ * 預設掃 wcag2a / wcag2aa。
+ */
+export async function runA11yScan(
+  page: Page,
+  opts: A11yScanOptions = {}
+): Promise<A11yViolation[]> {
+  // dynamic import 避免 axe-core 沒裝時 collect 階段就壞
+  const { AxeBuilder } = await import("@axe-core/playwright");
+  const tags = opts.tags ?? ["wcag2a", "wcag2aa", "wcag21a", "wcag21aa"];
+  let builder = new AxeBuilder({ page }).withTags(tags);
+  if (opts.include) {
+    for (const sel of opts.include) builder = builder.include(sel);
+  }
+  if (opts.exclude) {
+    for (const sel of opts.exclude) builder = builder.exclude(sel);
+  }
+  const result = await builder.analyze();
+  const violations = result.violations as unknown as A11yViolation[];
+  if (opts.allowlist?.length) {
+    return violations.filter((v) => !opts.allowlist!.includes(v.id));
+  }
+  return violations;
+}
+
+/**
+ * 嚴重度過濾：只回 critical / serious 級別的 violations
+ */
+export function filterCriticalSerious(violations: A11yViolation[]): A11yViolation[] {
+  return violations.filter((v) =>
+    v.impact === "critical" || v.impact === "serious"
+  );
+}
+
+/**
+ * 把 violations 格式化成易讀字串，附在 expect 失敗訊息上
+ */
+export function formatViolations(violations: A11yViolation[]): string {
+  if (!violations.length) return "(no violations)";
+  return violations
+    .map((v) => {
+      const targets = v.nodes
+        .slice(0, 3)
+        .map((n) => n.target.join(" "))
+        .join(" / ");
+      return `[${v.impact ?? "?"}] ${v.id}: ${v.help}\n  → ${targets}\n  ${v.helpUrl}`;
+    })
+    .join("\n\n");
+}

--- a/test/browser/helpers/cookie-auth.ts
+++ b/test/browser/helpers/cookie-auth.ts
@@ -1,0 +1,123 @@
+/**
+ * Cookie Session Auth Helper（F-039）
+ *
+ * 提供 Sprint 13 cookie session 認證流程：
+ * - loginWithCookie: POST /api/v1/auth/login → Set-Cookie aibo_session
+ * - logoutCookie: POST /api/v1/auth/logout
+ * - getMe: GET /api/v1/auth/me
+ * - 取得 cookie 屬性（HttpOnly / SameSite / Max-Age）
+ *
+ * 注意：使用 page.context().request 確保 cookie jar 共用，
+ * 後續 page.goto() 會自動帶上 aibo_session cookie。
+ */
+
+import type { Page, BrowserContext, APIRequestContext, Cookie } from "@playwright/test";
+
+const API_BASE_URL = process.env.API_BASE_URL || "http://localhost:8081";
+
+export const SESSION_COOKIE_NAME = "aibo_session";
+
+export interface LoginResult {
+  status: number;
+  body: unknown;
+  setCookieHeader?: string;
+  cookie?: Cookie;
+}
+
+/**
+ * 透過 master api key 登入並建立 cookie session。
+ * 使用 context.request 讓 cookie 寫入 BrowserContext jar，後續 page.goto 自動帶。
+ */
+export async function loginWithCookie(
+  context: BrowserContext,
+  apiKey: string,
+  baseURL: string = API_BASE_URL,
+): Promise<LoginResult> {
+  const resp = await context.request.post(`${baseURL}/api/v1/auth/login`, {
+    data: { api_key: apiKey },
+    headers: { "Content-Type": "application/json" },
+  });
+  const status = resp.status();
+  const body = status < 400 ? await resp.json().catch(() => null) : await resp.text();
+  const headers = resp.headers();
+  const setCookieHeader = headers["set-cookie"];
+  const cookies = await context.cookies();
+  const cookie = cookies.find((c) => c.name === SESSION_COOKIE_NAME);
+  return { status, body, setCookieHeader, cookie };
+}
+
+/**
+ * Logout：呼叫 /auth/logout 並驗證 cookie 已清除
+ */
+export async function logoutCookie(
+  context: BrowserContext,
+  baseURL: string = API_BASE_URL,
+): Promise<{ status: number }> {
+  const resp = await context.request.post(`${baseURL}/api/v1/auth/logout`);
+  return { status: resp.status() };
+}
+
+export async function getSessionCookie(
+  context: BrowserContext,
+): Promise<Cookie | undefined> {
+  const cookies = await context.cookies();
+  return cookies.find((c) => c.name === SESSION_COOKIE_NAME);
+}
+
+/**
+ * 強制把 session cookie expires 設成過去（測試 cookie 過期場景）
+ */
+export async function expireSessionCookie(context: BrowserContext): Promise<void> {
+  const cookies = await context.cookies();
+  const session = cookies.find((c) => c.name === SESSION_COOKIE_NAME);
+  if (!session) return;
+  await context.clearCookies({ name: SESSION_COOKIE_NAME });
+  await context.addCookies([
+    {
+      ...session,
+      expires: Math.floor(Date.now() / 1000) - 3600,
+    },
+  ]);
+}
+
+/**
+ * GET /api/v1/auth/me：回傳 { label, auth_method }
+ */
+export async function getMe(
+  request: APIRequestContext,
+  opts: { apiKey?: string; baseURL?: string } = {},
+): Promise<{ status: number; body: { label?: string; auth_method?: string } | string }> {
+  const baseURL = opts.baseURL ?? API_BASE_URL;
+  const headers: Record<string, string> = { "Content-Type": "application/json" };
+  if (opts.apiKey) headers["X-API-Key"] = opts.apiKey;
+  const resp = await request.get(`${baseURL}/api/v1/auth/me`, { headers });
+  const status = resp.status();
+  const body = status < 400 ? await resp.json().catch(() => null) : await resp.text();
+  return { status, body };
+}
+
+/**
+ * UI 流程：透過 /login 頁面填表單登入
+ *
+ * 假設 F-039 + F-036 的 /login 頁包含：
+ * - input[name="api_key"] 或 testid="login-api-key-input"
+ * - button[type="submit"] 或 testid="login-submit"
+ */
+export async function loginViaUI(
+  page: Page,
+  apiKey: string,
+  opts: { next?: string } = {},
+): Promise<void> {
+  const url = opts.next ? `/login?next=${encodeURIComponent(opts.next)}` : "/login";
+  await page.goto(url);
+  // 容錯：優先用 testid，fallback name
+  const input = page.getByTestId("login-api-key-input").or(
+    page.locator('input[name="api_key"]'),
+  );
+  await input.fill(apiKey);
+  const submit = page.getByTestId("login-submit").or(
+    page.locator('button[type="submit"]'),
+  );
+  await submit.click();
+  await page.waitForLoadState("networkidle");
+}

--- a/test/browser/helpers/theme.ts
+++ b/test/browser/helpers/theme.ts
@@ -1,0 +1,78 @@
+/**
+ * Theme Helper（F-035 Design Tokens / Theme System）
+ *
+ * 提供 light / dark / system 主題操作 + token 讀取。
+ */
+
+import type { Page, BrowserContext } from "@playwright/test";
+
+export type Theme = "light" | "dark" | "system";
+
+/**
+ * 在每個 document load 前注入 localStorage.theme。
+ * 必須在 page.goto 之前呼叫，避免初次 paint 取錯主題。
+ */
+export async function presetTheme(context: BrowserContext, theme: Theme): Promise<void> {
+  await context.addInitScript((t) => {
+    try {
+      window.localStorage.setItem("aibo_theme", t);
+    } catch {}
+  }, theme);
+}
+
+/**
+ * 透過 ThemeToggle 切換到指定主題（UI 流程）
+ *
+ * 假設 ThemeToggle 用 testid="theme-toggle" 觸發，下拉項目用
+ * testid="theme-option-light|dark|system"。
+ */
+export async function selectTheme(page: Page, theme: Theme): Promise<void> {
+  const toggle = page.getByTestId("theme-toggle");
+  await toggle.click();
+  const option = page.getByTestId(`theme-option-${theme}`);
+  await option.click();
+}
+
+export async function getHtmlTheme(page: Page): Promise<string | null> {
+  return page.evaluate(() => document.documentElement.getAttribute("data-theme"));
+}
+
+export async function getStoredTheme(page: Page): Promise<string | null> {
+  return page.evaluate(() => {
+    try {
+      return window.localStorage.getItem("aibo_theme");
+    } catch {
+      return null;
+    }
+  });
+}
+
+/**
+ * 從 :root 讀取 CSS variable（token 值）
+ */
+export async function getCssVar(page: Page, name: string): Promise<string> {
+  return page.evaluate((n) => {
+    return getComputedStyle(document.documentElement).getPropertyValue(n).trim();
+  }, name);
+}
+
+/**
+ * 取得元素的 computed background-color
+ */
+export async function getElementBg(page: Page, selector: string): Promise<string> {
+  return page.evaluate((sel) => {
+    const el = document.querySelector(sel);
+    if (!el) return "";
+    return getComputedStyle(el as Element).backgroundColor;
+  }, selector);
+}
+
+/**
+ * 模擬 prefers-color-scheme（依賴 Playwright emulateMedia）
+ */
+export async function emulateColorScheme(
+  page: Page,
+  scheme: "light" | "dark" | "no-preference",
+): Promise<void> {
+  await page.emulateMedia({ colorScheme: scheme === "no-preference" ? null : scheme });
+}

--- a/test/browser/specs/f035_design_tokens_theme.spec.ts
+++ b/test/browser/specs/f035_design_tokens_theme.spec.ts
@@ -1,0 +1,180 @@
+/**
+ * F-035: Design Tokens + Theme System
+ *
+ * Spec: specs/features/f035-design-tokens-theme.md
+ * Issue: #192
+ * QA Issue: #198
+ *
+ * 涵蓋 QA scenarios B-1 ~ B-6。
+ */
+
+import { test, expect } from "@playwright/test";
+import {
+  presetTheme,
+  selectTheme,
+  getHtmlTheme,
+  getStoredTheme,
+  getCssVar,
+  getElementBg,
+  emulateColorScheme,
+} from "../helpers/theme";
+import { loginWithCookie } from "../helpers/cookie-auth";
+
+test.describe("F-035 Design Tokens + Theme", () => {
+  test.beforeEach(async ({ context }) => {
+    await context.clearCookies();
+  });
+
+  test("B-1 預設跟隨系統：localStorage 無 theme + 系統 dark → data-theme=dark", async ({
+    page,
+    context,
+  }) => {
+    test.skip(true, "Wave 1 skeleton：等 F-035 inline theme script 實作");
+    await emulateColorScheme(page, "dark");
+    // 不預設 localStorage
+    await page.goto("/login");
+
+    const theme = await getHtmlTheme(page);
+    expect(theme).toBe("dark");
+
+    const bg = await getCssVar(page, "--bg");
+    expect(bg.length).toBeGreaterThan(0);
+    // 背景色實際值應對到 token --bg
+    const bodyBg = await getElementBg(page, "body");
+    expect(bodyBg.length).toBeGreaterThan(0);
+  });
+
+  test("B-2 手動切換 light：dark → ThemeToggle 選 Light → data-theme=light + localStorage", async ({
+    page,
+    context,
+  }) => {
+    test.skip(true, "Wave 1 skeleton：等 ThemeToggle 元件實作");
+    const apiKey = process.env.AIBO_E2E_API_KEY!;
+    await loginWithCookie(context, apiKey);
+    await emulateColorScheme(page, "dark");
+    await page.goto("/dashboard");
+
+    expect(await getHtmlTheme(page)).toBe("dark");
+
+    await selectTheme(page, "light");
+
+    expect(await getHtmlTheme(page)).toBe("light");
+    expect(await getStoredTheme(page)).toBe("light");
+  });
+
+  test("B-3 重新載入保留偏好：localStorage.theme=light → 第一個 paint 即為 light（無 dark flash）", async ({
+    page,
+    context,
+  }) => {
+    test.skip(true, "Wave 1 skeleton：等 inline blocking script 實作");
+    await presetTheme(context, "light");
+    await emulateColorScheme(page, "dark"); // 系統 dark 但偏好 light，應仍 light
+
+    await page.goto("/login");
+    expect(await getHtmlTheme(page)).toBe("light");
+
+    // 第一張畫面截圖，視覺迴歸基準（首次 run 自動產生 baseline）
+    await expect(page).toHaveScreenshot("f035-light-first-paint.png", {
+      maxDiffPixelRatio: 0.02,
+      timeout: 5000,
+    });
+  });
+
+  test("B-4 視窗中切換系統主題：theme=system → 系統 dark↔light → data-theme 即時切換", async ({
+    page,
+    context,
+  }) => {
+    test.skip(true, "Wave 1 skeleton：等 prefers-color-scheme media listener 實作");
+    await presetTheme(context, "system");
+    await emulateColorScheme(page, "light");
+    await page.goto("/login");
+    expect(await getHtmlTheme(page)).toBe("light");
+
+    await emulateColorScheme(page, "dark");
+    await expect(async () => {
+      expect(await getHtmlTheme(page)).toBe("dark");
+    }).toPass({ timeout: 2000 });
+  });
+
+  test("B-5 localStorage 禁用：app 仍可用，預設 system，ThemeToggle 顯示警告", async ({
+    page,
+    context,
+  }) => {
+    test.skip(true, "Wave 1 skeleton：localStorage 禁用 fallback 行為");
+    // 在 init script 內把 localStorage 禁掉
+    await context.addInitScript(() => {
+      const broken = {
+        getItem() {
+          throw new Error("disabled");
+        },
+        setItem() {
+          throw new Error("disabled");
+        },
+        removeItem() {
+          throw new Error("disabled");
+        },
+        key() {
+          return null;
+        },
+        clear() {},
+        length: 0,
+      };
+      Object.defineProperty(window, "localStorage", { get: () => broken });
+    });
+
+    await emulateColorScheme(page, "light");
+    await page.goto("/login");
+
+    expect(await getHtmlTheme(page)).toMatch(/light|dark/);
+
+    // ThemeToggle 應有 warning indicator
+    const toggle = page.getByTestId("theme-toggle");
+    await expect(toggle).toBeVisible();
+    await toggle.hover();
+    await expect(
+      page.getByText(/localStorage|偏好無法儲存|warning/i).first(),
+    ).toBeVisible({ timeout: 2000 });
+  });
+
+  test("B-6 Token 視覺一致：Button / Card / Badge computed bg 與 token 對齊", async ({
+    page,
+    context,
+  }) => {
+    test.skip(true, "Wave 2 skeleton：等 /dev/playground 元件展示頁實作");
+    const apiKey = process.env.AIBO_E2E_API_KEY!;
+    await loginWithCookie(context, apiKey);
+    await page.goto("/dev/playground");
+
+    const checks: Array<{ selector: string; tokenVar: string; label: string }> = [
+      {
+        selector: '[data-testid="demo-button-default"]',
+        tokenVar: "--accent",
+        label: "Button default",
+      },
+      {
+        selector: '[data-testid="demo-button-danger"]',
+        tokenVar: "--danger",
+        label: "Button danger",
+      },
+      {
+        selector: '[data-testid="demo-card"]',
+        tokenVar: "--bg-subtle",
+        label: "Card",
+      },
+      {
+        selector: '[data-testid="demo-badge"]',
+        tokenVar: "--accent",
+        label: "Badge",
+      },
+    ];
+
+    for (const c of checks) {
+      const tokenValue = await getCssVar(page, c.tokenVar);
+      const computedBg = await getElementBg(page, c.selector);
+      expect(tokenValue, `${c.label}: token ${c.tokenVar} 應有值`).not.toBe("");
+      expect(computedBg, `${c.label}: bg 應有值`).not.toBe("");
+      // token 與實際背景色，無法直接字串比對（一個是 OKLCH，一個被 browser 轉為 rgb）
+      // 改用 quasi check：兩者其一非空即視為通過 + 由視覺迴歸把關
+    }
+  });
+});

--- a/test/browser/specs/f036_app_shell_routing.spec.ts
+++ b/test/browser/specs/f036_app_shell_routing.spec.ts
@@ -1,0 +1,178 @@
+/**
+ * F-036: App Shell + Hybrid Routing
+ *
+ * Spec: specs/features/f036-app-shell-routing.md
+ * Issue: #195
+ * QA Issue: #198
+ *
+ * 涵蓋 QA scenarios C-1 ~ C-9。
+ */
+
+import { test, expect } from "@playwright/test";
+import { loginWithCookie, expireSessionCookie } from "../helpers/cookie-auth";
+
+const API_BASE_URL = process.env.API_BASE_URL || "http://localhost:8081";
+
+test.describe("F-036 App Shell + Parallel Routes", () => {
+  test.beforeEach(async ({ context }) => {
+    await context.clearCookies();
+  });
+
+  test("C-1 Dashboard 4 slot 並排：inbox/library/today/copilot 皆渲染", async ({
+    page,
+    context,
+  }) => {
+    test.skip(true, "Wave 2 skeleton：等 /dashboard parallel routes 實作");
+    const apiKey = process.env.AIBO_E2E_API_KEY!;
+    await loginWithCookie(context, apiKey);
+    await page.goto("/dashboard");
+
+    for (const slot of ["inbox", "library", "today", "copilot"]) {
+      await expect(page.getByTestId(`slot-${slot}`)).toBeVisible();
+    }
+  });
+
+  test("C-2 slot 之一失敗不影響其他：mock /entries?inbox=1 → 503，inbox slot 顯示 ErrorCard", async ({
+    page,
+    context,
+  }) => {
+    test.skip(true, "Wave 2 skeleton：parallel error boundary 實作");
+    const apiKey = process.env.AIBO_E2E_API_KEY!;
+    await loginWithCookie(context, apiKey);
+
+    await page.route("**/api/v1/entries**inbox=1**", (route) =>
+      route.fulfill({ status: 503, body: JSON.stringify({ error: "down" }) }),
+    );
+    await page.goto("/dashboard");
+
+    await expect(page.getByTestId("slot-inbox-error")).toBeVisible();
+    await expect(page.getByTestId("slot-inbox-retry")).toBeVisible();
+    // 其他三 slot 不受影響
+    for (const slot of ["library", "today", "copilot"]) {
+      await expect(page.getByTestId(`slot-${slot}`)).toBeVisible();
+    }
+  });
+
+  test("C-3 點 retry 重試成功：mock 改回 200 → slot 恢復", async ({ page, context }) => {
+    test.skip(true, "Wave 2 skeleton：retry 行為");
+    const apiKey = process.env.AIBO_E2E_API_KEY!;
+    await loginWithCookie(context, apiKey);
+
+    let calls = 0;
+    await page.route("**/api/v1/entries**inbox=1**", (route) => {
+      calls++;
+      if (calls < 2) {
+        route.fulfill({ status: 503, body: "{}" });
+      } else {
+        route.continue();
+      }
+    });
+
+    await page.goto("/dashboard");
+    await page.getByTestId("slot-inbox-retry").click();
+
+    await expect(page.getByTestId("slot-inbox-error")).toBeHidden();
+    await expect(page.getByTestId("slot-inbox")).toBeVisible();
+  });
+
+  test("C-4 深連結 /library 直達：未經 /dashboard，shell + library 內容", async ({
+    page,
+    context,
+  }) => {
+    test.skip(true, "Wave 2 skeleton：deep-link 直達");
+    const apiKey = process.env.AIBO_E2E_API_KEY!;
+    await loginWithCookie(context, apiKey);
+
+    await page.goto("/library");
+    await expect(page).toHaveURL(/\/library$/);
+    await expect(page.getByTestId("app-sidebar")).toBeVisible();
+    await expect(page.getByTestId("library-page")).toBeVisible();
+  });
+
+  test("C-5 Sidebar 不重 mount：/dashboard → /library，sidebar DOM 同一 instance", async ({
+    page,
+    context,
+  }) => {
+    test.skip(true, "Wave 2 skeleton：layout 不重渲染");
+    const apiKey = process.env.AIBO_E2E_API_KEY!;
+    await loginWithCookie(context, apiKey);
+
+    await page.goto("/dashboard");
+    const sidebar = page.getByTestId("app-sidebar");
+    await expect(sidebar).toBeVisible();
+
+    // 注入 marker 到 sidebar DOM
+    const markerBefore = await sidebar.evaluate((el) => {
+      (el as HTMLElement).dataset.aiboMountMarker = "marker-1";
+      return (el as HTMLElement).dataset.aiboMountMarker;
+    });
+
+    await page.getByTestId("nav-library").click();
+    await expect(page).toHaveURL(/\/library/);
+
+    // marker 仍應存在（DOM 沒被 unmount）
+    const markerAfter = await page.getByTestId("app-sidebar").evaluate(
+      (el) => (el as HTMLElement).dataset.aiboMountMarker,
+    );
+    expect(markerAfter).toBe(markerBefore);
+  });
+
+  test("C-6 未登入存取受保護路由：清 cookie → /library → /login?next=/library，登入後回 /library", async ({
+    page,
+    context,
+  }) => {
+    test.skip(true, "Wave 2 skeleton：等 /login 頁面 + 守衛實作");
+    await context.clearCookies();
+    await page.goto("/library");
+    await expect(page).toHaveURL(/\/login\?next=%2Flibrary/);
+
+    const apiKey = process.env.AIBO_E2E_API_KEY!;
+    await page.getByTestId("login-api-key-input").fill(apiKey);
+    await page.getByTestId("login-submit").click();
+
+    await expect(page).toHaveURL(/\/library/);
+  });
+
+  test("C-7 Sidebar 收合持久化：toggle → reload → 仍收合", async ({ page, context }) => {
+    test.skip(true, "Wave 2 skeleton：等 SidebarToggle 實作");
+    const apiKey = process.env.AIBO_E2E_API_KEY!;
+    await loginWithCookie(context, apiKey);
+    await page.goto("/dashboard");
+
+    const sidebar = page.getByTestId("app-sidebar");
+    await page.getByTestId("sidebar-toggle").click();
+    await expect(sidebar).toHaveAttribute("data-collapsed", "true");
+
+    await page.reload();
+    await expect(sidebar).toHaveAttribute("data-collapsed", "true");
+  });
+
+  test("C-8 default.tsx 存在：直接訪問 /inbox 不會 404", async ({ page, context }) => {
+    test.skip(true, "Wave 2 skeleton：parallel routes default.tsx 檢查");
+    const apiKey = process.env.AIBO_E2E_API_KEY!;
+    await loginWithCookie(context, apiKey);
+
+    for (const path of ["/inbox", "/library", "/today", "/copilot"]) {
+      const resp = await page.goto(path);
+      expect(resp?.status(), `${path} 應 200`).toBeLessThan(400);
+      await expect(page).toHaveURL(new RegExp(path + "$"));
+    }
+  });
+
+  test("C-9 Theme 在所有 shell 頁面一致：切 theme 後跨頁保持", async ({ page, context }) => {
+    test.skip(true, "Wave 2 skeleton：theme + shell 整合");
+    const apiKey = process.env.AIBO_E2E_API_KEY!;
+    await loginWithCookie(context, apiKey);
+    await page.goto("/dashboard");
+
+    // 切到 dark
+    await page.getByTestId("theme-toggle").click();
+    await page.getByTestId("theme-option-dark").click();
+    await expect(page.locator("html")).toHaveAttribute("data-theme", "dark");
+
+    for (const path of ["/library", "/today", "/dashboard"]) {
+      await page.goto(path);
+      await expect(page.locator("html")).toHaveAttribute("data-theme", "dark");
+    }
+  });
+});

--- a/test/browser/specs/f037_command_palette.spec.ts
+++ b/test/browser/specs/f037_command_palette.spec.ts
@@ -1,0 +1,204 @@
+/**
+ * F-037: Command Palette (CmdK) Skeleton
+ *
+ * Spec: specs/features/f037-command-palette-skeleton.md
+ * Issue: #196
+ * QA Issue: #198
+ *
+ * 涵蓋 QA scenarios E-1 ~ E-9。
+ */
+
+import { test, expect } from "@playwright/test";
+import { loginWithCookie } from "../helpers/cookie-auth";
+
+const isMac = process.platform === "darwin";
+const META = isMac ? "Meta" : "Control";
+
+test.describe("F-037 Command Palette", () => {
+  test.beforeEach(async ({ context }) => {
+    await context.clearCookies();
+  });
+
+  test("E-1 ⌘K 開啟：palette 顯示 + input 取得焦點", async ({ page, context }) => {
+    test.skip(true, "Wave 3 skeleton：等 CmdK 元件實作");
+    const apiKey = process.env.AIBO_E2E_API_KEY!;
+    await loginWithCookie(context, apiKey);
+    await page.goto("/dashboard");
+
+    await page.keyboard.press(`${META}+KeyK`);
+    const palette = page.getByTestId("cmdk-palette");
+    await expect(palette).toBeVisible();
+
+    const focused = await page.evaluate(() =>
+      document.activeElement?.getAttribute("data-testid"),
+    );
+    expect(focused).toBe("cmdk-input");
+  });
+
+  test("E-2 Ctrl+K 在非 Mac 開啟（強制使用 Control）", async ({ page, context }) => {
+    test.skip(true, "Wave 3 skeleton");
+    const apiKey = process.env.AIBO_E2E_API_KEY!;
+    await loginWithCookie(context, apiKey);
+    await page.goto("/dashboard");
+
+    await page.keyboard.press("Control+KeyK");
+    await expect(page.getByTestId("cmdk-palette")).toBeVisible();
+  });
+
+  test("E-3 Esc 關閉 + 焦點回到 trigger button", async ({ page, context }) => {
+    test.skip(true, "Wave 3 skeleton");
+    const apiKey = process.env.AIBO_E2E_API_KEY!;
+    await loginWithCookie(context, apiKey);
+    await page.goto("/dashboard");
+
+    const trigger = page.getByTestId("cmdk-trigger");
+    await trigger.focus();
+    await trigger.click();
+    await expect(page.getByTestId("cmdk-palette")).toBeVisible();
+
+    await page.keyboard.press("Escape");
+    await expect(page.getByTestId("cmdk-palette")).toBeHidden();
+
+    const focused = await page.evaluate(() =>
+      document.activeElement?.getAttribute("data-testid"),
+    );
+    expect(focused).toBe("cmdk-trigger");
+  });
+
+  test("E-4 Pages 分組：預設顯示 Pages（5 nav items）+ Quick Actions", async ({
+    page,
+    context,
+  }) => {
+    test.skip(true, "Wave 3 skeleton");
+    const apiKey = process.env.AIBO_E2E_API_KEY!;
+    await loginWithCookie(context, apiKey);
+    await page.goto("/dashboard");
+    await page.keyboard.press(`${META}+KeyK`);
+
+    const pagesGroup = page.getByTestId("cmdk-group-pages");
+    await expect(pagesGroup).toBeVisible();
+    const items = pagesGroup.locator('[role="option"]');
+    expect(await items.count()).toBeGreaterThanOrEqual(5);
+
+    await expect(page.getByTestId("cmdk-group-quick-actions")).toBeVisible();
+  });
+
+  test("E-5 搜尋 entry 200ms debounce", async ({ page, context }) => {
+    test.skip(true, "Wave 3 skeleton：等 entries 搜尋整合");
+    const apiKey = process.env.AIBO_E2E_API_KEY!;
+    await loginWithCookie(context, apiKey);
+    await page.goto("/dashboard");
+    await page.keyboard.press(`${META}+KeyK`);
+
+    let requestCount = 0;
+    let firstRequestAt: number | null = null;
+    page.on("request", (req) => {
+      const url = req.url();
+      if (url.includes("/api/v1/entries") && url.includes("q=")) {
+        requestCount++;
+        if (firstRequestAt === null) firstRequestAt = Date.now();
+      }
+    });
+
+    const startedAt = Date.now();
+    const input = page.getByTestId("cmdk-input");
+    // 連續快速輸入 → 應只觸發一次請求（debounce）
+    await input.type("go interface", { delay: 30 });
+
+    await page.waitForTimeout(500);
+    expect(requestCount).toBeGreaterThanOrEqual(1);
+    expect(requestCount).toBeLessThan(5);
+    expect(firstRequestAt! - startedAt).toBeGreaterThan(150);
+  });
+
+  test("E-6 點選 entry → navigate /library/{id}", async ({ page, context }) => {
+    test.skip(true, "Wave 3 skeleton：等 cmdk → /library deep link");
+    const apiKey = process.env.AIBO_E2E_API_KEY!;
+    const { client } = await (
+      await import("../helpers/api-client")
+    ).ApiClient.bootstrap(page.request, "cmdk-test");
+    const entry = await client.createEntry({
+      title: "go interface 測試 entry",
+      content: "search target",
+    });
+
+    await loginWithCookie(context, apiKey);
+    await page.goto("/dashboard");
+    await page.keyboard.press(`${META}+KeyK`);
+    await page.getByTestId("cmdk-input").type("go interface");
+
+    await page.waitForTimeout(300);
+    const result = page.getByTestId(`cmdk-entry-${entry.id}`);
+    await expect(result).toBeVisible();
+    await result.click();
+
+    await expect(page).toHaveURL(new RegExp(`/library/${entry.id}`));
+  });
+
+  test("E-7 切頁面：輸入 'library' → Pages → Enter → /library", async ({
+    page,
+    context,
+  }) => {
+    test.skip(true, "Wave 3 skeleton");
+    const apiKey = process.env.AIBO_E2E_API_KEY!;
+    await loginWithCookie(context, apiKey);
+    await page.goto("/dashboard");
+    await page.keyboard.press(`${META}+KeyK`);
+
+    await page.getByTestId("cmdk-input").type("library");
+    await page.keyboard.press("Enter");
+
+    await expect(page).toHaveURL(/\/library$/);
+  });
+
+  test("E-8 API 503 graceful：palette 仍開啟，Recent Entries 顯示『搜尋暫時不可用』", async ({
+    page,
+    context,
+  }) => {
+    test.skip(true, "Wave 3 skeleton");
+    const apiKey = process.env.AIBO_E2E_API_KEY!;
+    await loginWithCookie(context, apiKey);
+
+    await page.route("**/api/v1/entries**q=**", (route) =>
+      route.fulfill({ status: 503, body: '{"error":"down"}' }),
+    );
+
+    await page.goto("/dashboard");
+    await page.keyboard.press(`${META}+KeyK`);
+    await page.getByTestId("cmdk-input").type("anything");
+
+    await expect(page.getByTestId("cmdk-palette")).toBeVisible();
+    await expect(
+      page.getByText(/搜尋暫時不可用|search unavailable/i),
+    ).toBeVisible();
+  });
+
+  test("E-9 IME 組字 isComposing=true 按 Enter → palette 不關閉、不執行", async ({
+    page,
+    context,
+  }) => {
+    test.skip(true, "Wave 3 skeleton：CompositionEvent 模擬");
+    const apiKey = process.env.AIBO_E2E_API_KEY!;
+    await loginWithCookie(context, apiKey);
+    await page.goto("/dashboard");
+    await page.keyboard.press(`${META}+KeyK`);
+
+    const palette = page.getByTestId("cmdk-palette");
+    await expect(palette).toBeVisible();
+
+    const inputSelector = '[data-testid="cmdk-input"]';
+    await page.evaluate((sel) => {
+      const input = document.querySelector(sel) as HTMLInputElement;
+      input.focus();
+      input.dispatchEvent(new CompositionEvent("compositionstart"));
+      // isComposing=true 期間發 Enter
+      input.dispatchEvent(
+        new KeyboardEvent("keydown", { key: "Enter", isComposing: true, bubbles: true }),
+      );
+    }, inputSelector);
+
+    await expect(palette).toBeVisible();
+    // URL 不應變動
+    expect(page.url()).toMatch(/\/dashboard/);
+  });
+});

--- a/test/browser/specs/f038_shadcn_primitives.spec.ts
+++ b/test/browser/specs/f038_shadcn_primitives.spec.ts
@@ -1,0 +1,141 @@
+/**
+ * F-038: shadcn primitives + a11y
+ *
+ * Spec: specs/features/f038-shadcn-primitives.md
+ * Issue: #193
+ * QA Issue: #198
+ *
+ * 涵蓋 QA scenarios D-1 ~ D-6（含 axe-core a11y 掃描）。
+ *
+ * 假設 dev 環境提供 /dev/playground 頁展示所有 primitive，containing：
+ * - testid="demo-dialog-trigger" / "demo-dialog"
+ * - testid="demo-toast-success-trigger"
+ * - testid="demo-tooltip-target"
+ * - testid="demo-button-danger"
+ * - testid="demo-dropdown-trigger"
+ */
+
+import { test, expect } from "@playwright/test";
+import { loginWithCookie } from "../helpers/cookie-auth";
+import { runA11yScan, filterCriticalSerious, formatViolations } from "../helpers/a11y";
+import { getCssVar, getElementBg } from "../helpers/theme";
+
+test.describe("F-038 shadcn Primitives", () => {
+  test.beforeEach(async ({ context }) => {
+    await context.clearCookies();
+  });
+
+  test("D-1 Dialog Esc 關閉 + 焦點返回觸發按鈕", async ({ page, context }) => {
+    test.skip(true, "Wave 2 skeleton：等 Dialog primitive 實作");
+    const apiKey = process.env.AIBO_E2E_API_KEY!;
+    await loginWithCookie(context, apiKey);
+    await page.goto("/dev/playground");
+
+    const trigger = page.getByTestId("demo-dialog-trigger");
+    await trigger.focus();
+    await trigger.click();
+
+    const dialog = page.getByTestId("demo-dialog");
+    await expect(dialog).toBeVisible();
+
+    await page.keyboard.press("Escape");
+    await expect(dialog).toBeHidden();
+
+    // 焦點回到 trigger
+    const focused = await page.evaluate(() => document.activeElement?.getAttribute("data-testid"));
+    expect(focused).toBe("demo-dialog-trigger");
+  });
+
+  test("D-2 Toast 自動消失 5 秒；hover 暫停倒數", async ({ page, context }) => {
+    test.skip(true, "Wave 2 skeleton：等 sonner toast 整合");
+    const apiKey = process.env.AIBO_E2E_API_KEY!;
+    await loginWithCookie(context, apiKey);
+    await page.goto("/dev/playground");
+
+    await page.getByTestId("demo-toast-success-trigger").click();
+    const toast = page.locator("[data-sonner-toast]").first();
+    await expect(toast).toBeVisible();
+
+    // hover 期間不應消失
+    await toast.hover();
+    await page.waitForTimeout(3000);
+    await expect(toast).toBeVisible();
+
+    // 移開 hover 後等待 ~5s 消失
+    await page.mouse.move(0, 0);
+    await expect(toast).toBeHidden({ timeout: 8000 });
+  });
+
+  test("D-3 Tooltip 500ms delay 顯示", async ({ page, context }) => {
+    test.skip(true, "Wave 2 skeleton：等 Tooltip primitive 實作");
+    const apiKey = process.env.AIBO_E2E_API_KEY!;
+    await loginWithCookie(context, apiKey);
+    await page.goto("/dev/playground");
+
+    const target = page.getByTestId("demo-tooltip-target");
+    await target.hover();
+
+    // 600ms 後 tooltip 才出現
+    await page.waitForTimeout(600);
+    await expect(page.locator('[role="tooltip"]').first()).toBeVisible();
+  });
+
+  test("D-4 Button danger variant：bg = --danger token", async ({ page, context }) => {
+    test.skip(true, "Wave 2 skeleton：等 Button 自寫元件");
+    const apiKey = process.env.AIBO_E2E_API_KEY!;
+    await loginWithCookie(context, apiKey);
+    await page.goto("/dev/playground");
+
+    const dangerBg = await getElementBg(page, '[data-testid="demo-button-danger"]');
+    const tokenDanger = await getCssVar(page, "--danger");
+    expect(dangerBg, "danger button bg 應有值").not.toBe("");
+    expect(tokenDanger, "--danger token 應有值").not.toBe("");
+    // 不字串比對（OKLCH vs rgb），由視覺迴歸把關精確值
+  });
+
+  test("D-5 DropdownMenu 鍵盤導航：↓↑ 切換、Enter 選擇", async ({ page, context }) => {
+    test.skip(true, "Wave 2 skeleton：等 DropdownMenu primitive 實作");
+    const apiKey = process.env.AIBO_E2E_API_KEY!;
+    await loginWithCookie(context, apiKey);
+    await page.goto("/dev/playground");
+
+    const trigger = page.getByTestId("demo-dropdown-trigger");
+    await trigger.focus();
+    await trigger.press("Enter");
+
+    await expect(page.locator('[role="menu"]').first()).toBeVisible();
+    await page.keyboard.press("ArrowDown");
+    await page.keyboard.press("ArrowDown");
+    await page.keyboard.press("Enter");
+
+    // 預期觸發某個 demo action（用 toast 或 data 屬性驗證）
+    await expect(page.getByTestId("demo-dropdown-result")).toContainText(/item-?2/i);
+  });
+
+  test("D-6 a11y 掃描：/login + /dashboard，critical/serious 違規 = 0", async ({
+    page,
+    context,
+  }) => {
+    test.skip(true, "Wave 4 skeleton：等 /login + /dashboard 完整實作後再掃");
+    const apiKey = process.env.AIBO_E2E_API_KEY!;
+
+    // /login
+    await page.goto("/login");
+    let violations = await runA11yScan(page);
+    let blockers = filterCriticalSerious(violations);
+    expect(
+      blockers,
+      `/login a11y violations:\n${formatViolations(blockers)}`,
+    ).toEqual([]);
+
+    // /dashboard（需登入）
+    await loginWithCookie(context, apiKey);
+    await page.goto("/dashboard");
+    violations = await runA11yScan(page);
+    blockers = filterCriticalSerious(violations);
+    expect(
+      blockers,
+      `/dashboard a11y violations:\n${formatViolations(blockers)}`,
+    ).toEqual([]);
+  });
+});

--- a/test/browser/specs/f039_cookie_auth.spec.ts
+++ b/test/browser/specs/f039_cookie_auth.spec.ts
@@ -1,0 +1,227 @@
+/**
+ * F-039: Cookie Session Auth + API Client + SSE
+ *
+ * Spec: specs/features/f039-api-sse-auth.md
+ * Issue: #194
+ * QA Issue: #198
+ *
+ * 涵蓋 Sprint 13 QA scenarios A-1 ~ A-9 + F-1 ~ F-2。
+ *
+ * 注意：Sprint 13 起前端從「localStorage api_key」遷移到「cookie session」。
+ * 本檔測試新流程（cookie），舊流程仍由 f021 等 spec 涵蓋（待 engineer 完成 F-036/F-039 後一併修正）。
+ */
+
+import { test, expect } from "@playwright/test";
+import {
+  loginWithCookie,
+  loginViaUI,
+  logoutCookie,
+  getSessionCookie,
+  expireSessionCookie,
+  getMe,
+  SESSION_COOKIE_NAME,
+} from "../helpers/cookie-auth";
+
+const API_BASE_URL = process.env.API_BASE_URL || "http://localhost:8081";
+
+test.describe("F-039 Cookie Session Auth", () => {
+  test.beforeEach(async ({ context }) => {
+    // 確保乾淨 cookie jar
+    await context.clearCookies();
+  });
+
+  test("A-1 登入成功：未登入訪問 /library → redirect /login?next=/library，登入後回 /library", async ({
+    page,
+    context,
+  }) => {
+    test.skip(true, "Wave 1 skeleton：等 F-036 /library 路由 + F-039 /login 頁完成");
+    const apiKey = process.env.AIBO_E2E_API_KEY!;
+    expect(apiKey, "需要 shared key").toBeTruthy();
+
+    await page.goto("/library");
+    await expect(page).toHaveURL(/\/login\?next=%2Flibrary/);
+
+    await loginViaUI(page, apiKey, { next: "/library" });
+
+    await expect(page).toHaveURL(/\/library/);
+    const cookie = await getSessionCookie(context);
+    expect(cookie?.name).toBe(SESSION_COOKIE_NAME);
+  });
+
+  test("A-2 登入失敗：錯誤 api_key → 顯示錯誤訊息（INVALID_API_KEY），仍在 /login", async ({
+    page,
+  }) => {
+    test.skip(true, "Wave 1 skeleton：等 /login 頁面實作");
+    await page.goto("/login");
+    await loginViaUI(page, "wrong-key-xxx");
+
+    await expect(page).toHaveURL(/\/login/);
+    await expect(
+      page.getByText(/INVALID_API_KEY|API Key 不正確|登入失敗/i),
+    ).toBeVisible();
+  });
+
+  test("A-3 登入限流：同 IP 連 5 次失敗 → 第 6 次回 429", async ({ context }) => {
+    test.skip(true, "Wave 1 skeleton：429 rate limit 需在 backend 實作完成後跑");
+    const wrongs = Array.from({ length: 6 }, () => loginWithCookie(context, "definitely-wrong"));
+    const results = await Promise.all(wrongs);
+    const last = results[results.length - 1];
+    expect([401, 429]).toContain(last.status);
+    // 至少其中一個應為 429
+    expect(results.some((r) => r.status === 429)).toBeTruthy();
+  });
+
+  test("A-4 cookie 屬性正確：HttpOnly / SameSite=Lax / Path=/ / Max-Age 約 30 天", async ({
+    context,
+  }) => {
+    test.skip(true, "Wave 1 skeleton：等 /auth/login 後端實作");
+    const apiKey = process.env.AIBO_E2E_API_KEY!;
+    const res = await loginWithCookie(context, apiKey);
+    expect(res.status).toBe(200);
+
+    const cookie = res.cookie;
+    expect(cookie).toBeDefined();
+    expect(cookie!.name).toBe(SESSION_COOKIE_NAME);
+    expect(cookie!.httpOnly).toBe(true);
+    expect(cookie!.sameSite).toMatch(/Lax/i);
+    expect(cookie!.path).toBe("/");
+
+    // expires_at 應在 ~30 天後（容忍 ±1 天）
+    const now = Date.now() / 1000;
+    const days = (cookie!.expires - now) / 86400;
+    expect(days).toBeGreaterThan(28);
+    expect(days).toBeLessThan(32);
+  });
+
+  test("A-5 logout：UserMenu → Logout → cookie 清除 + redirect /login", async ({
+    page,
+    context,
+  }) => {
+    test.skip(true, "Wave 1 skeleton：等 UserMenu 元件 + /auth/logout 實作");
+    const apiKey = process.env.AIBO_E2E_API_KEY!;
+    await loginWithCookie(context, apiKey);
+    await page.goto("/dashboard");
+
+    await page.getByTestId("user-menu-trigger").click();
+    await page.getByTestId("user-menu-logout").click();
+
+    await expect(page).toHaveURL(/\/login/);
+    const cookie = await getSessionCookie(context);
+    expect(cookie).toBeUndefined();
+  });
+
+  test("A-6 滑動續期：mock expires_at 為 5 天後 → API 請求後 Max-Age 重設", async ({
+    context,
+  }) => {
+    test.skip(
+      true,
+      "Wave 4 skeleton：需要 test-api 提供 __test/sessions/expire-soon endpoint 才能 mock",
+    );
+    const apiKey = process.env.AIBO_E2E_API_KEY!;
+    await loginWithCookie(context, apiKey);
+
+    // 透過 test-only endpoint 將 sessions.expires_at 設為 5 天後
+    await context.request.post(`${API_BASE_URL}/api/v1/__test/sessions/expire-soon`, {
+      data: { days: 5 },
+    });
+
+    // 任一請求觸發續期
+    await context.request.get(`${API_BASE_URL}/api/v1/entries`);
+
+    const cookie = await getSessionCookie(context);
+    const days = (cookie!.expires - Date.now() / 1000) / 86400;
+    expect(days).toBeGreaterThan(28);
+  });
+
+  test("A-7 cookie 過期：expires_at 設為過去 → 請求 /entries → 401，前端 redirect /login", async ({
+    page,
+    context,
+  }) => {
+    test.skip(true, "Wave 1 skeleton：等前端 401 攔截邏輯實作");
+    const apiKey = process.env.AIBO_E2E_API_KEY!;
+    await loginWithCookie(context, apiKey);
+
+    await expireSessionCookie(context);
+
+    await page.goto("/library");
+    await expect(page).toHaveURL(/\/login/);
+  });
+
+  test("A-8 X-API-Key 仍可用（無 cookie）→ 200", async ({ request, context }) => {
+    test.skip(true, "Wave 1 skeleton：等 /auth/me 實作");
+    await context.clearCookies();
+    const apiKey = process.env.AIBO_E2E_API_KEY!;
+
+    const res = await request.get(`${API_BASE_URL}/api/v1/entries`, {
+      headers: { "X-API-Key": apiKey },
+    });
+    expect(res.status()).toBe(200);
+
+    const me = await getMe(request, { apiKey });
+    expect(me.status).toBe(200);
+    expect((me.body as any)?.auth_method).toBe("api_key");
+  });
+
+  test("A-9 同時帶 cookie + X-API-Key → 後端優先 cookie（auth_method=cookie）", async ({
+    context,
+  }) => {
+    test.skip(true, "Wave 1 skeleton：等 middleware 雙模式實作");
+    const apiKey = process.env.AIBO_E2E_API_KEY!;
+    await loginWithCookie(context, apiKey);
+
+    const resp = await context.request.get(`${API_BASE_URL}/api/v1/auth/me`, {
+      headers: { "X-API-Key": apiKey },
+    });
+    expect(resp.status()).toBe(200);
+    const body = await resp.json();
+    expect(body.auth_method).toBe("cookie");
+  });
+});
+
+test.describe("F-039 SSE Client（cookie 帶上）", () => {
+  test("F-1 EventSource 帶 cookie → 後端認證通過", async ({ page, context }) => {
+    test.skip(true, "Wave 4 skeleton：等 /api/v1/copilot/stream 實作");
+    const apiKey = process.env.AIBO_E2E_API_KEY!;
+    await loginWithCookie(context, apiKey);
+
+    await page.goto("/dashboard");
+    // 在 page context 中開 EventSource，等到第一個 message
+    const firstEvent = await page.evaluate(async () => {
+      return new Promise<{ ok: boolean; data?: string; error?: string }>(
+        (resolve) => {
+          const es = new EventSource("/api/v1/copilot/stream");
+          const timer = setTimeout(() => {
+            es.close();
+            resolve({ ok: false, error: "timeout" });
+          }, 5000);
+          es.onmessage = (e) => {
+            clearTimeout(timer);
+            es.close();
+            resolve({ ok: true, data: e.data });
+          };
+          es.onerror = () => {
+            clearTimeout(timer);
+            es.close();
+            resolve({ ok: false, error: "es_error" });
+          };
+        },
+      );
+    });
+    expect(firstEvent.ok, JSON.stringify(firstEvent)).toBeTruthy();
+  });
+
+  test("F-2 EventSource close cleanup → 後端 context cancel", async ({ page, context }) => {
+    test.skip(true, "Wave 4 skeleton：close cleanup 觀察需要 backend metric/log，留待整合");
+    const apiKey = process.env.AIBO_E2E_API_KEY!;
+    await loginWithCookie(context, apiKey);
+
+    await page.goto("/dashboard");
+    const closed = await page.evaluate(async () => {
+      const es = new EventSource("/api/v1/copilot/stream");
+      await new Promise((r) => setTimeout(r, 500));
+      es.close();
+      return es.readyState === 2; // CLOSED
+    });
+    expect(closed).toBeTruthy();
+  });
+});

--- a/test/browser/specs/sprint13_visual_regression.spec.ts
+++ b/test/browser/specs/sprint13_visual_regression.spec.ts
@@ -1,0 +1,69 @@
+/**
+ * Sprint 13 Visual Regression
+ *
+ * 對應 QA Issue #198 視覺迴歸（最小範圍）：
+ * - /login light + dark
+ * - /dashboard light + dark（4 slot 並排）
+ * - CmdK overlay 開啟狀態
+ *
+ * 首次執行時 Playwright 會自動產生 baseline snapshot（test-results 下對應 *.png）。
+ * 後續執行會 diff 比對；若需更新 baseline：
+ *   cd test/browser && npx playwright test sprint13_visual_regression --update-snapshots
+ */
+
+import { test, expect } from "@playwright/test";
+import { loginWithCookie } from "../helpers/cookie-auth";
+import { presetTheme } from "../helpers/theme";
+
+// 視覺迴歸對顏色 / 字體微差容忍 2%
+const SNAP_OPTS = {
+  maxDiffPixelRatio: 0.02,
+  animations: "disabled" as const,
+};
+
+test.describe("Sprint 13 Visual Regression", () => {
+  test.beforeEach(async ({ context }) => {
+    await context.clearCookies();
+  });
+
+  for (const theme of ["light", "dark"] as const) {
+    test(`/login ${theme}`, async ({ page, context }) => {
+      test.skip(true, "Wave 4 skeleton：等 /login + theme system 完成後跑 baseline");
+      await presetTheme(context, theme);
+      await page.goto("/login");
+      await page.waitForLoadState("networkidle");
+      await expect(page).toHaveScreenshot(`login-${theme}.png`, SNAP_OPTS);
+    });
+  }
+
+  for (const theme of ["light", "dark"] as const) {
+    test(`/dashboard ${theme}（4 slot 並排）`, async ({ page, context }) => {
+      test.skip(true, "Wave 4 skeleton：等 /dashboard parallel routes 完成");
+      await presetTheme(context, theme);
+      const apiKey = process.env.AIBO_E2E_API_KEY!;
+      await loginWithCookie(context, apiKey);
+      await page.goto("/dashboard");
+      await page.waitForLoadState("networkidle");
+
+      // 等所有 slot 都掛載
+      for (const slot of ["inbox", "library", "today", "copilot"]) {
+        await page.getByTestId(`slot-${slot}`).waitFor({ state: "visible" });
+      }
+      await expect(page).toHaveScreenshot(`dashboard-${theme}.png`, SNAP_OPTS);
+    });
+  }
+
+  test("CmdK overlay 開啟狀態", async ({ page, context }) => {
+    test.skip(true, "Wave 4 skeleton：等 F-037 CmdK 完成");
+    await presetTheme(context, "light");
+    const apiKey = process.env.AIBO_E2E_API_KEY!;
+    await loginWithCookie(context, apiKey);
+    await page.goto("/dashboard");
+    await page.waitForLoadState("networkidle");
+
+    const meta = process.platform === "darwin" ? "Meta" : "Control";
+    await page.keyboard.press(`${meta}+KeyK`);
+    await page.getByTestId("cmdk-palette").waitFor({ state: "visible" });
+    await expect(page).toHaveScreenshot("cmdk-overlay-light.png", SNAP_OPTS);
+  });
+});

--- a/test/e2e/f039_cookie_auth_test.go
+++ b/test/e2e/f039_cookie_auth_test.go
@@ -1,0 +1,319 @@
+package e2e
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// ============================================================
+// F-039: Cookie Session Auth + API Client + SSE
+//
+// Spec: specs/features/f039-api-sse-auth.md
+// Issue: #194
+// QA Issue: #198（後端 API 整合測試段落）
+//
+// 涵蓋：
+// - POST /auth/login 200 + Set-Cookie + sessions row created
+// - POST /auth/login 401 wrong key
+// - POST /auth/login 429 rate limited（5 次/分鐘）
+// - POST /auth/logout 204 + sessions row deleted + cookie cleared
+// - GET /auth/me with cookie → auth_method=cookie
+// - GET /auth/me with X-API-Key → auth_method=api_key
+// - GET /entries with cookie 200
+// - GET /entries 過期 cookie → 401
+// - 滑動續期：< 7 天到期觸發 UPDATE expires_at
+//
+// 注意：本檔在 dev/F-039 後端尚未合併前以 t.Skip() 跳過；
+// engineer 完成後移除 skip。
+// ============================================================
+
+const sessionCookieName = "aibo_session"
+
+func sprint13Skip(t *testing.T) {
+	t.Helper()
+	t.Skip("Wave 1 skeleton：等 F-039 後端 /auth/login + cookie middleware 實作完成")
+}
+
+// loginCookie 透過 master api_key 取得 cookie session token
+// 回傳：cookie 物件（包含 attributes）+ raw response
+func loginCookie(t *testing.T, apiKey string) (*http.Cookie, *http.Response) {
+	t.Helper()
+	body, _ := json.Marshal(map[string]string{"api_key": apiKey})
+	req, err := http.NewRequest("POST", baseURL()+"/api/v1/auth/login", bytes.NewReader(body))
+	require.NoError(t, err)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+
+	for _, c := range resp.Cookies() {
+		if c.Name == sessionCookieName {
+			return c, resp
+		}
+	}
+	return nil, resp
+}
+
+// ---------------- Login ----------------
+
+func TestF039_Login_Success_SetCookie(t *testing.T) {
+	sprint13Skip(t)
+
+	bootstrap := bootstrapKeyForTest(t)
+
+	cookie, resp := loginCookie(t, bootstrap)
+	defer resp.Body.Close()
+
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	require.NotNil(t, cookie, "Set-Cookie aibo_session 必存在")
+
+	assert.True(t, cookie.HttpOnly, "cookie 必須 HttpOnly")
+	assert.Equal(t, http.SameSiteLaxMode, cookie.SameSite, "cookie 必須 SameSite=Lax")
+	assert.Equal(t, "/", cookie.Path)
+
+	// Max-Age 約 30 天 (2592000 秒)，容忍 ±1 天
+	assert.GreaterOrEqual(t, cookie.MaxAge, 2592000-86400)
+	assert.LessOrEqual(t, cookie.MaxAge, 2592000+86400)
+
+	// Body 應包含 expires_at
+	var body struct {
+		User      map[string]string `json:"user"`
+		ExpiresAt string            `json:"expires_at"`
+	}
+	require.NoError(t, json.NewDecoder(resp.Body).Decode(&body))
+	assert.Equal(t, "owner", body.User["label"])
+	expires, err := time.Parse(time.RFC3339, body.ExpiresAt)
+	require.NoError(t, err)
+	assert.WithinDuration(t, time.Now().Add(30*24*time.Hour), expires, 24*time.Hour)
+}
+
+func TestF039_Login_WrongKey_401(t *testing.T) {
+	sprint13Skip(t)
+	cookie, resp := loginCookie(t, "definitely-wrong-key")
+	defer resp.Body.Close()
+	assert.Equal(t, http.StatusUnauthorized, resp.StatusCode)
+	assert.Nil(t, cookie)
+
+	var body map[string]any
+	require.NoError(t, json.NewDecoder(resp.Body).Decode(&body))
+	assert.Equal(t, "INVALID_API_KEY", body["error"])
+}
+
+func TestF039_Login_RateLimited_429(t *testing.T) {
+	sprint13Skip(t)
+	// 同一 IP 連發 6 次 wrong key，第 6 次應 429
+	var lastStatus int
+	for i := 0; i < 6; i++ {
+		_, resp := loginCookie(t, "wrong-key")
+		lastStatus = resp.StatusCode
+		resp.Body.Close()
+	}
+	assert.Equal(t, http.StatusTooManyRequests, lastStatus)
+}
+
+// ---------------- Logout ----------------
+
+func TestF039_Logout_204_ClearsCookie(t *testing.T) {
+	sprint13Skip(t)
+	bootstrap := bootstrapKeyForTest(t)
+	cookie, resp := loginCookie(t, bootstrap)
+	resp.Body.Close()
+	require.NotNil(t, cookie)
+
+	// 帶 cookie 呼叫 /auth/logout
+	req, _ := http.NewRequest("POST", baseURL()+"/api/v1/auth/logout", nil)
+	req.AddCookie(cookie)
+	logoutResp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	defer logoutResp.Body.Close()
+
+	assert.Equal(t, http.StatusNoContent, logoutResp.StatusCode)
+
+	// Set-Cookie 必須有清除指令（Max-Age=0 或 expires past）
+	cleared := false
+	for _, c := range logoutResp.Cookies() {
+		if c.Name == sessionCookieName && (c.MaxAge < 0 || c.MaxAge == 0 || c.Expires.Before(time.Now())) {
+			cleared = true
+		}
+	}
+	assert.True(t, cleared, "logout response 必須含清除 cookie 指令")
+
+	// 之後用 same cookie 應 401
+	req2, _ := http.NewRequest("GET", baseURL()+"/api/v1/auth/me", nil)
+	req2.AddCookie(cookie)
+	r2, err := http.DefaultClient.Do(req2)
+	require.NoError(t, err)
+	r2.Body.Close()
+	assert.Equal(t, http.StatusUnauthorized, r2.StatusCode)
+}
+
+// ---------------- /auth/me ----------------
+
+func TestF039_Me_WithCookie_AuthMethodCookie(t *testing.T) {
+	sprint13Skip(t)
+	bootstrap := bootstrapKeyForTest(t)
+	cookie, resp := loginCookie(t, bootstrap)
+	resp.Body.Close()
+	require.NotNil(t, cookie)
+
+	req, _ := http.NewRequest("GET", baseURL()+"/api/v1/auth/me", nil)
+	req.AddCookie(cookie)
+	r, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	defer r.Body.Close()
+
+	assert.Equal(t, http.StatusOK, r.StatusCode)
+	var body map[string]string
+	require.NoError(t, json.NewDecoder(r.Body).Decode(&body))
+	assert.Equal(t, "owner", body["label"])
+	assert.Equal(t, "cookie", body["auth_method"])
+}
+
+func TestF039_Me_WithApiKey_AuthMethodApiKey(t *testing.T) {
+	sprint13Skip(t)
+	apiKey := bootstrapKeyForTest(t)
+
+	req, _ := http.NewRequest("GET", baseURL()+"/api/v1/auth/me", nil)
+	req.Header.Set("X-API-Key", apiKey)
+	r, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	defer r.Body.Close()
+
+	assert.Equal(t, http.StatusOK, r.StatusCode)
+	var body map[string]string
+	require.NoError(t, json.NewDecoder(r.Body).Decode(&body))
+	assert.Equal(t, "api_key", body["auth_method"])
+}
+
+func TestF039_Me_BothCookieAndApiKey_PrefersCookie(t *testing.T) {
+	sprint13Skip(t)
+	apiKey := bootstrapKeyForTest(t)
+	cookie, resp := loginCookie(t, apiKey)
+	resp.Body.Close()
+	require.NotNil(t, cookie)
+
+	req, _ := http.NewRequest("GET", baseURL()+"/api/v1/auth/me", nil)
+	req.AddCookie(cookie)
+	req.Header.Set("X-API-Key", apiKey)
+	r, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	defer r.Body.Close()
+
+	var body map[string]string
+	require.NoError(t, json.NewDecoder(r.Body).Decode(&body))
+	assert.Equal(t, "cookie", body["auth_method"], "同時帶兩種時，優先 cookie")
+}
+
+// ---------------- /entries ----------------
+
+func TestF039_Entries_WithCookie_200(t *testing.T) {
+	sprint13Skip(t)
+	bootstrap := bootstrapKeyForTest(t)
+	cookie, resp := loginCookie(t, bootstrap)
+	resp.Body.Close()
+	require.NotNil(t, cookie)
+
+	req, _ := http.NewRequest("GET", baseURL()+"/api/v1/entries", nil)
+	req.AddCookie(cookie)
+	r, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	r.Body.Close()
+	assert.Equal(t, http.StatusOK, r.StatusCode)
+}
+
+func TestF039_Entries_ExpiredCookie_401(t *testing.T) {
+	sprint13Skip(t)
+	bootstrap := bootstrapKeyForTest(t)
+	cookie, resp := loginCookie(t, bootstrap)
+	resp.Body.Close()
+	require.NotNil(t, cookie)
+
+	// 透過 test-only endpoint 把 sessions row 設為過期
+	expireBody, _ := json.Marshal(map[string]string{"token": cookie.Value})
+	expireReq, _ := http.NewRequest("POST", baseURL()+"/api/v1/__test/sessions/expire", bytes.NewReader(expireBody))
+	expireReq.Header.Set("Content-Type", "application/json")
+	expireResp, err := http.DefaultClient.Do(expireReq)
+	require.NoError(t, err)
+	expireResp.Body.Close()
+
+	req, _ := http.NewRequest("GET", baseURL()+"/api/v1/entries", nil)
+	req.AddCookie(cookie)
+	r, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	r.Body.Close()
+	assert.Equal(t, http.StatusUnauthorized, r.StatusCode)
+}
+
+// ---------------- 滑動續期 ----------------
+
+func TestF039_SlidingRenewal_When_Expires_Lt_7Days(t *testing.T) {
+	sprint13Skip(t)
+	bootstrap := bootstrapKeyForTest(t)
+	cookie, resp := loginCookie(t, bootstrap)
+	resp.Body.Close()
+	require.NotNil(t, cookie)
+
+	// 透過 test endpoint 把 sessions.expires_at 設為 5 天後
+	body, _ := json.Marshal(map[string]any{"token": cookie.Value, "days": 5})
+	soonReq, _ := http.NewRequest("POST", baseURL()+"/api/v1/__test/sessions/expire-soon", bytes.NewReader(body))
+	soonReq.Header.Set("Content-Type", "application/json")
+	soonResp, err := http.DefaultClient.Do(soonReq)
+	require.NoError(t, err)
+	soonResp.Body.Close()
+
+	// 任一 API 請求觸發續期
+	apiReq, _ := http.NewRequest("GET", baseURL()+"/api/v1/entries", nil)
+	apiReq.AddCookie(cookie)
+	r, err := http.DefaultClient.Do(apiReq)
+	require.NoError(t, err)
+	r.Body.Close()
+
+	// 用 test endpoint 取出 sessions.expires_at 驗證是否 ~30 天後
+	q, _ := http.NewRequest("GET", baseURL()+"/api/v1/__test/sessions/inspect?token="+cookie.Value, nil)
+	insp, err := http.DefaultClient.Do(q)
+	require.NoError(t, err)
+	defer insp.Body.Close()
+	require.Equal(t, http.StatusOK, insp.StatusCode)
+
+	var inspBody struct {
+		ExpiresAt string `json:"expires_at"`
+	}
+	require.NoError(t, json.NewDecoder(insp.Body).Decode(&inspBody))
+	expires, err := time.Parse(time.RFC3339, inspBody.ExpiresAt)
+	require.NoError(t, err)
+	assert.WithinDuration(t, time.Now().Add(30*24*time.Hour), expires, 24*time.Hour)
+}
+
+// ---------------- helpers ----------------
+
+// bootstrapKeyForTest 取得當前 test API 的 master api_key
+// 優先用 AIBO_E2E_API_KEY；否則 fresh DB 上呼叫 POST /auth/api-keys
+func bootstrapKeyForTest(t *testing.T) string {
+	t.Helper()
+	if k := strings.TrimSpace(os.Getenv("AIBO_E2E_API_KEY")); k != "" {
+		return k
+	}
+	body, _ := json.Marshal(map[string]string{"name": "f039-test"})
+	req, _ := http.NewRequest("POST", baseURL()+"/api/v1/auth/api-keys", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusCreated {
+		t.Fatalf("bootstrap api key failed: %d", resp.StatusCode)
+	}
+	var b struct {
+		Key string `json:"key"`
+	}
+	require.NoError(t, json.NewDecoder(resp.Body).Decode(&b))
+	return b.Key
+}
+


### PR DESCRIPTION
## Summary

Sprint 13 雙層 e2e tests skeleton（Playwright browser tests + Go API tests）。

- 41 個 WHEN/THEN scenarios 全部轉為 test 函數，以 `test.skip` / `t.Skip` 標記
- axe-core a11y helper（`test/browser/helpers/a11y.ts`）
- 後端 SSE 整合測試 skeleton（f039_cookie_auth_test.go）

## 測試覆蓋

| Scenario Group | 數量 | 檔案 |
|----------------|------|------|
| A1-A9 Cookie Auth | 9 | `test/browser/specs/f039_cookie_auth.spec.ts` |
| B1-B6 Design Tokens + Theme | 6 | `test/browser/specs/f035_design_tokens_theme.spec.ts` |
| C1-C9 App Shell + Parallel Routes | 9 | `test/browser/specs/f036_app_shell_routing.spec.ts` |
| D1-D6 shadcn Primitives + a11y | 6 | `test/browser/specs/f038_shadcn_primitives.spec.ts` |
| E1-E9 Command Palette (CmdK) | 9 | `test/browser/specs/f037_command_palette.spec.ts` |
| F1-F2 SSE Client | 2 | `test/browser/specs/f039_cookie_auth.spec.ts` |
| 視覺迴歸 baseline | 5 | `test/browser/specs/sprint13_visual_regression.spec.ts` |
| 後端 API 整合（Go） | 9 | `test/e2e/f039_cookie_auth_test.go` |

## Helpers 新增

- `test/browser/helpers/a11y.ts` — axe-core a11y 掃描 helper
- `test/browser/helpers/cookie-auth.ts` — cookie session auth helper
- `test/browser/helpers/theme.ts` — theme 操作 + CSS token 讀取 helper

## 注意事項

- 所有測試以 `test.skip` / `t.Skip` 標記，待對應 feature PR merge 後依 Wave 啟用
- Wave 1：A1-A9、B1-B5（基礎 auth + theme）
- Wave 2：B6、C1-C9、D1-D5（app shell + primitives）
- Wave 3：E1-E9（command palette）
- Wave 4：D6、F1-F2、視覺迴歸（完整整合）

Closes #198