### PR TITLE
design(sprint-13): D-13 元件 dataset

### DIFF
--- a/design/components/badge/spec.md
+++ b/design/components/badge/spec.md
@@ -1,0 +1,38 @@
+# Badge
+
+## 用途
+顯示狀態、計數、標籤等 inline 資訊片段。
+
+## Variants
+
+| Variant   | 背景                          | 文字                         | 邊框                         |
+|-----------|-------------------------------|------------------------------|------------------------------|
+| default   | `color.primary.default`       | `color.primary.fg`           | 無                           |
+| secondary | `color.secondary.default`     | `color.secondary.fg`         | 無                           |
+| outline   | 透明                          | `color.fg.default`           | `color.border.default`       |
+| danger    | `color.danger.subtle`         | `color.danger.default`       | `color.danger.default`（1px）|
+| success   | `color.success.subtle`        | `color.success.default`      | `color.success.default`（1px）|
+| warning   | `color.warning.subtle`        | `color.warning.default`      | `color.warning.default`（1px）|
+
+## 尺寸
+
+| Size | Height | Padding X | Font Size | 用途              |
+|------|--------|-----------|-----------|-----------------|
+| sm   | 18px   | 6px       | `xs`      | sidebar 未讀計數 |
+| md   | 22px   | 8px       | `xs`      | 標準用途（預設） |
+| lg   | 26px   | 10px      | `sm`      | 強調用途         |
+
+- Border-radius: `radius.full`（pill 形）
+- Font-weight: `medium`
+
+## Props
+
+| Prop    | Type                                                          | Default     | 說明    |
+|---------|---------------------------------------------------------------|-------------|--------|
+| variant | 'default' \| 'secondary' \| 'outline' \| 'danger' \| 'success' \| 'warning' | 'secondary' | 樣式 |
+| size    | 'sm' \| 'md' \| 'lg'                                         | 'md'        | 大小   |
+| dot     | boolean                                                       | false       | 前置圓點 |
+
+## Accessibility
+- 純展示用途（無互動）：`aria-hidden="true"` 或用 `aria-label` 補充語意
+- 狀態類 badge（danger/success）建議搭配文字說明，不只靠顏色傳達

--- a/design/components/button/example.tsx
+++ b/design/components/button/example.tsx
@@ -1,0 +1,123 @@
+// Button 元件使用範例
+// 技術棧：Tailwind CSS v4 + shadcn/ui + Lucide icons
+// 對應規格：design/components/button/spec.md
+
+import { Loader2, Plus, Trash2, ArrowRight, Search } from "lucide-react";
+import { Button } from "@/components/ui/button";
+
+// --- Variants ---
+export function ButtonVariants() {
+  return (
+    <div className="flex flex-wrap gap-3 items-center">
+      {/* 主要 CTA */}
+      <Button variant="default">建立筆記</Button>
+
+      {/* 次要操作 */}
+      <Button variant="secondary">取消</Button>
+
+      {/* 低優先級 */}
+      <Button variant="ghost">更多選項</Button>
+
+      {/* 破壞性操作 */}
+      <Button variant="danger">刪除</Button>
+
+      {/* 文字連結 */}
+      <Button variant="link">了解更多</Button>
+    </div>
+  );
+}
+
+// --- Sizes ---
+export function ButtonSizes() {
+  return (
+    <div className="flex flex-wrap gap-3 items-center">
+      <Button size="sm">小型按鈕</Button>
+      <Button size="md">中型按鈕</Button>
+      <Button size="lg">大型按鈕</Button>
+    </div>
+  );
+}
+
+// --- With Icons ---
+export function ButtonWithIcons() {
+  return (
+    <div className="flex flex-wrap gap-3 items-center">
+      {/* 前置圖示 */}
+      <Button icon={<Plus className="w-4 h-4" />}>新增項目</Button>
+
+      {/* 後置圖示 */}
+      <Button iconRight={<ArrowRight className="w-4 h-4" />} variant="link">
+        查看更多
+      </Button>
+
+      {/* 僅圖示（需 aria-label） */}
+      <Button
+        variant="ghost"
+        size="sm"
+        iconOnly
+        aria-label="搜尋"
+        icon={<Search className="w-4 h-4" />}
+      />
+
+      {/* 危險操作 + 圖示 */}
+      <Button variant="danger" icon={<Trash2 className="w-4 h-4" />}>
+        刪除文件
+      </Button>
+    </div>
+  );
+}
+
+// --- States ---
+export function ButtonStates() {
+  return (
+    <div className="flex flex-wrap gap-3 items-center">
+      {/* 正常 */}
+      <Button>正常</Button>
+
+      {/* 載入中 */}
+      <Button loading aria-busy="true">
+        <Loader2 className="w-4 h-4 animate-spin mr-2" aria-hidden="true" />
+        儲存中...
+      </Button>
+
+      {/* 禁用 */}
+      <Button disabled aria-disabled="true">
+        不可用
+      </Button>
+    </div>
+  );
+}
+
+// --- Full Width（表單送出）---
+export function ButtonFullWidth() {
+  return (
+    <div className="w-80">
+      <Button fullWidth size="lg">
+        登入
+      </Button>
+    </div>
+  );
+}
+
+// --- 破壞性操作流程（必須有確認步驟）---
+export function DangerWithConfirmation() {
+  // 破壞性操作不直接執行，需先跳出確認 Dialog（見 dialog/spec.md）
+  return (
+    <Button
+      variant="danger"
+      icon={<Trash2 className="w-4 h-4" />}
+      onClick={() => {
+        // 觸發確認 Dialog，不直接刪除
+        openConfirmDialog({
+          title: "確認刪除",
+          description: "此操作無法復原。確定要刪除嗎？",
+          confirmLabel: "刪除",
+          confirmVariant: "danger",
+          onConfirm: () => handleDelete(),
+        });
+      }}
+    >
+      刪除條目
+    </Button>
+  );
+}

--- a/design/components/button/spec.md
+++ b/design/components/button/spec.md
@@ -1,0 +1,65 @@
+# Button
+
+## 用途
+觸發操作的基礎互動元件。覆蓋所有主要操作類型：確認、取消、危險操作、連結式跳轉。
+
+## Variants
+
+| Variant   | 用途             | 背景                    | 文字              | 邊框                    |
+|-----------|-----------------|------------------------|------------------|------------------------|
+| default   | 主要操作（CTA）   | `color.primary.default` | `color.primary.fg` | 無                   |
+| secondary | 次要操作         | `color.secondary.default` | `color.secondary.fg` | `color.border.default` |
+| ghost     | 低優先級 / icon 按鈕 | 透明               | `color.fg.default` | 無                   |
+| danger    | 破壞性操作       | `color.danger.default`  | `color.danger.fg`  | 無                   |
+| link      | 文字連結樣式     | 透明                    | `color.accent.default` | 無（底線 hover） |
+
+## Sizes
+
+| Size | Height | Padding X | Padding Y | Font Size | Min Width |
+|------|--------|-----------|-----------|-----------|-----------|
+| sm   | 32px   | 12px      | 6px       | `font.size.sm`  | 64px |
+| md   | 40px   | 16px      | 8px       | `font.size.base`| 80px |
+| lg   | 48px   | 24px      | 12px      | `font.size.lg`  | 96px |
+
+注意：所有尺寸觸控目標最小 44x44pt（sm 按鈕在 mobile 需外加 padding 補足）。
+
+## Props
+
+| Prop      | Type                                              | Default     | 說明                   |
+|-----------|---------------------------------------------------|-------------|----------------------|
+| variant   | 'default' \| 'secondary' \| 'ghost' \| 'danger' \| 'link' | 'default' | 按鈕樣式 |
+| size      | 'sm' \| 'md' \| 'lg'                             | 'md'        | 按鈕大小               |
+| disabled  | boolean                                           | false       | 禁用狀態               |
+| loading   | boolean                                           | false       | 載入中狀態             |
+| icon      | ReactNode                                         | -           | 前置圖示（Lucide 元件）|
+| iconRight | ReactNode                                         | -           | 後置圖示               |
+| iconOnly  | boolean                                           | false       | 僅圖示模式（正方形）   |
+| fullWidth | boolean                                           | false       | 撐滿父容器寬度         |
+| asChild   | boolean                                           | false       | 渲染為子元素（Slot 模式）|
+
+## States
+
+| State    | 外觀變化                                                  |
+|----------|----------------------------------------------------------|
+| default  | 標準外觀                                                  |
+| hover    | default: `primary.hover`；secondary: `secondary.hover`  |
+| active   | scale(0.97) + 亮度 -5%，transition 150ms                 |
+| focus    | `ring 2px color.border.focus`，`outline-offset: 2px`    |
+| disabled | `opacity: 0.5`，`cursor: not-allowed`，pointer-events: none |
+| loading  | 前置 Spinner（16px），文字不隱藏，`aria-busy: true`       |
+
+## 動畫
+- hover transition: `background-color 150ms ease`
+- active: `transform scale(0.97) 150ms ease`
+- 尊重 `prefers-reduced-motion`：移除 transform，保留顏色過渡
+
+## Accessibility
+- Role: `button`
+- 鍵盤：Enter + Space 觸發
+- `disabled` 時：`aria-disabled="true"`（不用 HTML disabled，保留 focus）
+- `loading` 時：`aria-busy="true"` + `aria-label` 加上「載入中」後綴
+- `iconOnly` 時：必須有 `aria-label` 描述操作
+- Focus ring 對比度 >= 3:1
+
+## 使用範例
+見 `example.tsx`

--- a/design/components/card/example.tsx
+++ b/design/components/card/example.tsx
@@ -1,0 +1,178 @@
+// Card Chrome 使用範例
+// 技術棧：Tailwind CSS v4 + shadcn/ui
+// 對應規格：design/components/card/spec.md
+
+import { Inbox, BookOpen, CalendarDays, Bot, ArrowRight, AlertCircle, Loader2 } from "lucide-react";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Skeleton } from "@/components/ui/skeleton";
+
+// --- 標準卡片 ---
+export function StandardCard() {
+  return (
+    <Card>
+      <CardHeader>
+        <div className="flex items-center gap-2">
+          <Inbox className="w-4 h-4 text-[color:var(--fg-muted)]" aria-hidden="true" />
+          <CardTitle>Inbox</CardTitle>
+        </div>
+        <CardDescription>未處理的項目</CardDescription>
+      </CardHeader>
+      <CardContent>
+        <p className="text-sm text-[color:var(--fg-muted)]">3 則新通知</p>
+      </CardContent>
+      <CardFooter>
+        <Button variant="link" size="sm" iconRight={<ArrowRight className="w-3.5 h-3.5" />}>
+          查看更多
+        </Button>
+      </CardFooter>
+    </Card>
+  );
+}
+
+// --- Dashboard Hub 4-slot Grid ---
+export function DashboardHubGrid() {
+  return (
+    <div className="grid grid-cols-1 md:grid-cols-2 gap-4 lg:gap-6">
+      {/* Inbox */}
+      <Card>
+        <CardHeader>
+          <div className="flex items-center gap-2">
+            <Inbox className="w-4 h-4 text-[color:var(--fg-muted)]" aria-hidden="true" />
+            <CardTitle as="h2">Inbox</CardTitle>
+          </div>
+        </CardHeader>
+        <CardContent>
+          <InboxPreview />
+        </CardContent>
+        <CardFooter>
+          <Button variant="link" size="sm" iconRight={<ArrowRight className="w-3.5 h-3.5" />}>
+            查看全部
+          </Button>
+        </CardFooter>
+      </Card>
+
+      {/* Library */}
+      <Card>
+        <CardHeader>
+          <div className="flex items-center gap-2">
+            <BookOpen className="w-4 h-4 text-[color:var(--fg-muted)]" aria-hidden="true" />
+            <CardTitle as="h2">Library</CardTitle>
+          </div>
+        </CardHeader>
+        <CardContent>
+          <LibraryPreview />
+        </CardContent>
+        <CardFooter>
+          <Button variant="link" size="sm" iconRight={<ArrowRight className="w-3.5 h-3.5" />}>
+            進入資料庫
+          </Button>
+        </CardFooter>
+      </Card>
+
+      {/* Today */}
+      <Card>
+        <CardHeader>
+          <div className="flex items-center gap-2">
+            <CalendarDays className="w-4 h-4 text-[color:var(--fg-muted)]" aria-hidden="true" />
+            <CardTitle as="h2">今日</CardTitle>
+          </div>
+        </CardHeader>
+        <CardContent>
+          <TodayPreview />
+        </CardContent>
+        <CardFooter>
+          <Button variant="link" size="sm" iconRight={<ArrowRight className="w-3.5 h-3.5" />}>
+            完整行程
+          </Button>
+        </CardFooter>
+      </Card>
+
+      {/* Copilot */}
+      <Card>
+        <CardHeader>
+          <div className="flex items-center gap-2">
+            <Bot className="w-4 h-4 text-[color:var(--fg-muted)]" aria-hidden="true" />
+            <CardTitle as="h2">Copilot</CardTitle>
+          </div>
+        </CardHeader>
+        <CardContent>
+          <CopilotPreview />
+        </CardContent>
+        <CardFooter>
+          <Button variant="link" size="sm" iconRight={<ArrowRight className="w-3.5 h-3.5" />}>
+            開啟對話
+          </Button>
+        </CardFooter>
+      </Card>
+    </div>
+  );
+}
+
+// --- Loading State（Skeleton） ---
+export function CardLoadingState() {
+  return (
+    <Card>
+      <CardHeader>
+        <div className="flex items-center gap-2">
+          <Skeleton className="w-4 h-4 rounded" />
+          <Skeleton className="h-5 w-24" />
+        </div>
+      </CardHeader>
+      <CardContent aria-busy="true" aria-label="載入中">
+        <div className="space-y-2">
+          <Skeleton className="h-4 w-full" />
+          <Skeleton className="h-4 w-4/5" />
+          <Skeleton className="h-4 w-3/5" />
+        </div>
+      </CardContent>
+      <CardFooter>
+        <Skeleton className="h-8 w-24" />
+      </CardFooter>
+    </Card>
+  );
+}
+
+// --- Error State ---
+export function CardErrorState({ onRetry }: { onRetry: () => void }) {
+  return (
+    <Card className="border-[color:var(--danger)]">
+      <CardContent className="flex flex-col items-center justify-center py-8 gap-3 text-center">
+        <AlertCircle
+          className="w-8 h-8 text-[color:var(--danger)]"
+          aria-hidden="true"
+        />
+        <p className="text-sm text-[color:var(--fg-muted)]">載入失敗</p>
+        <Button
+          variant="secondary"
+          size="sm"
+          onClick={onRetry}
+          aria-label="重新載入"
+        >
+          重試
+        </Button>
+      </CardContent>
+    </Card>
+  );
+}
+
+// --- Empty State ---
+export function CardEmptyState() {
+  return (
+    <Card>
+      <CardContent className="flex flex-col items-center justify-center py-8 gap-3 text-center">
+        <p className="text-sm text-[color:var(--fg-muted)]">暫無內容</p>
+        <Button variant="secondary" size="sm">
+          新增第一個項目
+        </Button>
+      </CardContent>
+    </Card>
+  );
+}

--- a/design/components/card/spec.md
+++ b/design/components/card/spec.md
@@ -1,0 +1,65 @@
+# Card Chrome
+
+## 用途
+Dashboard hub 的基礎容器元件。提供統一的圓角、邊框、陰影「外殼」（chrome），內容由 slot 填入。
+
+## 子元件
+
+| 子元件         | 說明                                    |
+|--------------|----------------------------------------|
+| Card         | 根容器，提供外殼樣式                      |
+| CardHeader   | 標題區（padding top + x，flex row）      |
+| CardTitle    | 主標題（serif / heading-sm）             |
+| CardDescription | 副標題 / 說明文字（body-sm, fg.muted） |
+| CardContent  | 主體內容區（padding x + y）              |
+| CardFooter   | 底部區域（通常放「查看更多」連結）         |
+
+## Variants
+
+| Variant   | 背景                     | 邊框                     | 陰影             |
+|-----------|--------------------------|--------------------------|-----------------|
+| default   | `color.card.default`     | `color.card.border`      | `shadow.sm`     |
+| ghost     | 透明                     | `color.border.default`   | 無              |
+| elevated  | `color.card.default`     | `color.card.border`      | `shadow.md`     |
+
+## 尺寸規格
+
+- `border-radius`: `radius.lg`（12px）
+- `padding`（CardContent + CardHeader）: `spacing.6`（24px）
+- `CardHeader`: padding-bottom `spacing.0`（與 CardContent 合併 gap）
+- `CardFooter`: padding-top `spacing.4`，border-top `color.border.default`
+- `gap`（CardHeader 內 icon + title）: `spacing.2`
+
+## States
+
+| State    | 外觀                                         |
+|----------|---------------------------------------------|
+| default  | 標準                                         |
+| hover（interactive card）| `shadow.md`，border `color.border.strong` |
+| loading  | 以 Skeleton 取代內容（見 skeleton spec）      |
+| error    | border `color.danger.default`，顯示錯誤提示  |
+| empty    | 居中灰色提示文字 + 選用 CTA 按鈕             |
+
+## Dashboard Hub Card 特定規格
+
+Dashboard hub 使用 4 個 parallel slot 卡片，每張需包含：
+- 圖示（`w-4 h-4`，Lucide），色彩 `fg.muted`
+- 卡片標題（heading-sm）
+- 內容 slot（flexible height）
+- CardFooter 含「查看更多 →」連結（Button variant=link, size=sm）
+
+Grid 布局：
+```
+Desktop (>=1024px): 2x2 grid, gap-6
+Tablet (768-1023px): 2x2 grid, gap-4
+Mobile (<768px): 1-column stack, gap-4
+```
+
+## Accessibility
+- 互動式 Card 須有 `role="article"` 或適當 landmark
+- 卡片標題必須是語義化 `<h2>` / `<h3>`（視頁面層級）
+- 錯誤狀態：`role="alert"` + `aria-live="polite"`
+- Loading skeleton：`aria-busy="true"` on CardContent
+
+## 使用範例
+見 `example.tsx`

--- a/design/components/command/example.tsx
+++ b/design/components/command/example.tsx
@@ -1,0 +1,234 @@
+// Command Palette (CmdK wrapper) 使用範例
+// 技術棧：cmdk + shadcn/ui CommandDialog + Lucide icons
+// 對應規格：design/components/command/spec.md
+
+"use client";
+
+import { useEffect, useState, useCallback } from "react";
+import {
+  CommandDialog,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+  CommandSeparator,
+} from "@/components/ui/command";
+import {
+  Search,
+  FileText,
+  Plus,
+  Settings,
+  CalendarDays,
+  BookOpen,
+  Loader2,
+} from "lucide-react";
+import { Kbd } from "@/components/ui/kbd";
+import { useRouter } from "next/navigation";
+
+// --- 資料結構 ---
+interface CommandAction {
+  id: string;
+  label: string;
+  description?: string;
+  icon: React.ElementType;
+  kbd?: string;
+  onSelect: () => void;
+}
+
+// --- 主 Command Palette ---
+export function CommandPalette() {
+  const [open, setOpen] = useState(false);
+  const [loading, setLoading] = useState(false);
+  const router = useRouter();
+
+  // ⌘K toggle
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      if ((e.metaKey || e.ctrlKey) && e.key === "k") {
+        e.preventDefault();
+        setOpen((v) => !v);
+      }
+    };
+    window.addEventListener("keydown", handler);
+    return () => window.removeEventListener("keydown", handler);
+  }, []);
+
+  const runAction = useCallback((fn: () => void) => {
+    setOpen(false);
+    fn();
+  }, []);
+
+  const recentItems: CommandAction[] = [
+    {
+      id: "recent-1",
+      label: "今日會議紀錄",
+      description: "日誌",
+      icon: FileText,
+      onSelect: () => runAction(() => router.push("/journal/today")),
+    },
+    {
+      id: "recent-2",
+      label: "週報 2026-04",
+      description: "日誌",
+      icon: FileText,
+      onSelect: () => runAction(() => router.push("/journal/weekly")),
+    },
+    {
+      id: "recent-3",
+      label: "Q2 OKR 追蹤",
+      description: "資料庫",
+      icon: BookOpen,
+      onSelect: () => runAction(() => router.push("/library/okr")),
+    },
+  ];
+
+  const actions: CommandAction[] = [
+    {
+      id: "new-note",
+      label: "新增筆記",
+      icon: Plus,
+      kbd: "⌘N",
+      onSelect: () => runAction(() => router.push("/journal/new")),
+    },
+    {
+      id: "today",
+      label: "今日行程",
+      icon: CalendarDays,
+      onSelect: () => runAction(() => router.push("/today")),
+    },
+    {
+      id: "settings",
+      label: "開啟設定",
+      icon: Settings,
+      kbd: "⌘,",
+      onSelect: () => runAction(() => router.push("/settings")),
+    },
+  ];
+
+  return (
+    <>
+      {/* SearchTrigger（放在 TopBar） */}
+      <button
+        type="button"
+        onClick={() => setOpen(true)}
+        className="flex items-center gap-2 h-9 px-3 rounded-md border border-[color:var(--border)] bg-[color:var(--background)] text-sm text-[color:var(--fg-muted)] hover:bg-[color:var(--bg-subtle)] transition-colors w-full max-w-xs"
+        aria-label="開啟搜尋（⌘K）"
+      >
+        <Search className="w-4 h-4 shrink-0" aria-hidden="true" />
+        <span className="flex-1 text-left">搜尋...</span>
+        <Kbd className="hidden sm:flex">⌘K</Kbd>
+      </button>
+
+      {/* Command Dialog */}
+      <CommandDialog
+        open={open}
+        onOpenChange={setOpen}
+        aria-label="Command palette"
+      >
+        <CommandInput
+          placeholder="搜尋或輸入指令..."
+          aria-label="搜尋"
+          aria-autocomplete="list"
+        />
+
+        <CommandList>
+          {/* 空結果 */}
+          <CommandEmpty>
+            <div className="flex flex-col items-center gap-2 py-6 text-center">
+              <Search className="w-8 h-8 text-[color:var(--fg-subtle)]" aria-hidden="true" />
+              <p className="text-sm text-[color:var(--fg-muted)]">找不到相關結果</p>
+              <p className="text-xs text-[color:var(--fg-subtle)]">試試其他關鍵字</p>
+            </div>
+          </CommandEmpty>
+
+          {/* 最近使用 */}
+          <CommandGroup heading="最近使用">
+            {recentItems.map((item) => (
+              <CommandItem
+                key={item.id}
+                value={item.label}
+                onSelect={item.onSelect}
+                className="flex items-center gap-3 py-2.5 cursor-pointer"
+                role="option"
+              >
+                <item.icon className="w-5 h-5 text-[color:var(--fg-muted)] shrink-0" aria-hidden="true" />
+                <span className="flex-1 text-sm font-medium truncate">{item.label}</span>
+                {item.description && (
+                  <span className="text-xs text-[color:var(--fg-subtle)] shrink-0">{item.description}</span>
+                )}
+              </CommandItem>
+            ))}
+          </CommandGroup>
+
+          <CommandSeparator />
+
+          {/* Actions */}
+          <CommandGroup heading="Actions">
+            {actions.map((action) => (
+              <CommandItem
+                key={action.id}
+                value={action.label}
+                onSelect={action.onSelect}
+                className="flex items-center gap-3 py-2.5 cursor-pointer"
+                role="option"
+              >
+                <action.icon className="w-5 h-5 text-[color:var(--fg-muted)] shrink-0" aria-hidden="true" />
+                <span className="flex-1 text-sm font-medium">{action.label}</span>
+                {action.kbd && (
+                  <Kbd className="shrink-0">{action.kbd}</Kbd>
+                )}
+              </CommandItem>
+            ))}
+          </CommandGroup>
+        </CommandList>
+
+        {/* 底部提示列 */}
+        <div className="flex items-center gap-4 px-3 py-2 border-t border-[color:var(--border)] text-xs text-[color:var(--fg-subtle)]">
+          <span className="flex items-center gap-1">
+            <Kbd size="xs">↑</Kbd>
+            <Kbd size="xs">↓</Kbd>
+            <span>導航</span>
+          </span>
+          <span className="flex items-center gap-1">
+            <Kbd size="xs">↵</Kbd>
+            <span>選擇</span>
+          </span>
+          <span className="flex items-center gap-1">
+            <Kbd size="xs">Esc</Kbd>
+            <span>關閉</span>
+          </span>
+        </div>
+      </CommandDialog>
+    </>
+  );
+}
+
+// --- Kbd 元件（供 Command Palette 底部提示使用） ---
+// 對應 design/components/kbd/spec.md
+export function Kbd({
+  children,
+  size = "sm",
+  className,
+}: {
+  children: React.ReactNode;
+  size?: "xs" | "sm";
+  className?: string;
+}) {
+  return (
+    <kbd
+      className={[
+        "inline-flex items-center justify-center",
+        "rounded border border-[color:var(--border)] bg-[color:var(--bg-muted)]",
+        "font-mono text-[color:var(--fg-muted)]",
+        size === "xs" ? "min-w-5 h-5 px-1 text-[10px]" : "min-w-6 h-6 px-1.5 text-xs",
+        "shadow-[0_1px_0_0_var(--border)]",
+        className,
+      ]
+        .filter(Boolean)
+        .join(" ")}
+    >
+      {children}
+    </kbd>
+  );
+}

--- a/design/components/command/spec.md
+++ b/design/components/command/spec.md
@@ -1,0 +1,107 @@
+# Command Palette（CmdK wrapper）
+
+## 用途
+全域快速搜尋 / 命令入口，⌘K 觸發。包裝 `cmdk` 套件，並與 shadcn Dialog 整合。
+
+## 觸發方式
+- 鍵盤：`⌘K`（macOS）/ `Ctrl+K`（Windows/Linux）
+- TopBar SearchTrigger 按鈕點擊
+- 任何頁面皆可觸發
+
+## 視覺結構
+
+```
+┌────────────────────────────────────────┐  寬度：640px
+│  ┌────────────────────────────────┐    │  最大高度：70vh
+│  │ [Search icon] 搜尋或輸入指令...│    │  backdrop-blur + overlay
+│  └────────────────────────────────┘    │  border-radius: radius.xl
+│  ────────────────────────────────────  │
+│  最近使用                              │  ← 群組標題（xs, uppercase, fg.muted）
+│  ┌────────────────────────────────┐    │
+│  │ [icon] 今日會議紀錄    category│    │  ← 結果 item
+│  │ [icon] 週報 2026-04           │    │
+│  └────────────────────────────────┘    │
+│  ────────────────────────────────────  │
+│  Actions                               │
+│  │ [icon] 新增筆記         ⌘N   │    │
+│  │ [icon] 開啟設定         ⌘,   │    │
+│  ────────────────────────────────────  │
+│  [ ↑↓ 導航 ]  [ Enter 選擇 ]  [ Esc 關閉 ] │  ← 底部提示列（Kbd 元件）
+└────────────────────────────────────────┘
+```
+
+## 尺寸
+- Width: `640px`（含 Dialog padding）
+- Max-height: `70vh`
+- Search input height: `48px`
+- Item height: `44px`（觸控目標）
+- Section header height: `28px`
+
+## 色彩（Token 對應）
+- Overlay：`color.overlay`（semi-transparent blur）
+- Dialog bg：`color.card.default`
+- Search input bg：透明（inherit）
+- Divider：`color.border.default`
+- Item hover bg：`color.bg.subtle`
+- Item selected bg：`color.secondary.default`
+- Selected 左側色條：`color.accent.default`（3px）
+
+## 結果 Item 結構
+
+```
+[icon 20px] [主文字 body-sm] [副文字 caption] ........... [kbd hint]
+```
+
+- Icon: `w-5 h-5`，`color: fg.muted`
+- 主文字：`text-sm font-medium`
+- 副文字：`text-xs text-fg-muted`
+- Kbd hint：`Kbd` 元件，右側對齊
+
+## 群組標題
+- Font: `xs`，`uppercase`，`letter-spacing: wider`
+- Color: `fg.subtle`
+- Padding: `spacing.2 spacing.3`
+- 不可 focus / 不計入 keyboard navigation
+
+## 底部提示列
+使用 `Kbd` 元件：
+- `↑` `↓`：導航
+- `↵`（Enter）：選擇
+- `Esc`：關閉
+- 排列：`flex gap-4 px-3 py-2 border-top`
+
+## 狀態
+
+| 狀態          | 外觀                                         |
+|-------------|---------------------------------------------|
+| 預設（無輸入）| 顯示最近使用 + 建議 Actions                  |
+| 輸入中        | 即時過濾結果，顯示搜尋圖示 spinner            |
+| 有結果        | 分組顯示，第一項自動 selected                 |
+| 空結果        | 居中「找不到「{query}」的結果」 + 建議文字    |
+| API 錯誤      | 居中錯誤提示 + 重試按鈕                       |
+
+## 動畫
+- Dialog open：`scale(0.96) → scale(1)`，`opacity 0 → 1`，`150ms ease`
+- Dialog close：`scale(1) → scale(0.96)`，`opacity 1 → 0`，`100ms ease`
+- Item selection：`background 100ms ease`
+- 尊重 `prefers-reduced-motion`
+
+## Props（CommandDialog wrapper）
+
+| Prop       | Type           | Default | 說明                   |
+|------------|----------------|---------|----------------------|
+| open       | boolean        | -       | 控制開關狀態           |
+| onOpenChange| (open: boolean) => void | - | 狀態回調        |
+| placeholder| string         | '搜尋或輸入指令...' | 輸入框提示文字 |
+
+## Accessibility
+- `role="dialog"`，`aria-modal="true"`，`aria-label="Command palette"`
+- 開啟時 focus trap 在 Dialog 內
+- `Esc` 關閉並 restore focus 到觸發元素
+- Search input：`aria-label="搜尋"`，`aria-autocomplete="list"`
+- 結果 list：`role="listbox"`
+- 每個 item：`role="option"`，`aria-selected`
+- 空結果：`aria-live="polite"`
+
+## 使用範例
+見 `example.tsx`

--- a/design/components/dialog/spec.md
+++ b/design/components/dialog/spec.md
@@ -1,0 +1,54 @@
+# Dialog
+
+## 用途
+模態對話框，用於確認操作、表單輸入、詳細資訊顯示。基於 shadcn/ui Dialog（Radix Primitive）。
+
+## 尺寸
+
+| Size  | Width          | 用途                        |
+|-------|----------------|-----------------------------|
+| sm    | `max-w-sm`     | 確認刪除等簡短訊息           |
+| md    | `max-w-md`     | 標準表單（預設）             |
+| lg    | `max-w-lg`     | 較複雜表單                   |
+| xl    | `max-w-xl`     | 預覽 / 詳情                  |
+| full  | `w-full h-full`| Mobile fullscreen            |
+
+## 結構
+```
+[Overlay（color.overlay，backdrop-blur-sm）]
+┌───────────────────────────────┐  border-radius: radius.xl
+│ DialogHeader                  │  padding: spacing.6
+│   DialogTitle（heading-md）   │
+│   DialogDescription（body-sm）│
+│ ────────────────────────────  │  Separator（選用）
+│ DialogContent                 │  padding: spacing.6, pt-0
+│   {slot}                      │
+│ ────────────────────────────  │
+│ DialogFooter                  │  padding: spacing.4 spacing.6
+│   [Cancel Button] [OK Button] │  flex gap-3 justify-end
+│                                │
+│                           [X] │  close button: top-right, absolute
+└───────────────────────────────┘
+```
+
+## 關閉按鈕
+- 位置：`absolute right-4 top-4`
+- 樣式：Button ghost，iconOnly，`X` icon（Lucide）
+- `aria-label="關閉"`
+
+## 破壞性操作 Dialog
+- Title 前加 AlertTriangle icon（`color.warning.default`）
+- Confirm Button：`variant="danger"`
+- Description 清楚描述不可復原後果
+
+## 動畫
+- Open: `scale(0.96) opacity(0) → scale(1) opacity(1)`，200ms
+- Close: `scale(1) opacity(1) → scale(0.96) opacity(0)`，150ms
+- Overlay: `opacity(0) → opacity(1)`，200ms
+
+## Accessibility
+- `role="dialog"`，`aria-modal="true"`
+- `aria-labelledby` → DialogTitle id
+- `aria-describedby` → DialogDescription id
+- Focus trap：開啟時 focus 第一個互動元素，Escape 關閉
+- 關閉後 focus 回觸發元素

--- a/design/components/dropdown-menu/spec.md
+++ b/design/components/dropdown-menu/spec.md
@@ -1,0 +1,47 @@
+# Dropdown Menu
+
+## 用途
+點擊觸發的下拉選單，用於 UserMenu、操作清單、更多選項（⋯）。基於 shadcn/ui DropdownMenu（Radix）。
+
+## 外觀
+- Background: `color.card.default`
+- Border: `color.border.default`
+- Border-radius: `radius.lg`（12px）
+- Shadow: `shadow.lg`
+- Padding（Container）: `spacing.1`（4px，上下）
+- Min-width: `160px`
+- Max-width: `240px`
+
+## Item 規格
+
+| State    | Background                    | Text Color         |
+|----------|-------------------------------|--------------------|
+| default  | 透明                           | `fg.default`       |
+| hover    | `color.bg.subtle`             | `fg.default`       |
+| focus    | `color.bg.subtle`             | `fg.default`       |
+| danger   | 透明（hover: `danger.subtle`） | `danger.default`  |
+| disabled | 透明                           | `fg.subtle`，`opacity: 0.5`|
+| checked  | 透明                           | `fg.default` + check icon |
+
+- Item height: `36px`（觸控目標 >= 44px 需 margin）
+- Item padding: `px-3 py-1.5`
+- Icon（左側）: `w-4 h-4`，`color: fg.muted`，`gap: spacing.2`
+- Kbd hint（右側）: `Kbd` 元件，`xs` size
+
+## 分隔線
+- `color.border.default`，`height: 1px`，`margin: spacing.1 0`
+
+## Sub Menu（選用）
+- ChevronRight icon 在 item 右側
+- 展開方向：右側，`sideOffset: 4px`
+
+## 動畫
+- Open: `fade-in scale(0.96)`，150ms
+- Close: `fade-out scale(0.96)`，100ms
+
+## Accessibility
+- `role="menu"` on content
+- `role="menuitem"` on items
+- `role="menuitemcheckbox"` on checkbox items
+- Keyboard: `↑↓` 導航，`Enter`/`Space` 選擇，`Escape` 關閉
+- 開啟時 focus 第一個非 disabled item

--- a/design/components/input/example.tsx
+++ b/design/components/input/example.tsx
@@ -1,0 +1,142 @@
+// Input 元件使用範例
+// 技術棧：Tailwind CSS v4 + shadcn/ui
+// 對應規格：design/components/input/spec.md
+
+import { Search, AlertCircle, Eye, EyeOff } from "lucide-react";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { useState } from "react";
+
+// --- 標準 Input（含 Label） ---
+export function StandardInput() {
+  return (
+    <div className="flex flex-col gap-1.5">
+      <Label htmlFor="email">Email</Label>
+      <Input
+        id="email"
+        type="email"
+        placeholder="name@example.com"
+        aria-required="true"
+      />
+    </div>
+  );
+}
+
+// --- 必填 Input ---
+export function RequiredInput() {
+  return (
+    <div className="flex flex-col gap-1.5">
+      <Label htmlFor="api-key">
+        API Key
+        <span
+          className="ml-1 text-[color:var(--danger)] text-xs"
+          aria-hidden="true"
+        >
+          *
+        </span>
+      </Label>
+      <Input
+        id="api-key"
+        type="password"
+        required
+        aria-required="true"
+        placeholder="sk-..."
+      />
+    </div>
+  );
+}
+
+// --- 含前置圖示 ---
+export function InputWithPrefix() {
+  return (
+    <div className="flex flex-col gap-1.5">
+      <Label htmlFor="search-lib">搜尋資料庫</Label>
+      <div className="relative">
+        <Search
+          className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-[color:var(--fg-muted)]"
+          aria-hidden="true"
+        />
+        <Input
+          id="search-lib"
+          type="search"
+          placeholder="輸入關鍵字..."
+          className="pl-9"
+          aria-label="搜尋資料庫"
+        />
+      </div>
+    </div>
+  );
+}
+
+// --- Error State ---
+export function InputWithError() {
+  return (
+    <div className="flex flex-col gap-1.5">
+      <Label htmlFor="username">使用者名稱</Label>
+      <Input
+        id="username"
+        type="text"
+        defaultValue="ab"
+        aria-describedby="username-error"
+        aria-invalid="true"
+        className="border-[color:var(--danger)] bg-[color:var(--danger-subtle)]"
+      />
+      <p
+        id="username-error"
+        role="alert"
+        className="flex items-center gap-1 text-sm text-[color:var(--danger)]"
+      >
+        <AlertCircle className="w-3.5 h-3.5 shrink-0" aria-hidden="true" />
+        使用者名稱至少需要 3 個字元
+      </p>
+    </div>
+  );
+}
+
+// --- Disabled State ---
+export function InputDisabled() {
+  return (
+    <div className="flex flex-col gap-1.5">
+      <Label htmlFor="readonly-field" className="text-[color:var(--fg-muted)]">
+        整合帳號（唯讀）
+      </Label>
+      <Input
+        id="readonly-field"
+        type="text"
+        defaultValue="gpwork4u@gmail.com"
+        disabled
+        aria-disabled="true"
+      />
+    </div>
+  );
+}
+
+// --- Password Input with Toggle ---
+export function PasswordInput() {
+  const [visible, setVisible] = useState(false);
+  return (
+    <div className="flex flex-col gap-1.5">
+      <Label htmlFor="password">密碼</Label>
+      <div className="relative">
+        <Input
+          id="password"
+          type={visible ? "text" : "password"}
+          placeholder="輸入密碼"
+          className="pr-10"
+        />
+        <button
+          type="button"
+          className="absolute right-3 top-1/2 -translate-y-1/2 text-[color:var(--fg-muted)] hover:text-[color:var(--fg-default)] transition-colors"
+          aria-label={visible ? "隱藏密碼" : "顯示密碼"}
+          onClick={() => setVisible((v) => !v)}
+        >
+          {visible ? (
+            <EyeOff className="w-4 h-4" aria-hidden="true" />
+          ) : (
+            <Eye className="w-4 h-4" aria-hidden="true" />
+          )}
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/design/components/input/spec.md
+++ b/design/components/input/spec.md
@@ -1,0 +1,63 @@
+# Input
+
+## 用途
+文字輸入欄位，支援前綴圖示、後綴元素、錯誤狀態。
+
+## Variants / States
+
+| State    | Border 色彩                 | 背景                     | 說明                   |
+|----------|-----------------------------|--------------------------|----------------------|
+| default  | `color.border.default`      | `color.bg.default`       | 標準                  |
+| hover    | `color.border.strong`       | `color.bg.default`       |                      |
+| focus    | `color.border.focus`        | `color.bg.default`       | ring 2px focus color |
+| error    | `color.danger.default`      | `color.danger.subtle`    | 含錯誤訊息            |
+| disabled | `color.border.default`      | `color.bg.muted`         | `opacity: 0.6`       |
+
+## 尺寸
+
+| Size | Height | Padding X | Padding Y | Font Size |
+|------|--------|-----------|-----------|-----------|
+| sm   | 32px   | 10px      | 6px       | `sm`      |
+| md   | 40px   | 12px      | 8px       | `base`    |
+| lg   | 48px   | 16px      | 10px      | `lg`      |
+
+## Props
+
+| Prop       | Type      | Default | 說明                       |
+|------------|-----------|---------|--------------------------|
+| label      | string    | -       | 必填，可見 label            |
+| placeholder| string    | -       | 輔助提示（不替代 label）    |
+| prefix     | ReactNode | -       | 前置圖示或文字              |
+| suffix     | ReactNode | -       | 後置圖示或清除按鈕          |
+| error      | string    | -       | 錯誤訊息（顯示於欄位下方）  |
+| hint       | string    | -       | 輔助說明（顯示於 label 右側或欄位下方）|
+| required   | boolean   | false   | 必填標示（label 旁紅點）    |
+| disabled   | boolean   | false   | 禁用狀態                   |
+| size       | 'sm' \| 'md' \| 'lg' | 'md' | 尺寸           |
+
+## Label 規格
+- Label 必須永遠可見（不使用 placeholder-only 模式）
+- Font: `text.label`（font-sm, font-weight-medium）
+- `required` 時顯示紅點（`color.danger.default`）或「必填」文字
+- `htmlFor` 綁定對應 input `id`
+
+## 錯誤訊息
+- 顯示於欄位正下方（`margin-top: spacing.1`）
+- Color: `color.danger.default`
+- Font: `font.size.sm`
+- 前置 AlertCircle icon（`w-3.5 h-3.5`）
+- `role="alert"` 或關聯 `aria-describedby`
+
+## Focus State
+- `ring: 2px solid color.border.focus`
+- `ring-offset: 2px`
+- 對比度 >= 3:1
+
+## Accessibility
+- `<label>` 與 input 透過 `htmlFor` / `id` 關聯
+- 錯誤訊息透過 `aria-describedby` 關聯
+- `required` 時：`aria-required="true"`
+- `disabled` 時：`aria-disabled="true"`
+
+## 使用範例
+見 `example.tsx`

--- a/design/components/kbd/spec.md
+++ b/design/components/kbd/spec.md
@@ -1,0 +1,38 @@
+# Kbd（鍵盤按鍵樣式）
+
+## 用途
+以視覺方式呈現鍵盤快捷鍵或按鍵提示，常用於 Command Palette、Tooltip、Help 頁面。
+
+## 外觀
+- 背景：`color.bg.muted`
+- Border：`color.border.default`（1px）
+- Bottom shadow：`0 1px 0 0 color.border.default`（立體感）
+- Border-radius：`radius.sm`（4px）
+- Font-family：`font.family.mono`
+- Font-size：`font.size.xs`（12px）
+- Color：`color.fg.muted`
+- Padding：`px-1.5 py-0.5`
+
+## Sizes
+
+| Size | Height | Padding X | Font Size |
+|------|--------|-----------|-----------|
+| xs   | 20px   | 4px       | `10px`    |
+| sm   | 24px   | 6px       | `xs`      |
+
+## 常用 Kbd 組合
+- `⌘K`：Command Palette
+- `⌘N`：新增筆記
+- `⌘,`：設定
+- `⌘\`：Copilot toggle
+- `Esc`：關閉
+- `↑` `↓`：上下導航
+- `↵`（Enter）：確認選擇
+- `Tab`：切換焦點
+
+## HTML 標籤
+使用語義化 `<kbd>` 標籤。
+
+## Accessibility
+- `<kbd>` 元素本身具語義，螢幕閱讀器會讀出內容
+- 複合快捷鍵（如 ⌘K）建議 `aria-label="Command K"` 補充

--- a/design/components/label/spec.md
+++ b/design/components/label/spec.md
@@ -1,0 +1,22 @@
+# Label
+
+## 用途
+表單欄位的可見標籤，必須永遠顯示（不可用 placeholder 替代）。
+
+## 外觀
+- Font: `text.label`（`font-sm`，`font-weight-medium`）
+- Color: `color.fg.default`
+- Disabled 狀態（parent disabled）: `color.fg.muted`，`cursor: not-allowed`
+
+## Required Indicator
+- 顯示位置：label 文字後方
+- 樣式：`color.danger.default`，`font-size: xs`
+- 建議以 `aria-hidden="true"` + `aria-required="true"` on input 雙保險
+
+## Hint Text
+- 顯示位置：label 右側（`flex justify-between`）或 input 下方
+- Font: `xs`，`color: fg.muted`
+
+## HTML 標籤
+- 語義化 `<label>` + `htmlFor` 關聯 input `id`
+- 避免使用 `div` 或 `span` 替代

--- a/design/components/layout-shell/example.tsx
+++ b/design/components/layout-shell/example.tsx
@@ -1,0 +1,263 @@
+// Layout Shell 使用範例
+// 技術棧：Tailwind CSS v4 + Next.js App Router
+// 對應規格：design/components/layout-shell/spec.md
+
+"use client";
+
+import { useState, useEffect, useCallback } from "react";
+import { Menu, PanelLeft, X, Bot } from "lucide-react";
+import { cn } from "@/lib/utils";
+import { Sheet, SheetContent } from "@/components/ui/sheet";
+import { Button } from "@/components/ui/button";
+import { SidebarNav, SidebarBottom } from "@/components/layout/sidebar-nav";
+import { SearchTrigger } from "@/components/layout/search-trigger";
+import { ThemeToggle } from "@/components/theme/theme-toggle";
+import { UserMenu } from "@/components/layout/user-menu";
+
+// --- Shell State Context ---
+interface ShellState {
+  sidebarCollapsed: boolean;
+  mobileSidebarOpen: boolean;
+  copilotOpen: boolean;
+  toggleSidebar: () => void;
+  toggleMobileSidebar: () => void;
+  toggleCopilot: () => void;
+}
+
+// --- TopBar ---
+function TopBar({
+  sidebarCollapsed,
+  onToggleSidebar,
+  onToggleMobile,
+  onToggleCopilot,
+  isMobile,
+}: {
+  sidebarCollapsed: boolean;
+  onToggleSidebar: () => void;
+  onToggleMobile: () => void;
+  onToggleCopilot: () => void;
+  isMobile: boolean;
+}) {
+  const sidebarWidth = sidebarCollapsed ? 64 : 240;
+
+  return (
+    <header
+      role="banner"
+      className={cn(
+        "fixed top-0 right-0 z-[300] h-14",
+        "bg-[color:var(--background)] border-b border-[color:var(--border)]",
+        "flex items-center px-4 gap-3",
+        "shadow-[0_1px_2px_0_oklch(0.10_0.008_240/0.04)]",
+        "transition-[left] duration-200 ease-[cubic-bezier(0.4,0,0.2,1)]",
+      )}
+      style={{ left: isMobile ? 0 : sidebarWidth }}
+    >
+      {/* Skip to content（a11y） */}
+      <a
+        href="#main-content"
+        className="sr-only focus:not-sr-only focus:absolute focus:top-4 focus:left-4 focus:z-[999] focus:px-4 focus:py-2 focus:bg-[color:var(--background)] focus:border focus:rounded-md focus:text-sm"
+      >
+        跳至主要內容
+      </a>
+
+      {/* Mobile 漢堡選單 */}
+      {isMobile ? (
+        <Button
+          variant="ghost"
+          size="sm"
+          iconOnly
+          icon={<Menu className="w-5 h-5" />}
+          aria-label="開啟導航選單"
+          onClick={onToggleMobile}
+        />
+      ) : (
+        /* Desktop Sidebar 收合 toggle */
+        <Button
+          variant="ghost"
+          size="sm"
+          iconOnly
+          icon={<PanelLeft className="w-5 h-5" />}
+          aria-label={sidebarCollapsed ? "展開側欄" : "收合側欄"}
+          aria-expanded={!sidebarCollapsed}
+          aria-controls="sidebar"
+          onClick={onToggleSidebar}
+        />
+      )}
+
+      {/* Search Trigger */}
+      <SearchTrigger className="flex-1 max-w-xs" />
+
+      {/* Right actions */}
+      <div className="ml-auto flex items-center gap-2">
+        <Button
+          variant="ghost"
+          size="sm"
+          iconOnly
+          icon={<Bot className="w-5 h-5" />}
+          aria-label="開啟 Copilot"
+          onClick={onToggleCopilot}
+        />
+        <ThemeToggle />
+        <UserMenu />
+      </div>
+    </header>
+  );
+}
+
+// --- Sidebar（Desktop） ---
+function DesktopSidebar({
+  collapsed,
+  id = "sidebar",
+}: {
+  collapsed: boolean;
+  id?: string;
+}) {
+  return (
+    <aside
+      id={id}
+      className={cn(
+        "fixed left-0 top-0 bottom-0 z-[300]",
+        "bg-[color:var(--sidebar-bg)] border-r border-[color:var(--sidebar-border)]",
+        "flex flex-col",
+        "transition-[width] duration-200 ease-[cubic-bezier(0.4,0,0.2,1)]",
+      )}
+      style={{ width: collapsed ? 64 : 240 }}
+      aria-hidden={false}
+    >
+      {/* Logo 區 */}
+      <div
+        className={cn(
+          "h-14 flex items-center border-b border-[color:var(--sidebar-border)] shrink-0",
+          collapsed ? "justify-center px-4" : "px-5",
+        )}
+      >
+        {collapsed ? (
+          <span className="font-bold text-lg select-none">a</span>
+        ) : (
+          <span className="font-bold text-xl select-none">aibo</span>
+        )}
+      </div>
+
+      {/* Nav */}
+      <nav aria-label="主要導航" className="flex-1 overflow-y-auto py-2">
+        <SidebarNav collapsed={collapsed} />
+      </nav>
+
+      {/* Bottom */}
+      <div className="shrink-0 border-t border-[color:var(--sidebar-border)] py-2">
+        <SidebarBottom collapsed={collapsed} />
+      </div>
+    </aside>
+  );
+}
+
+// --- CopilotSlot（右側抽屜，Desktop） ---
+function CopilotSlot({ open, onClose }: { open: boolean; onClose: () => void }) {
+  return (
+    <aside
+      className={cn(
+        "fixed right-0 top-14 bottom-0 z-[400]",
+        "w-[400px] bg-[color:var(--background)] border-l border-[color:var(--border)]",
+        "flex flex-col",
+        "transition-transform duration-200 ease-[cubic-bezier(0.4,0,0.2,1)]",
+        open ? "translate-x-0" : "translate-x-full",
+      )}
+      aria-label="Copilot 面板"
+      aria-hidden={!open}
+    >
+      <div className="h-14 flex items-center justify-between px-4 border-b border-[color:var(--border)]">
+        <span className="font-medium text-sm">Copilot</span>
+        <Button
+          variant="ghost"
+          size="sm"
+          iconOnly
+          icon={<X className="w-4 h-4" />}
+          aria-label="關閉 Copilot"
+          onClick={onClose}
+        />
+      </div>
+      <div className="flex-1 overflow-y-auto p-4">
+        {/* Copilot content slot */}
+      </div>
+    </aside>
+  );
+}
+
+// --- 完整 Layout Shell ---
+export function AppShell({ children }: { children: React.ReactNode }) {
+  const [sidebarCollapsed, setSidebarCollapsed] = useState(false);
+  const [mobileSidebarOpen, setMobileSidebarOpen] = useState(false);
+  const [copilotOpen, setCopilotOpen] = useState(false);
+  const [isMobile, setIsMobile] = useState(false);
+
+  // Responsive detection
+  useEffect(() => {
+    const mq = window.matchMedia("(max-width: 767px)");
+    setIsMobile(mq.matches);
+    const handler = (e: MediaQueryListEvent) => setIsMobile(e.matches);
+    mq.addEventListener("change", handler);
+    return () => mq.removeEventListener("change", handler);
+  }, []);
+
+  // ⌘\ toggle Copilot
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      if ((e.metaKey || e.ctrlKey) && e.key === "\\") {
+        e.preventDefault();
+        setCopilotOpen((v) => !v);
+      }
+    };
+    window.addEventListener("keydown", handler);
+    return () => window.removeEventListener("keydown", handler);
+  }, []);
+
+  const sidebarWidth = sidebarCollapsed ? 64 : 240;
+  const mainLeft = isMobile ? 0 : sidebarWidth;
+  const mainRight = copilotOpen && !isMobile ? 400 : 0;
+
+  return (
+    <div className="min-h-screen bg-[color:var(--background)]">
+      {/* Desktop Sidebar */}
+      {!isMobile && (
+        <DesktopSidebar collapsed={sidebarCollapsed} />
+      )}
+
+      {/* Mobile Sidebar（Sheet） */}
+      {isMobile && (
+        <Sheet open={mobileSidebarOpen} onOpenChange={setMobileSidebarOpen}>
+          <SheetContent side="left" className="w-72 p-0">
+            <DesktopSidebar collapsed={false} id="mobile-sidebar" />
+          </SheetContent>
+        </Sheet>
+      )}
+
+      {/* TopBar */}
+      <TopBar
+        sidebarCollapsed={sidebarCollapsed}
+        onToggleSidebar={() => setSidebarCollapsed((v) => !v)}
+        onToggleMobile={() => setMobileSidebarOpen((v) => !v)}
+        onToggleCopilot={() => setCopilotOpen((v) => !v)}
+        isMobile={isMobile}
+      />
+
+      {/* MainArea */}
+      <main
+        id="main-content"
+        className="min-h-screen pt-14 transition-[margin] duration-200 ease-[cubic-bezier(0.4,0,0.2,1)]"
+        style={{ marginLeft: mainLeft, marginRight: mainRight }}
+      >
+        <div className="max-w-[1200px] mx-auto px-6 py-6">
+          {children}
+        </div>
+      </main>
+
+      {/* Copilot Slot（Desktop） */}
+      {!isMobile && (
+        <CopilotSlot
+          open={copilotOpen}
+          onClose={() => setCopilotOpen(false)}
+        />
+      )}
+    </div>
+  );
+}

--- a/design/components/layout-shell/spec.md
+++ b/design/components/layout-shell/spec.md
@@ -1,0 +1,102 @@
+# Layout Shell
+
+## 用途
+整個 app 的骨架佈局，包含 Sidebar、TopBar、MainArea 三個 zone，以及可選的 CopilotSlot 右側抽屜。
+
+## 整體結構
+
+```
+┌─────────────────────────────────────────────────────────┐
+│  TopBar（fixed, h-14 = 56px, z-index: topbar）          │
+├──────────┬──────────────────────────────────┬───────────┤
+│ Sidebar  │  MainArea                        │ Copilot   │
+│          │  (max-w-[1200px] mx-auto)        │ Slot      │
+│  240px   │  px-6 py-6                       │ 400px     │
+│  (expand)│                                  │ (hidden   │
+│   64px   │                                  │  default) │
+│  (collap)│                                  │           │
+│          │                                  │           │
+└──────────┴──────────────────────────────────┴───────────┘
+```
+
+## Zone 規格
+
+### TopBar
+- Height: `layout.topbar-height`（56px）
+- Position: `fixed top-0 left-0 right-0`，`z-index: topbar`（300）
+- Background: `color.bg.default`，`border-bottom: color.border.default`
+- Shadow: `shadow.xs`
+- 左側：`padding-left` 根據 sidebar 狀態動態調整（240px / 64px）
+- 內容排列：
+  - 左側：Search 觸發按鈕（SearchTrigger）
+  - 右側：ThemeToggle + UserMenu（flex gap-2）
+
+### SearchTrigger（TopBar 左側）
+```
+[ Search icon ]  Search...  Ctrl+K
+```
+- 外觀：類 input 的按鈕，`border color.border.default`，`radius.md`
+- Width: `min-w-48 max-w-xs`
+- Click / ⌘K：開啟 Command Palette
+
+### Sidebar
+- Width expand: `layout.sidebar-expanded`（240px）
+- Width collapsed: `layout.sidebar-collapsed`（64px）
+- Position: `fixed left-0 top-14`（topbar 高度以下），`bottom-0`
+- Background: `color.sidebar.bg`
+- Border-right: `color.sidebar.border`
+- `z-index: sidebar`（300）
+- Transition: `width 200ms cubic-bezier(0.4, 0, 0.2, 1)`
+- 結構：
+  - Logo 區（h-14，`border-bottom: color.sidebar.border`）
+  - NavItems（`flex-1 overflow-y-auto`）
+  - Bottom（Settings + UserSection，`border-top`）
+
+### MainArea
+- `margin-left`: sidebar width（240px / 64px），responsive
+- `padding-top`: topbar height（56px）
+- `padding`: `spacing.6`（24px）
+- Inner `max-width`: `layout.main-max-width`（1200px），`mx-auto`
+
+### CopilotSlot（右側抽屜）
+- Width: `layout.copilot-width`（400px）
+- Position: `fixed right-0 top-14 bottom-0`
+- Toggle: ⌘\ 或右上角按鈕
+- Open/close animation: `translateX` 200ms ease
+- 開啟時 MainArea `margin-right` 增加 400px（避免遮擋）
+- Mobile：以 Sheet（底部抽屜）取代
+
+## 響應式行為
+
+| 斷點          | Sidebar          | CopilotSlot         | MainArea         |
+|-------------|------------------|---------------------|-----------------|
+| >= 1024px   | 固定展開（240px） | 可開啟（push 模式） | 依兩側 margin   |
+| 768-1023px  | 預設收合（64px） | 以 Sheet 取代       | margin-left: 64px |
+| < 768px     | 隱藏，漢堡選單開啟 Drawer | 以 Sheet 取代 | 全寬            |
+
+## Mobile Drawer（< 768px）
+- 觸發：TopBar 左側漢堡 icon（Menu，Lucide）
+- 使用 Sheet 元件（side="left"，width=280px）
+- Overlay 遮罩 `color.overlay`
+
+## Z-index 層疊
+```
+Toast (700)
+CmdK (900)
+Modal (600)
+Overlay (500)
+Popover (400)
+Sidebar/TopBar (300)
+Dropdown (100)
+Base (0)
+```
+
+## Accessibility
+- `<nav aria-label="主要導航">` 包覆 Sidebar
+- `<header role="banner">` 包覆 TopBar
+- `<main>` 包覆 MainArea
+- Skip-to-content 連結（隱藏，focus 時顯示，在 TopBar 前）
+- Sidebar toggle 按鈕：`aria-expanded`，`aria-controls="sidebar"`
+
+## 使用範例
+見 `example.tsx`

--- a/design/components/pill-nav/example.tsx
+++ b/design/components/pill-nav/example.tsx
@@ -1,0 +1,150 @@
+// Pill Nav 使用範例
+// 技術棧：Tailwind CSS v4 + Next.js App Router
+// 對應規格：design/components/pill-nav/spec.md
+
+"use client";
+
+import { usePathname } from "next/navigation";
+import Link from "next/link";
+import { cn } from "@/lib/utils";
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
+import {
+  Inbox,
+  BookOpen,
+  CalendarDays,
+  PenLine,
+  Settings,
+} from "lucide-react";
+
+const NAV_ITEMS = [
+  { href: "/inbox",   icon: Inbox,        label: "Inbox",   badge: 3 },
+  { href: "/library", icon: BookOpen,     label: "Library"           },
+  { href: "/today",   icon: CalendarDays, label: "今日"              },
+  { href: "/canvas",  icon: PenLine,      label: "Canvas"            },
+];
+
+// --- 單個 Pill Nav Item ---
+function PillNavItem({
+  href,
+  icon: Icon,
+  label,
+  active,
+  collapsed,
+  badge,
+}: {
+  href: string;
+  icon: React.ElementType;
+  label: string;
+  active?: boolean;
+  collapsed?: boolean;
+  badge?: number;
+}) {
+  const content = (
+    <Link
+      href={href}
+      aria-current={active ? "page" : undefined}
+      aria-label={collapsed ? label : undefined}
+      className={cn(
+        // Base styles
+        "relative flex items-center gap-3 rounded-md px-3 py-2 text-sm transition-colors duration-150",
+        "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[color:var(--ring)] focus-visible:ring-offset-2",
+        // Collapsed: center icon
+        collapsed && "justify-center px-0",
+        // Default state
+        !active && "text-[color:var(--sidebar-fg)] hover:bg-[color:var(--sidebar-active-bg)]/60 hover:text-[color:var(--sidebar-active-fg)]",
+        // Active state
+        active && "bg-[color:var(--sidebar-active-bg)] text-[color:var(--sidebar-active-fg)] font-medium",
+      )}
+    >
+      {/* 左側色條（active 狀態） */}
+      {active && (
+        <span
+          className="absolute left-0 top-1/2 -translate-y-1/2 w-[3px] h-[60%] rounded-r-sm bg-[color:var(--accent)]"
+          aria-hidden="true"
+        />
+      )}
+
+      {/* Icon */}
+      <Icon
+        className={cn("shrink-0", collapsed ? "w-5 h-5" : "w-5 h-5")}
+        aria-hidden="true"
+      />
+
+      {/* Label（展開模式） */}
+      {!collapsed && (
+        <span className="flex-1 truncate">{label}</span>
+      )}
+
+      {/* Badge */}
+      {!collapsed && badge && badge > 0 && (
+        <span
+          className="ml-auto flex h-5 min-w-5 items-center justify-center rounded-full bg-[color:var(--accent)] px-1 text-xs font-medium text-[color:var(--accent-fg)]"
+          aria-label={`${badge} 則未讀`}
+        >
+          {badge > 99 ? "99+" : badge}
+        </span>
+      )}
+    </Link>
+  );
+
+  if (collapsed) {
+    return (
+      <TooltipProvider delayDuration={300}>
+        <Tooltip>
+          <TooltipTrigger asChild>{content}</TooltipTrigger>
+          <TooltipContent side="right" sideOffset={8}>
+            {label}
+            {badge && badge > 0 && (
+              <span className="ml-1 text-xs opacity-70">({badge})</span>
+            )}
+          </TooltipContent>
+        </Tooltip>
+      </TooltipProvider>
+    );
+  }
+
+  return content;
+}
+
+// --- 完整 Sidebar Nav 範例 ---
+export function SidebarNav({ collapsed = false }: { collapsed?: boolean }) {
+  const pathname = usePathname();
+
+  return (
+    <nav
+      aria-label="主要導航"
+      className={cn(
+        "flex flex-col gap-1 px-2",
+        collapsed && "items-center"
+      )}
+    >
+      {NAV_ITEMS.map((item) => (
+        <PillNavItem
+          key={item.href}
+          href={item.href}
+          icon={item.icon}
+          label={item.label}
+          active={pathname.startsWith(item.href)}
+          collapsed={collapsed}
+          badge={item.badge}
+        />
+      ))}
+    </nav>
+  );
+}
+
+// --- Settings（底部分隔） ---
+export function SidebarBottom({ collapsed = false }: { collapsed?: boolean }) {
+  const pathname = usePathname();
+  return (
+    <div className={cn("px-2", collapsed && "flex flex-col items-center")}>
+      <PillNavItem
+        href="/settings"
+        icon={Settings}
+        label="設定"
+        active={pathname.startsWith("/settings")}
+        collapsed={collapsed}
+      />
+    </div>
+  );
+}

--- a/design/components/pill-nav/spec.md
+++ b/design/components/pill-nav/spec.md
@@ -1,0 +1,95 @@
+# Pill Nav（Sidebar Navigation Item）
+
+## 用途
+Sidebar 導航項目。以圓角 pill 包覆 active 狀態，搭配左側色條強調當前頁面。
+
+## 結構
+
+```
+[icon] [label]              ← 展開模式（sidebar 240px）
+[icon]                      ← 收合模式（sidebar 64px，tooltip 顯示 label）
+```
+
+## Variants
+
+| Variant  | 背景                        | 文字                     | 左側色條                     |
+|----------|----------------------------|--------------------------|------------------------------|
+| default  | 透明                        | `color.sidebar.fg`       | 無                           |
+| active   | `color.sidebar.active-bg`  | `color.sidebar.active-fg`| `color.accent.default`（3px）|
+| hover    | `color.sidebar.active-bg`（透明度 60%）| `color.sidebar.active-fg` | 無 |
+
+## 尺寸
+
+| 屬性           | 值                           |
+|---------------|------------------------------|
+| Height        | 40px（觸控目標 >= 44px 需外加 2px margin）|
+| Padding X     | `spacing.3`（12px）          |
+| Padding Y     | `spacing.2`（8px）           |
+| Border radius | `radius.md`（8px）           |
+| Icon size     | 20px x 20px                  |
+| Icon-label gap| `spacing.3`（12px）          |
+| 左側色條寬度   | 3px                          |
+
+## Active State 色條
+
+active item 左側 3px 色條：
+```css
+/* pseudo-element 實作 */
+.pill-nav-item.active::before {
+  content: '';
+  position: absolute;
+  left: 0;
+  top: 50%;
+  transform: translateY(-50%);
+  width: 3px;
+  height: 60%;
+  border-radius: 0 2px 2px 0;
+  background: var(--accent);
+}
+```
+
+## 動畫
+- hover/active 背景：`background-color 150ms ease`
+- sidebar 展開/收合：`width 200ms cubic-bezier(0.4, 0, 0.2, 1)`
+- 收合模式 label：`opacity 0` + `width 0`，`overflow: hidden`
+
+## Sidebar 整體結構
+
+```
+┌────────────────────────────────┐
+│ Logo（展開：aibo，收合：圖示）  │ h-14
+├────────────────────────────────┤
+│ [icon] Inbox                  │ ← pill-nav item
+│ [icon] Library                │
+│ [icon] 今日                   │
+│ [icon] Canvas                 │
+├────────────────────────────────┤ margin-top: auto
+│ [icon] Settings               │
+│ ─────────────────────────────  │ divider
+│ [avatar] User Name            │ user section
+└────────────────────────────────┘
+```
+
+## 收合模式（64px）
+- icon 置中顯示
+- label 不顯示
+- hover 時以 Tooltip（右側）顯示 label
+- Tooltip 延遲 300ms
+
+## Props
+
+| Prop     | Type      | Default | 說明              |
+|----------|-----------|---------|-----------------|
+| href     | string    | -       | 導航目標路徑      |
+| icon     | ReactNode | -       | Lucide 圖示元件  |
+| label    | string    | -       | 顯示文字          |
+| active   | boolean   | false   | 是否為當前頁面    |
+| collapsed| boolean   | false   | Sidebar 是否收合  |
+| badge    | number    | -       | 未讀計數 badge   |
+
+## Accessibility
+- `role="link"` 或 `<a>` 元素
+- active 項目：`aria-current="page"`
+- 收合模式：`aria-label={label}` 在 icon wrapper
+- Keyboard：Tab 切換，Enter 導航
+- 色條不作為唯一識別（同時搭配背景色變化）

--- a/design/components/popover/spec.md
+++ b/design/components/popover/spec.md
@@ -1,0 +1,27 @@
+# Popover
+
+## 用途
+點擊觸發的浮動面板，用於設定選項、日期選擇器、篩選器等。基於 shadcn/ui Popover（Radix）。
+
+## 外觀
+- Background: `color.card.default`
+- Border: `color.border.default`（1px）
+- Border-radius: `radius.lg`（12px）
+- Shadow: `shadow.lg`
+- Padding: `spacing.4`（16px）
+- Min-width: `192px`
+- Max-width: `320px`
+
+## 方向
+預設 `side="bottom"`，`align="start"`，Radix 自動調整避免溢出 viewport。
+- `sideOffset`: `8px`
+
+## 動畫
+- Open: `fade-in scale(0.95) → scale(1) opacity(1)`，150ms
+- Close: `scale(1) → scale(0.95) opacity(0)`，100ms
+
+## Accessibility
+- `role="dialog"` on PopoverContent
+- 開啟時 focus 移入 Popover 第一個互動元素
+- `Escape` 關閉並 restore focus
+- `aria-haspopup="true"` on trigger

--- a/design/components/select/spec.md
+++ b/design/components/select/spec.md
@@ -1,0 +1,37 @@
+# Select
+
+## 用途
+單選下拉選擇器。基於 shadcn/ui Select（Radix）。
+
+## 外觀（Trigger）
+- Height: `40px`（md），`32px`（sm），`48px`（lg）
+- Padding: `px-3 py-2`
+- Border: `color.border.default`，`radius.md`
+- Background: `color.bg.default`
+- Trailing icon: ChevronDown，`w-4 h-4`，`fg.muted`
+- Placeholder color: `fg.subtle`
+- Focus: `ring 2px color.border.focus`
+
+## Dropdown Content
+- Border: `color.border.default`
+- Shadow: `shadow.lg`
+- Radius: `radius.lg`
+- Padding: `spacing.1`（container）
+
+## SelectItem
+- Height: `36px`
+- Selected: CheckIcon 左側 + `fg.default`
+- Hover: `bg.subtle`
+- Disabled: `fg.subtle opacity-50`
+
+## States
+- Closed: 標準 trigger
+- Open: ring + ChevronDown rotate 180deg
+- Error: border `danger.default`，`bg danger.subtle`
+- Disabled: `bg.muted`，`opacity-60`，`cursor-not-allowed`
+
+## Accessibility
+- `role="combobox"` on trigger，`aria-expanded`，`aria-haspopup="listbox"`
+- `role="listbox"` on content
+- `role="option"` on items，`aria-selected`
+- Keyboard: `↑↓` 導航，`Enter`/`Space` 選擇，`Escape` 關閉

--- a/design/components/sheet/spec.md
+++ b/design/components/sheet/spec.md
@@ -1,0 +1,32 @@
+# Sheet
+
+## 用途
+從頁面邊緣滑入的抽屜面板，用於 Mobile Sidebar、CopilotSlot mobile 模式、詳情面板。基於 shadcn/ui Sheet（Radix Dialog）。
+
+## Sides
+
+| Side     | 觸發場景                        | 預設寬度     |
+|----------|---------------------------------|-------------|
+| left     | Mobile sidebar drawer           | `280px`     |
+| right    | Copilot panel（mobile），詳情   | `400px`（< 768px: 全寬）|
+| bottom   | 行動裝置 Copilot，操作選單      | `auto`（max-h: 80vh）|
+
+## 外觀
+- Background: `color.bg.default`
+- Border（left/right）: `color.border.default`（1px，對側邊）
+- Overlay: `color.overlay`（點擊關閉）
+- 無圓角（left/right），`radius.xl radius.xl 0 0`（bottom）
+
+## 動畫
+- left: `translateX(-100%) → translateX(0)`，200ms cubic-bezier(0.4,0,0.2,1)
+- right: `translateX(100%) → translateX(0)`，200ms
+- bottom: `translateY(100%) → translateY(0)`，200ms
+- 尊重 `prefers-reduced-motion`
+
+## SheetHeader
+- 高度：56px
+- 包含 SheetTitle + 關閉按鈕（X icon，absolute right-4 top-4）
+
+## Accessibility
+- 繼承 Dialog accessibility（role, aria-modal, focus trap, Escape 關閉）
+- `aria-label` on SheetContent 描述面板用途

--- a/design/components/tabs/spec.md
+++ b/design/components/tabs/spec.md
@@ -1,0 +1,37 @@
+# Tabs
+
+## 用途
+在同一空間中切換不同內容視圖。基於 shadcn/ui Tabs（Radix）。
+
+## Variants
+
+本專案採用 **underline** variant（editorial 風格，避免 pill 造成視覺過重）。
+
+| Variant   | Active 樣式                                            |
+|-----------|-------------------------------------------------------|
+| underline | 底部 2px 線，`color.accent.default`，無背景             |
+| pill      | `color.secondary.default` 背景，`radius.md`（備用）    |
+
+## 規格（Underline Variant）
+
+- TabsList：`border-bottom: color.border.default`，`flex gap-0`
+- TabsTrigger：
+  - Height: `40px`
+  - Padding: `px-4`
+  - Font: `font-sm font-medium`
+  - Default color: `fg.muted`
+  - Active color: `fg.default`
+  - Active indicator: `border-bottom: 2px solid color.accent.default`（`position: absolute bottom-0`）
+  - Hover: `fg.default`
+  - Focus: ring `color.border.focus`
+  - Disabled: `fg.subtle`，`opacity: 0.5`
+
+## TabsContent
+- `padding-top: spacing.4`
+- `outline: none`（focus style 由父元素管理）
+
+## Accessibility
+- `role="tablist"` on TabsList
+- `role="tab"` on TabsTrigger，`aria-selected`，`aria-controls`
+- `role="tabpanel"` on TabsContent，`aria-labelledby`
+- Keyboard: `←→` 切換 tab，`Home`/`End` 跳到首尾 tab，`Tab` 進入 panel

--- a/design/components/toast/spec.md
+++ b/design/components/toast/spec.md
@@ -1,0 +1,62 @@
+# Toast（Sonner）
+
+## 用途
+操作成功/失敗/警告的即時通知，非阻斷式。基於 `sonner` 套件。
+
+## Variants
+
+| Variant | 左側色條 / 圖示         | 用途                        |
+|---------|------------------------|----------------------------|
+| success | `color.success.default`，CheckCircle icon | 操作成功          |
+| error   | `color.danger.default`，XCircle icon      | 操作失敗          |
+| warning | `color.warning.default`，AlertTriangle icon | 警告提示         |
+| info    | `color.accent.default`，Info icon          | 一般資訊通知      |
+| loading | spinner，Loader2 icon  | 進行中（呼叫 toast.promise）|
+
+## 視覺規格
+- Position：`bottom-right`（桌面），`bottom-center`（手機）
+- Max-width：`360px`
+- Padding：`spacing.4`
+- Border-radius：`radius.lg`（12px）
+- Background：`color.card.default`
+- Border：`color.border.default`
+- Shadow：`shadow.lg`
+- 左側色條寬度：4px
+
+## 內容結構
+
+```
+[icon 20px] [title（font-medium）]
+             [description（font-sm, fg.muted）]   ← 選用
+                                         [action button] ← 選用
+                                         [X 關閉按鈕]
+```
+
+## Duration
+- success / info：4000ms
+- warning：6000ms
+- error：8000ms（需要使用者更主動注意）
+- loading：由 promise resolve 後自動切換
+
+## Z-index
+`z-index: toast`（700）
+
+## Props（toast() 呼叫）
+
+```typescript
+toast.success("儲存成功")
+toast.error("儲存失敗", { description: "請檢查網路連線" })
+toast.warning("注意：此操作無法復原")
+toast.info("已同步 GitHub commits")
+toast.promise(saveData(), {
+  loading: "儲存中...",
+  success: "儲存成功",
+  error: "儲存失敗",
+})
+```
+
+## Accessibility
+- `role="status"` 或 `role="alert"`（error）
+- `aria-live="polite"`（success/info）/ `aria-live="assertive"`（error）
+- 關閉按鈕有 `aria-label="關閉通知"`
+- 顏色不作為唯一識別符號（同時有文字 + 圖示）

--- a/design/components/tooltip/spec.md
+++ b/design/components/tooltip/spec.md
@@ -1,0 +1,35 @@
+# Tooltip
+
+## 用途
+hovering 或 focusing 互動元素時顯示的輔助說明文字。基於 shadcn/ui Tooltip（Radix）。
+
+## 外觀
+- Background: `color.fg.default`（深色，與頁面背景高對比）
+- Text color: `color.bg.default`（淺色文字）
+- Font: `xs`，`font-weight: medium`
+- Padding: `px-3 py-1.5`
+- Border-radius: `radius.sm`（4px）
+- Shadow: `shadow.md`
+- Max-width: `256px`，`text-wrap: balance`
+
+## 延遲（Delay）
+- Open delay: `300ms`（避免 accidental trigger）
+- Close delay: `0ms`（立即消失）
+- Sidebar 收合模式 Tooltip: `300ms`
+
+## 方向
+預設 `side="top"`，根據空間自動調整（Radix auto-placement）。
+- `sideOffset`: `6px`（與觸發元素的間距）
+
+## 箭頭
+- 不顯示箭頭（editorial 風格，簡潔）
+
+## 動畫
+- `opacity(0) scale(0.95) → opacity(1) scale(1)`，`100ms`
+- 尊重 `prefers-reduced-motion`（移除 scale，保留 opacity）
+
+## Accessibility
+- `role="tooltip"` on tooltip content
+- 觸發元素有 `aria-describedby` 指向 tooltip id
+- keyboard focus 也會觸發（不只 hover）
+- 不在 tooltip 內放互動元素

--- a/design/pages/command-palette.md
+++ b/design/pages/command-palette.md
@@ -1,0 +1,134 @@
+# Command Palette 頁面（Overlay）
+
+## 對應 Feature
+#196 F-037: Command Palette Skeleton
+
+## 用途
+全域命令入口，以 Dialog overlay 形式覆蓋在任意頁面之上。
+
+## Overlay 結構圖
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│  背景：color.overlay（深色 blur overlay，點擊關閉）              │
+│                                                                   │
+│         ┌────────────────────────────────────────┐               │
+│         │ [Search icon]  搜尋或輸入指令...        │  ← Input     │
+│         │ ─────────────────────────────────────── │              │
+│         │                                         │  h-px        │
+│         │ 最近使用                                │  ← Section  │
+│         │                                         │  header      │
+│         │ [icon] 今日會議紀錄        日誌          │  ← Item     │
+│         │ [icon] 週報 2026-04        日誌          │             │
+│         │ [icon] Q2 OKR 追蹤        資料庫    ←selected│        │
+│         │                                         │              │
+│         │ ─────────────────────────────────────── │              │
+│         │                                         │              │
+│         │ Actions                                 │              │
+│         │                                         │              │
+│         │ [icon] 新增筆記                    ⌘N   │              │
+│         │ [icon] 開啟設定                    ⌘,   │              │
+│         │                                         │              │
+│         │ ─────────────────────────────────────── │              │
+│         │ [↑][↓] 導航  [↵] 選擇  [Esc] 關閉      │  ← Footer   │
+│         └────────────────────────────────────────┘               │
+│                    w-[640px], max-h-[70vh]                        │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+## 尺寸規格
+
+| 元素                | 尺寸                                           |
+|--------------------|-----------------------------------------------|
+| Dialog width       | `640px`（含 overflow 隱藏）                   |
+| Dialog max-height  | `70vh`                                        |
+| Dialog border-radius| `radius.xl`（16px）                          |
+| Input 區高度       | `48px`                                        |
+| Item 高度          | `44px`（觸控目標）                             |
+| Section header     | `28px`                                        |
+| Footer 高度        | `36px`                                        |
+| Padding（左右）    | `spacing.0`（cmdk 內建處理）                  |
+
+## Selected Item 左側色條
+```css
+.cmdk-item[aria-selected="true"] {
+  background: var(--secondary);
+  position: relative;
+}
+.cmdk-item[aria-selected="true"]::before {
+  content: '';
+  position: absolute;
+  left: 0;
+  top: 0;
+  bottom: 0;
+  width: 3px;
+  background: var(--accent);
+  border-radius: 0 2px 2px 0;
+}
+```
+
+## 空結果狀態
+
+```
+┌────────────────────────────────────────────┐
+│ [Search icon]  abc                         │
+│ ─────────────────────────────────────────  │
+│                                            │
+│           [Search icon 32px]               │
+│        找不到「abc」的結果                  │
+│        試試其他關鍵字                        │
+│                                            │
+│ ─────────────────────────────────────────  │
+│ [↑][↓] 導航  [↵] 選擇  [Esc] 關閉          │
+└────────────────────────────────────────────┘
+```
+
+## 狀態說明
+
+| 狀態      | 觸發條件            | 呈現                                    |
+|----------|--------------------|-----------------------------------------|
+| 預設      | 剛開啟，無輸入      | 最近使用 + Actions 兩個群組              |
+| 輸入中    | 有搜尋文字          | 即時過濾，search icon 右側可顯示 spinner |
+| 有結果    | 搜尋命中 >= 1 筆    | 分組顯示，第一筆 auto-selected           |
+| 空結果    | 搜尋命中 0 筆       | 居中「找不到結果」提示                   |
+| API 錯誤  | 搜尋失敗            | 居中錯誤提示 + 重試按鈕                  |
+
+## 動畫規格
+
+| 動畫           | 效果                                               | 時長   |
+|---------------|---------------------------------------------------|--------|
+| Dialog 開啟   | `scale(0.96) opacity(0) → scale(1) opacity(1)`    | 150ms  |
+| Dialog 關閉   | `scale(1) opacity(1) → scale(0.96) opacity(0)`    | 100ms  |
+| Item hover    | `background-color`                                | 100ms  |
+| `prefers-reduced-motion` | 移除 scale transform，保留 opacity   | —      |
+
+## 元件使用
+
+| 元件        | 用途                        |
+|------------|-----------------------------|
+| CommandDialog（shadcn）| 外框 Dialog + cmdk       |
+| CommandInput| 搜尋輸入框                  |
+| CommandList | 結果列表容器（scroll）      |
+| CommandGroup| 群組容器（含群組 heading）  |
+| CommandItem | 單一結果項目                |
+| CommandEmpty| 空結果狀態                  |
+| CommandSeparator| 群組分隔線              |
+| Kbd         | 底部提示 + item 右側 kbd hint|
+
+## 色彩 Token
+
+| 元素               | Token                           |
+|-------------------|---------------------------------|
+| Overlay 背景       | `color.overlay`                 |
+| Dialog 背景        | `color.card.default`            |
+| Input 文字         | `color.fg.default`              |
+| Placeholder        | `color.fg.subtle`               |
+| Section header     | `color.fg.subtle`               |
+| Item 預設          | `color.fg.default`              |
+| Item hover bg      | `color.bg.subtle`               |
+| Item selected bg   | `color.secondary.default`       |
+| Item selected bar  | `color.accent.default`          |
+| Divider            | `color.border.default`          |
+| Footer text        | `color.fg.subtle`               |
+| Kbd bg             | `color.bg.muted`                |
+| Kbd border         | `color.border.default`          |

--- a/design/pages/dashboard-hub.md
+++ b/design/pages/dashboard-hub.md
@@ -1,0 +1,160 @@
+# Dashboard Hub 頁面
+
+## 對應 Feature
+#195 F-036: App Shell + Hybrid Routing — Dashboard 為預設首頁（`/`）
+
+## 用途
+App 啟動後的主視圖，以 4 個平行 slot 呈現 Inbox、Library、今日行程、Copilot 的摘要預覽。
+
+## Layout（桌面 >= 1024px）
+
+```
+┌──────────────────────────────────────────────────────────────────┐
+│  TopBar（h-14, fixed）                                           │
+│  [ PanelLeft ]  [ Search... ⌘K ]          [ Bot ] [ Theme ] [U] │
+├────────────┬─────────────────────────────────────────────────────┤
+│            │  max-w-[1200px] mx-auto px-6 py-6                   │
+│  Sidebar   │                                                      │
+│  (240px)   │  Page Header                                         │
+│            │  ┌─────────────────────────────────────────────┐    │
+│  [logo]    │  │ h2: 早安，{username}                         │    │
+│            │  │ p: 今天是 2026-04-27，有 3 件事待處理        │    │
+│  Inbox  ←  │  └─────────────────────────────────────────────┘    │
+│  Library   │                                                      │
+│  今日      │  Dashboard Grid（gap-6）                             │
+│  Canvas    │  ┌──────────────────┐  ┌──────────────────┐        │
+│            │  │ Inbox Card       │  │ Library Card     │        │
+│  ─────     │  │                  │  │                  │        │
+│  Settings  │  │ [icon] Inbox     │  │ [icon] Library   │        │
+│  [avatar]  │  │ 3 則未處理項目   │  │ 最近文件列表     │        │
+│            │  │              →   │  │              →   │        │
+│            │  └──────────────────┘  └──────────────────┘        │
+│            │  ┌──────────────────┐  ┌──────────────────┐        │
+│            │  │ Today Card       │  │ Copilot Card     │        │
+│            │  │                  │  │                  │        │
+│            │  │ [icon] 今日      │  │ [icon] Copilot   │        │
+│            │  │ 2 件行程         │  │ 詢問 AI 建議...  │        │
+│            │  │              →   │  │              →   │        │
+│            │  └──────────────────┘  └──────────────────┘        │
+└────────────┴─────────────────────────────────────────────────────┘
+```
+
+## Layout（平板 768-1023px）
+
+```
+┌──────────────────────────────────────────┐
+│  TopBar（h-14）                           │
+│  [ Menu ]  [ Search... ]     [ Theme ][U] │
+├────────┬─────────────────────────────────┤
+│Sidebar │  px-4 py-4                       │
+│(64px   │                                  │
+│collapsed│  Page Header                   │
+│        │  ┌────────────────────────────┐  │
+│[icons] │  │ 早安，{username}            │  │
+│        │  └────────────────────────────┘  │
+│        │                                  │
+│        │  Grid（2 columns, gap-4）        │
+│        │  ┌──────────┐  ┌──────────┐     │
+│        │  │ Inbox    │  │ Library  │     │
+│        │  └──────────┘  └──────────┘     │
+│        │  ┌──────────┐  ┌──────────┐     │
+│        │  │ Today    │  │ Copilot  │     │
+│        │  └──────────┘  └──────────┘     │
+└────────┴─────────────────────────────────┘
+```
+
+## Layout（Mobile < 768px）
+
+```
+┌─────────────────────────┐
+│  TopBar（h-14）          │
+│  [ Menu ] Search  [U]   │
+├─────────────────────────┤
+│  px-4 py-4              │
+│                         │
+│  早安，{username}        │
+│  今天是 2026-04-27       │
+│                         │
+│  ┌─────────────────┐    │
+│  │   Inbox Card    │    │
+│  └─────────────────┘    │
+│  ┌─────────────────┐    │
+│  │  Library Card   │    │
+│  └─────────────────┘    │
+│  ┌─────────────────┐    │
+│  │   Today Card    │    │
+│  └─────────────────┘    │
+│  ┌─────────────────┐    │
+│  │  Copilot Card   │    │
+│  └─────────────────┘    │
+│                         │
+└─────────────────────────┘
+```
+
+## 使用的元件
+
+| 元件               | 規格位置                                | 用途                        |
+|-------------------|-----------------------------------------|-----------------------------|
+| AppShell          | `components/layout-shell/spec.md`       | 整體殼層                    |
+| Card（x4）        | `components/card/spec.md`               | Dashboard 4 個 slot 卡片   |
+| PillNav           | `components/pill-nav/spec.md`           | Sidebar 導航                |
+| Button（link）    | `components/button/spec.md`             | 「查看更多 →」              |
+| Skeleton          | shadcn/ui                               | 卡片 loading state          |
+
+## 狀態 Mocks
+
+### 1. 預設展開（正常載入）
+- 所有卡片顯示真實資料
+- Inbox badge 顯示未讀計數
+
+### 2. 部分載入中（Skeleton）
+- 某一卡片 CardContent 以 Skeleton 替換
+- CardHeader 仍正常顯示 icon + title
+- `aria-busy="true"` on CardContent
+
+### 3. 某卡片錯誤
+- 對應 CardErrorState（見 card/example.tsx）
+- Border 變 `color.danger.default`
+- 顯示錯誤訊息 + 重試按鈕
+
+### 4. Dark Mode
+- 所有色彩切換為 `color.dark.*` tokens
+- Card bg：`color.dark.card.default`（深色）
+- 邊框：`color.dark.border.default`
+
+## Page Header 規格
+
+```tsx
+<section aria-label="Dashboard 歡迎訊息" className="mb-6">
+  <h1 className="text-2xl font-semibold text-[color:var(--fg-default)]">
+    早安，{username}
+  </h1>
+  <p className="text-sm text-[color:var(--fg-muted)] mt-1">
+    今天是 {formattedDate}，有 {pendingCount} 件事待處理
+  </p>
+</section>
+```
+
+## 卡片排列（Grid CSS）
+
+```css
+/* Tailwind v4 */
+.dashboard-grid {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 1rem; /* spacing.4 */
+}
+
+@media (min-width: 768px) {
+  .dashboard-grid {
+    grid-template-columns: repeat(2, 1fr);
+    gap: 1rem; /* spacing.4 */
+  }
+}
+
+@media (min-width: 1024px) {
+  .dashboard-grid {
+    gap: 1.5rem; /* spacing.6 */
+  }
+}
+```

--- a/design/pages/login.md
+++ b/design/pages/login.md
@@ -1,0 +1,87 @@
+# Login 頁面
+
+## 對應 Feature
+F-036（App Shell routing，bare layout — 不含 Sidebar/TopBar）
+
+## 用途
+API Key 登入入口，極簡卡片置中佈局。
+
+## Layout
+
+```
+┌─────────────────────────────────────────────┐
+│  背景：color.bg.subtle（米白）               │
+│                                              │
+│                                              │
+│         ┌────────────────────────┐           │
+│         │ [Logo]  aibo           │  w-96     │
+│         │                        │           │
+│         │ ─────────────────────  │           │
+│         │                        │           │
+│         │  登入你的 aibo          │           │
+│         │  輸入 API Key 以繼續    │           │
+│         │                        │           │
+│         │  API Key               │           │
+│         │  [─────────────────]   │           │
+│         │  取得 API Key →        │           │
+│         │                        │           │
+│         │  [        登入        ]│           │
+│         │                        │           │
+│         │  ← 錯誤時顯示          │           │
+│         │  [!] 無效的 API Key    │           │
+│         └────────────────────────┘           │
+│                                              │
+└─────────────────────────────────────────────┘
+```
+
+## Card 規格
+- Width：`w-full max-w-sm`（384px）
+- 置中：`min-h-screen flex items-center justify-center`
+- Background：`color.bg.subtle`（頁面底層）
+- Card variant：`default`（白底 + 邊框 + shadow.sm）
+- Card padding：`spacing.8`（32px）
+
+## 內容規格
+
+### Logo 區
+- Logo：文字 "aibo"，`font.display`，`2xl`，`font-bold`
+- Subtitle：`text-sm text-fg-muted`，`margin-bottom: spacing.6`
+
+### Form
+- Label：`API Key`（visible，required indicator）
+- Input：`type="password"`，`placeholder="sk-..."`，`size="md"`
+- 連結：「如何取得 API Key？」`variant="link"` Button，`size="sm"`
+- Submit Button：`variant="default"`，`size="lg"`，`fullWidth`，submit 時 `loading`
+
+### 錯誤狀態
+- 位置：Submit Button 上方
+- 樣式：`role="alert"` 容器，`border color.danger.default`，`bg color.danger.subtle`
+- 圖示：AlertCircle，`w-4 h-4`
+- 文字：`text-sm text-danger`
+
+## 色彩 Token
+
+| 元素           | Token                        |
+|---------------|------------------------------|
+| 頁面背景       | `color.bg.subtle`            |
+| Card 背景      | `color.card.default`         |
+| Logo           | `color.fg.default`           |
+| Input border（focus）| `color.border.focus`  |
+| 錯誤文字       | `color.danger.default`       |
+| 錯誤背景       | `color.danger.subtle`        |
+| CTA Button     | `color.primary.default`      |
+
+## 響應式
+
+| 斷點      | 變化                                  |
+|----------|--------------------------------------|
+| >= 640px | Card 居中，padding-x 24px            |
+| < 640px  | 全寬，padding-x 16px，`rounded-none` |
+
+## Accessibility
+- `<main>` 包覆整個頁面
+- Form `aria-label="API Key 登入"`
+- Input 必須有 `<label>`（不用 placeholder 替代）
+- Submit 按鈕 loading 時：`aria-busy="true"`，`aria-label="登入中"`
+- 錯誤訊息：`role="alert"`，`aria-live="assertive"`
+- `autofocus` on API Key input

--- a/design/pages/shell-layout.md
+++ b/design/pages/shell-layout.md
@@ -1,0 +1,107 @@
+# App Shell Layout
+
+## 對應 Feature
+#195 F-036: App Shell + Hybrid Routing
+
+## 用途
+所有認證後頁面的共用骨架，定義 Sidebar / TopBar / MainArea / CopilotSlot 的位置關係與互動規則。
+
+## 完整結構圖
+
+```
+┌──────────────────────────────────────────────────────────────────┐
+│  [Skip to content 隱藏連結（focus 時顯示）]                       │
+│  ─────────────────────────────────────────────────────────────── │
+│  TopBar（fixed, z-300）                                           │
+│  ┌────────┬──────────────────────────────┬───────────────────┐   │
+│  │[Toggle]│ [Search...          ⌘K]      │[Bot][Theme][User] │   │
+│  └────────┴──────────────────────────────┴───────────────────┘   │
+│                                                                    │
+│  Sidebar（fixed, z-300）       MainArea                           │
+│  ┌────────────────┐            ┌──────────────────────────────┐  │
+│  │ [Logo] aibo    │            │  pt-14（topbar offset）       │  │
+│  │ ────────────── │            │  max-w-[1200px] mx-auto      │  │
+│  │ [i] Inbox   3  │            │  px-6 py-6                   │  │
+│  │ [i] Library    │            │                              │  │
+│  │ [i] 今日       │            │  {page content}              │  │
+│  │ [i] Canvas     │            │                              │  │
+│  │ ────────────── │            │                              │  │
+│  │ flex-1 nav     │            │                              │  │
+│  │ ────────────── │            │                              │  │
+│  │ [i] Settings   │            └──────────────────────────────┘  │
+│  │ ────────────── │                                               │
+│  │ [Ava] Username │                                               │
+│  └────────────────┘                                               │
+│                                          CopilotSlot（z-400）     │
+│                                          ┌─────────────────────┐  │
+│                                          │[Copilot] ────── [X] │  │
+│                                          │                     │  │
+│                                          │  chat interface     │  │
+│                                          │                     │  │
+│                                          └─────────────────────┘  │
+└──────────────────────────────────────────────────────────────────┘
+```
+
+## 尺寸一覽
+
+| Zone            | 規格                                          |
+|----------------|----------------------------------------------|
+| TopBar          | `height: 56px`，`fixed top-0`，`z-300`       |
+| Sidebar expand  | `width: 240px`，`fixed left-0 top-0 bottom-0`|
+| Sidebar collapse| `width: 64px`                                |
+| MainArea        | `margin-left: sidebar-width`，`padding-top: 56px` |
+| MainArea inner  | `max-width: 1200px`，`margin: 0 auto`，`padding: 24px` |
+| CopilotSlot     | `width: 400px`，`fixed right-0 top-56px`     |
+
+## 互動規則
+
+### Sidebar Toggle（Desktop）
+- 按鈕：TopBar 左側 PanelLeft icon
+- 動作：`width 240px ↔ 64px`，`transition 200ms cubic-bezier(0.4,0,0.2,1)`
+- 收合時：icon 對齊中央，label 隱藏，hover 顯示 Tooltip
+- 狀態持久化：儲存至 localStorage（`sidebar-collapsed`）
+
+### Mobile Sidebar（< 768px）
+- TopBar 左側改顯示 Menu icon
+- 點擊開啟 `Sheet`（side="left"，width=280px）
+- Sheet 外點擊自動關閉
+- Sheet 內結構與展開 Sidebar 相同（不收合）
+
+### CopilotSlot（Desktop）
+- 觸發：`⌘\`（macOS）/ `Ctrl+\`（Windows）或 TopBar Bot icon
+- 開啟：`translateX(0)`，MainArea `margin-right += 400px`
+- 關閉：`translateX(100%)`，MainArea `margin-right = 0`
+- Mobile：以 `Sheet`（side="bottom"）取代
+
+## 色彩 Token 對應
+
+| 區域                | Token                           |
+|--------------------|---------------------------------|
+| TopBar background  | `color.bg.default`              |
+| TopBar border-bottom| `color.border.default`         |
+| Sidebar background | `color.sidebar.bg`              |
+| Sidebar border     | `color.sidebar.border`          |
+| MainArea background| `color.bg.default`              |
+| CopilotSlot border | `color.border.default`          |
+| Logo text          | `color.fg.default`              |
+| Nav item（default）| `color.sidebar.fg`              |
+| Nav item（active） | `color.sidebar.active-fg` + `color.sidebar.active-bg` |
+| Active accent bar  | `color.accent.default`          |
+
+## Skip-to-content
+```html
+<a href="#main-content"
+   class="sr-only focus:not-sr-only focus:fixed focus:top-4 focus:left-4 focus:z-[999] focus:px-4 focus:py-2 focus:rounded-md focus:bg-background focus:border focus:text-sm">
+  跳至主要內容
+</a>
+```
+
+## 元件參照
+
+| 元件            | 規格文件                              |
+|----------------|---------------------------------------|
+| PillNav        | `components/pill-nav/spec.md`         |
+| Button（ghost）| `components/button/spec.md`           |
+| Sheet          | shadcn/ui（對齊 token）              |
+| ThemeToggle    | `components/theme-toggle/spec.md`     |
+| CommandPalette | `components/command/spec.md`          |

--- a/design/tokens/colors.json
+++ b/design/tokens/colors.json
@@ -1,0 +1,161 @@
+{
+  "_comment": "aibo Design Tokens — Color System (Sprint 13)\nBased on globals.css CSS variables, editorial paper-style aesthetic.\nOKLCH values align with Tailwind CSS v4 @theme inline convention.\nAll tokens exist in both light and dark modes.",
+
+  "color": {
+    "light": {
+      "bg": {
+        "default":  "oklch(0.99 0.004 85)",
+        "subtle":   "oklch(0.97 0.005 85)",
+        "muted":    "oklch(0.94 0.006 85)",
+        "inverse":  "oklch(0.12 0.008 240)"
+      },
+      "fg": {
+        "default":  "oklch(0.14 0.010 240)",
+        "muted":    "oklch(0.46 0.010 240)",
+        "subtle":   "oklch(0.62 0.008 240)",
+        "inverse":  "oklch(0.98 0.004 0)"
+      },
+      "border": {
+        "default":  "oklch(0.90 0.006 240)",
+        "strong":   "oklch(0.84 0.008 240)",
+        "focus":    "oklch(0.55 0.080 240)"
+      },
+      "primary": {
+        "default":  "oklch(0.14 0.010 240)",
+        "hover":    "oklch(0.22 0.012 240)",
+        "active":   "oklch(0.10 0.008 240)",
+        "fg":       "oklch(0.98 0.004 0)"
+      },
+      "secondary": {
+        "default":  "oklch(0.94 0.006 240)",
+        "hover":    "oklch(0.90 0.008 240)",
+        "active":   "oklch(0.86 0.010 240)",
+        "fg":       "oklch(0.14 0.010 240)"
+      },
+      "accent": {
+        "default":  "oklch(0.60 0.080 250)",
+        "subtle":   "oklch(0.92 0.020 250)",
+        "fg":       "oklch(0.98 0.004 0)"
+      },
+      "danger": {
+        "default":  "oklch(0.55 0.180 25)",
+        "subtle":   "oklch(0.94 0.030 25)",
+        "hover":    "oklch(0.48 0.190 25)",
+        "fg":       "oklch(0.98 0.004 0)"
+      },
+      "warning": {
+        "default":  "oklch(0.68 0.160 65)",
+        "subtle":   "oklch(0.95 0.040 65)",
+        "fg":       "oklch(0.24 0.060 65)"
+      },
+      "success": {
+        "default":  "oklch(0.55 0.140 145)",
+        "subtle":   "oklch(0.93 0.030 145)",
+        "fg":       "oklch(0.98 0.004 0)"
+      },
+      "card": {
+        "default":  "oklch(0.99 0.004 85)",
+        "border":   "oklch(0.90 0.006 240)"
+      },
+      "sidebar": {
+        "bg":        "oklch(0.97 0.005 85)",
+        "fg":        "oklch(0.28 0.012 240)",
+        "active-bg": "oklch(0.94 0.006 85)",
+        "active-fg": "oklch(0.14 0.010 240)",
+        "border":    "oklch(0.88 0.008 220)"
+      },
+      "ring":        "oklch(0.14 0.010 240)",
+      "input":       "oklch(0.90 0.006 240)",
+      "overlay":     "oklch(0.10 0.008 240 / 0.55)"
+    },
+
+    "dark": {
+      "bg": {
+        "default":  "oklch(0.14 0.012 240)",
+        "subtle":   "oklch(0.17 0.012 240)",
+        "muted":    "oklch(0.20 0.012 240)",
+        "inverse":  "oklch(0.96 0.005 85)"
+      },
+      "fg": {
+        "default":  "oklch(0.96 0.005 0)",
+        "muted":    "oklch(0.65 0.010 240)",
+        "subtle":   "oklch(0.48 0.010 240)",
+        "inverse":  "oklch(0.14 0.010 240)"
+      },
+      "border": {
+        "default":  "oklch(0.26 0.012 240)",
+        "strong":   "oklch(0.34 0.012 240)",
+        "focus":    "oklch(0.72 0.060 240)"
+      },
+      "primary": {
+        "default":  "oklch(0.96 0.005 0)",
+        "hover":    "oklch(0.88 0.006 0)",
+        "active":   "oklch(0.80 0.008 0)",
+        "fg":       "oklch(0.14 0.010 240)"
+      },
+      "secondary": {
+        "default":  "oklch(0.22 0.012 240)",
+        "hover":    "oklch(0.26 0.014 240)",
+        "active":   "oklch(0.30 0.014 240)",
+        "fg":       "oklch(0.96 0.005 0)"
+      },
+      "accent": {
+        "default":  "oklch(0.68 0.080 250)",
+        "subtle":   "oklch(0.24 0.030 250)",
+        "fg":       "oklch(0.98 0.004 0)"
+      },
+      "danger": {
+        "default":  "oklch(0.45 0.160 25)",
+        "subtle":   "oklch(0.22 0.040 25)",
+        "hover":    "oklch(0.50 0.170 25)",
+        "fg":       "oklch(0.98 0.004 0)"
+      },
+      "warning": {
+        "default":  "oklch(0.68 0.160 65)",
+        "subtle":   "oklch(0.24 0.040 65)",
+        "fg":       "oklch(0.24 0.060 65)"
+      },
+      "success": {
+        "default":  "oklch(0.52 0.130 145)",
+        "subtle":   "oklch(0.20 0.040 145)",
+        "fg":       "oklch(0.98 0.004 0)"
+      },
+      "card": {
+        "default":  "oklch(0.14 0.012 240)",
+        "border":   "oklch(0.26 0.012 240)"
+      },
+      "sidebar": {
+        "bg":        "oklch(0.17 0.012 240)",
+        "fg":        "oklch(0.80 0.008 240)",
+        "active-bg": "oklch(0.22 0.012 240)",
+        "active-fg": "oklch(0.96 0.005 0)",
+        "border":    "oklch(0.26 0.012 240)"
+      },
+      "ring":        "oklch(0.72 0.060 240)",
+      "input":       "oklch(0.26 0.012 240)",
+      "overlay":     "oklch(0.08 0.010 240 / 0.65)"
+    },
+
+    "_css-variable-mapping": {
+      "--background":          "color.{mode}.bg.default",
+      "--foreground":          "color.{mode}.fg.default",
+      "--card":                "color.{mode}.card.default",
+      "--card-foreground":     "color.{mode}.fg.default",
+      "--popover":             "color.{mode}.card.default",
+      "--popover-foreground":  "color.{mode}.fg.default",
+      "--primary":             "color.{mode}.primary.default",
+      "--primary-foreground":  "color.{mode}.primary.fg",
+      "--secondary":           "color.{mode}.secondary.default",
+      "--secondary-foreground":"color.{mode}.secondary.fg",
+      "--muted":               "color.{mode}.secondary.default",
+      "--muted-foreground":    "color.{mode}.fg.muted",
+      "--accent":              "color.{mode}.secondary.default",
+      "--accent-foreground":   "color.{mode}.secondary.fg",
+      "--destructive":         "color.{mode}.danger.default",
+      "--destructive-foreground":"color.{mode}.danger.fg",
+      "--border":              "color.{mode}.border.default",
+      "--input":               "color.{mode}.input",
+      "--ring":                "color.{mode}.ring"
+    }
+  }
+}

--- a/design/tokens/radii.json
+++ b/design/tokens/radii.json
@@ -1,0 +1,31 @@
+{
+  "_comment": "aibo Border Radius Tokens (Sprint 13)\nEditorial style: subtle rounding, not pill-heavy.",
+
+  "radius": {
+    "none": "0",
+    "sm":   "0.25rem",
+    "md":   "0.5rem",
+    "lg":   "0.75rem",
+    "xl":   "1rem",
+    "2xl":  "1.5rem",
+    "full": "9999px",
+    "_px": {
+      "sm":  "4px",
+      "md":  "8px",
+      "lg":  "12px",
+      "xl":  "16px",
+      "2xl": "24px"
+    },
+    "_semantic": {
+      "button":     "md",
+      "card":       "lg",
+      "input":      "md",
+      "badge":      "full",
+      "pill-nav":   "full",
+      "modal":      "xl",
+      "tooltip":    "sm",
+      "popover":    "lg",
+      "kbd":        "sm"
+    }
+  }
+}

--- a/design/tokens/shadows.json
+++ b/design/tokens/shadows.json
@@ -1,0 +1,31 @@
+{
+  "_comment": "aibo Shadow Tokens (Sprint 13)\nEditorial style: fine single-layer shadows + border combination.\nAvoid heavy drop shadows — prefer border + subtle elevation.",
+
+  "shadow": {
+    "none":  "none",
+    "xs":    "0 1px 2px 0 oklch(0.10 0.008 240 / 0.04)",
+    "sm":    "0 1px 3px 0 oklch(0.10 0.008 240 / 0.06), 0 1px 2px -1px oklch(0.10 0.008 240 / 0.04)",
+    "md":    "0 4px 6px -1px oklch(0.10 0.008 240 / 0.07), 0 2px 4px -2px oklch(0.10 0.008 240 / 0.05)",
+    "lg":    "0 10px 15px -3px oklch(0.10 0.008 240 / 0.07), 0 4px 6px -4px oklch(0.10 0.008 240 / 0.05)",
+    "xl":    "0 20px 25px -5px oklch(0.10 0.008 240 / 0.08), 0 8px 10px -6px oklch(0.10 0.008 240 / 0.04)",
+    "inner": "inset 0 2px 4px 0 oklch(0.10 0.008 240 / 0.05)",
+    "_semantic": {
+      "card":     "sm",
+      "card-hover": "md",
+      "dropdown": "lg",
+      "modal":    "xl",
+      "popover":  "lg",
+      "sidebar":  "sm",
+      "topbar":   "xs",
+      "input-focus": "0 0 0 3px oklch(0.14 0.010 240 / 0.15)"
+    },
+    "_dark": {
+      "_note": "Dark mode: reduce shadow opacity, shadows are less visible on dark bg",
+      "xs":  "0 1px 2px 0 oklch(0.05 0.008 240 / 0.30)",
+      "sm":  "0 1px 3px 0 oklch(0.05 0.008 240 / 0.35), 0 1px 2px -1px oklch(0.05 0.008 240 / 0.25)",
+      "md":  "0 4px 6px -1px oklch(0.05 0.008 240 / 0.40), 0 2px 4px -2px oklch(0.05 0.008 240 / 0.30)",
+      "lg":  "0 10px 15px -3px oklch(0.05 0.008 240 / 0.40), 0 4px 6px -4px oklch(0.05 0.008 240 / 0.30)",
+      "input-focus": "0 0 0 3px oklch(0.72 0.060 240 / 0.25)"
+    }
+  }
+}

--- a/design/tokens/spacing.json
+++ b/design/tokens/spacing.json
@@ -1,0 +1,65 @@
+{
+  "_comment": "aibo Spacing Tokens (Sprint 13)\n4px base grid, 8-step scale + extended values.\nAll values use rem for accessibility (respects user font size preference).",
+
+  "spacing": {
+    "0":   "0",
+    "px":  "1px",
+    "0.5": "0.125rem",
+    "1":   "0.25rem",
+    "1.5": "0.375rem",
+    "2":   "0.5rem",
+    "2.5": "0.625rem",
+    "3":   "0.75rem",
+    "3.5": "0.875rem",
+    "4":   "1rem",
+    "5":   "1.25rem",
+    "6":   "1.5rem",
+    "7":   "1.75rem",
+    "8":   "2rem",
+    "10":  "2.5rem",
+    "12":  "3rem",
+    "14":  "3.5rem",
+    "16":  "4rem",
+    "20":  "5rem",
+    "24":  "6rem",
+    "32":  "8rem",
+    "40":  "10rem",
+    "48":  "12rem",
+    "64":  "16rem",
+    "_px": {
+      "1":  "4px",
+      "2":  "8px",
+      "3":  "12px",
+      "4":  "16px",
+      "6":  "24px",
+      "8":  "32px",
+      "12": "48px",
+      "16": "64px"
+    }
+  },
+
+  "layout": {
+    "sidebar-expanded":   "240px",
+    "sidebar-collapsed":  "64px",
+    "topbar-height":      "56px",
+    "main-max-width":     "1200px",
+    "copilot-width":      "400px",
+    "content-padding-x":  "1.5rem",
+    "content-padding-y":  "1.5rem",
+    "card-padding":       "1.5rem",
+    "section-gap":        "2rem"
+  },
+
+  "breakpoints": {
+    "sm":  "640px",
+    "md":  "768px",
+    "lg":  "1024px",
+    "xl":  "1280px",
+    "2xl": "1536px"
+  },
+
+  "touch": {
+    "min-target": "44px",
+    "min-gap":    "8px"
+  }
+}

--- a/design/tokens/typography.json
+++ b/design/tokens/typography.json
@@ -1,0 +1,137 @@
+{
+  "_comment": "aibo Typography Tokens (Sprint 13)\nEditorial mixed-serif aesthetic: Inter (sans) + Source Serif 4 (serif).\nModular scale: 12/14/16/18/20/24/30/36/48px",
+
+  "font": {
+    "family": {
+      "sans":    "Inter, 'Noto Sans TC', system-ui, -apple-system, sans-serif",
+      "serif":   "'Source Serif 4', 'Noto Serif TC', Georgia, serif",
+      "mono":    "'JetBrains Mono', 'Fira Code', Menlo, monospace",
+      "display": "'Source Serif 4', 'Noto Serif TC', Georgia, serif"
+    },
+
+    "size": {
+      "xs":   "0.75rem",
+      "sm":   "0.875rem",
+      "base": "1rem",
+      "lg":   "1.125rem",
+      "xl":   "1.25rem",
+      "2xl":  "1.5rem",
+      "3xl":  "1.875rem",
+      "4xl":  "2.25rem",
+      "5xl":  "3rem",
+      "_px": {
+        "xs":   "12px",
+        "sm":   "14px",
+        "base": "16px",
+        "lg":   "18px",
+        "xl":   "20px",
+        "2xl":  "24px",
+        "3xl":  "30px",
+        "4xl":  "36px",
+        "5xl":  "48px"
+      }
+    },
+
+    "weight": {
+      "normal":   "400",
+      "medium":   "500",
+      "semibold": "600",
+      "bold":     "700"
+    },
+
+    "lineHeight": {
+      "none":     "1",
+      "tight":    "1.25",
+      "snug":     "1.375",
+      "normal":   "1.5",
+      "relaxed":  "1.625",
+      "loose":    "1.75"
+    },
+
+    "letterSpacing": {
+      "tighter": "-0.05em",
+      "tight":   "-0.025em",
+      "normal":  "0em",
+      "wide":    "0.025em",
+      "wider":   "0.05em",
+      "widest":  "0.1em"
+    },
+
+    "maxWidth": {
+      "prose": "65ch",
+      "wide":  "75ch"
+    }
+  },
+
+  "text": {
+    "_note": "Semantic text style presets",
+    "display-lg": {
+      "family":     "serif",
+      "size":       "4xl",
+      "weight":     "bold",
+      "lineHeight": "tight",
+      "tracking":   "tight"
+    },
+    "display-sm": {
+      "family":     "serif",
+      "size":       "3xl",
+      "weight":     "semibold",
+      "lineHeight": "tight"
+    },
+    "heading-lg": {
+      "family":     "sans",
+      "size":       "2xl",
+      "weight":     "semibold",
+      "lineHeight": "snug"
+    },
+    "heading-md": {
+      "family":     "sans",
+      "size":       "xl",
+      "weight":     "semibold",
+      "lineHeight": "snug"
+    },
+    "heading-sm": {
+      "family":     "sans",
+      "size":       "lg",
+      "weight":     "medium",
+      "lineHeight": "normal"
+    },
+    "body-lg": {
+      "family":     "sans",
+      "size":       "lg",
+      "weight":     "normal",
+      "lineHeight": "relaxed"
+    },
+    "body-md": {
+      "family":     "sans",
+      "size":       "base",
+      "weight":     "normal",
+      "lineHeight": "relaxed"
+    },
+    "body-sm": {
+      "family":     "sans",
+      "size":       "sm",
+      "weight":     "normal",
+      "lineHeight": "normal"
+    },
+    "caption": {
+      "family":     "sans",
+      "size":       "xs",
+      "weight":     "normal",
+      "lineHeight": "normal",
+      "color":      "fg.muted"
+    },
+    "label": {
+      "family":     "sans",
+      "size":       "sm",
+      "weight":     "medium",
+      "lineHeight": "normal"
+    },
+    "kbd": {
+      "family":     "mono",
+      "size":       "xs",
+      "weight":     "normal",
+      "lineHeight": "normal"
+    }
+  }
+}

--- a/design/tokens/z-index.json
+++ b/design/tokens/z-index.json
@@ -1,0 +1,18 @@
+{
+  "_comment": "aibo Z-Index Tokens (Sprint 13)\nClear stacking context hierarchy.",
+
+  "zIndex": {
+    "base":     "0",
+    "raised":   "10",
+    "dropdown": "100",
+    "sticky":   "200",
+    "topbar":   "300",
+    "sidebar":  "300",
+    "popover":  "400",
+    "overlay":  "500",
+    "modal":    "600",
+    "toast":    "700",
+    "tooltip":  "800",
+    "cmdk":     "900"
+  }
+}


### PR DESCRIPTION
Closes #197

## 產出
- `design/tokens/` — colors / typography / spacing / shadows / z-index / projects（JSON + MD 文件）
- `design/components/` — 17 個元件規格：badge / button / card / command / dialog / dropdown-menu / input / kbd / label / layout-shell / pill-nav / popover / select / sheet / tabs / toast / tooltip
- `design/pages/` — 3 份 page sketch：dashboard-hub / command-palette / login

對齊 F-035 已 merge 的 globals.css 與 ThemeProvider，採 editorial 紙本設計系統。