### PR TITLE
feat(frontend): F-038 shadcn primitives 紙本主題整合

### DIFF
--- a/dev/frontend/components/ui/badge.tsx
+++ b/dev/frontend/components/ui/badge.tsx
@@ -2,18 +2,29 @@ import * as React from "react";
 import { cva, type VariantProps } from "class-variance-authority";
 import { cn } from "@/lib/utils";
 
+/**
+ * Badge — 自寫元件，吃 F-035 design tokens
+ *
+ * Variants: default / secondary / outline / danger / success / warning
+ */
+
 const badgeVariants = cva(
-  "inline-flex items-center rounded-full border px-2.5 py-0.5 text-xs font-semibold transition-colors focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2",
+  "inline-flex items-center rounded-ed-sm border px-2 py-0.5 text-xs font-medium transition-colors focus:outline-none focus:ring-2 focus:ring-[--ring]",
   {
     variants: {
       variant: {
-        default: "border-transparent bg-primary text-primary-foreground",
-        secondary: "border-transparent bg-secondary text-secondary-foreground",
-        destructive:
-          "border-transparent bg-destructive text-destructive-foreground",
-        success: "border-transparent bg-success text-success-foreground",
-        warning: "border-transparent bg-warning text-warning-foreground",
-        outline: "text-foreground",
+        default:
+          "border-transparent bg-[--accent] text-[--accent-fg]",
+        secondary:
+          "border-transparent bg-[--bg-muted] text-[--fg-muted]",
+        outline:
+          "border-[--border] text-[--fg]",
+        danger:
+          "border-transparent bg-[--danger] text-[--danger-fg]",
+        success:
+          "border-transparent bg-[--success] text-[--success-fg]",
+        warning:
+          "border-transparent bg-[--warning] text-[--warning-fg]",
       },
     },
     defaultVariants: { variant: "default" },

--- a/dev/frontend/components/ui/button.tsx
+++ b/dev/frontend/components/ui/button.tsx
@@ -3,29 +3,54 @@ import { Slot } from "@radix-ui/react-slot";
 import { cva, type VariantProps } from "class-variance-authority";
 import { cn } from "@/lib/utils";
 
+/**
+ * Button — 自寫元件，吃 F-035 design tokens
+ *
+ * Variants: default / secondary / ghost / danger / link / outline
+ * Sizes: sm / md (default) / lg
+ *
+ * Scenario: 自寫 Button variant
+ * - variant="danger" → bg = var(--danger), text = var(--danger-fg)
+ */
+
 const buttonVariants = cva(
-  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
+  [
+    "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-ed-md text-sm font-medium",
+    "ring-offset-transparent transition-colors",
+    "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[--ring]",
+    "disabled:pointer-events-none disabled:opacity-50",
+    "[&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
+  ].join(" "),
   {
     variants: {
       variant: {
-        default: "bg-primary text-primary-foreground hover:bg-primary/90",
-        destructive:
-          "bg-destructive text-destructive-foreground hover:bg-destructive/90",
-        outline:
-          "border border-input bg-background hover:bg-accent hover:text-accent-foreground",
+        /** 主要動作：accent 背景 */
+        default:
+          "bg-[--accent] text-[--accent-fg] hover:bg-[--accent]/90",
+        /** 次要動作：低調背景 */
         secondary:
-          "bg-secondary text-secondary-foreground hover:bg-secondary/80",
-        ghost: "hover:bg-accent hover:text-accent-foreground",
-        link: "text-primary underline-offset-4 hover:underline",
+          "bg-[--bg-muted] text-[--fg] hover:bg-[--bg-subtle]",
+        /** Ghost：無背景，hover 顯示 */
+        ghost:
+          "text-[--fg] hover:bg-[--accent-soft] hover:text-[--tok-accent]",
+        /** 危險操作：danger 背景 */
+        danger:
+          "bg-[--danger] text-[--danger-fg] hover:bg-[--danger]/90",
+        /** 連結樣式 */
+        link:
+          "text-[--tok-accent] underline-offset-4 hover:underline",
+        /** 外框樣式 */
+        outline:
+          "border border-[--border] bg-transparent text-[--fg] hover:bg-[--bg-subtle]",
       },
       size: {
-        default: "h-10 px-4 py-2",
-        sm: "h-9 rounded-md px-3",
-        lg: "h-11 rounded-md px-8",
-        icon: "h-10 w-10",
+        sm: "h-8 rounded-ed-sm px-3 text-xs",
+        md: "h-9 px-4 py-2",
+        lg: "h-11 rounded-ed-lg px-8",
+        icon: "h-9 w-9",
       },
     },
-    defaultVariants: { variant: "default", size: "default" },
+    defaultVariants: { variant: "default", size: "md" },
   },
 );
 

--- a/dev/frontend/components/ui/card.tsx
+++ b/dev/frontend/components/ui/card.tsx
@@ -1,12 +1,17 @@
 import * as React from "react";
 import { cn } from "@/lib/utils";
 
+/**
+ * Card — 自寫元件，吃 F-035 design tokens
+ * Card / CardHeader / CardTitle / CardDescription / CardContent / CardFooter
+ */
+
 const Card = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
   ({ className, ...props }, ref) => (
     <div
       ref={ref}
       className={cn(
-        "rounded-lg border bg-card text-card-foreground shadow-sm",
+        "rounded-ed-lg border border-[--border] bg-[--surface] text-[--fg] shadow-ed-sm",
         className,
       )}
       {...props}
@@ -26,7 +31,7 @@ const CardTitle = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivE
   ({ className, ...props }, ref) => (
     <div
       ref={ref}
-      className={cn("text-lg font-semibold leading-none tracking-tight", className)}
+      className={cn("text-lg font-semibold leading-none tracking-tight text-[--fg]", className)}
       {...props}
     />
   ),
@@ -37,7 +42,7 @@ const CardDescription = React.forwardRef<
   HTMLDivElement,
   React.HTMLAttributes<HTMLDivElement>
 >(({ className, ...props }, ref) => (
-  <div ref={ref} className={cn("text-sm text-muted-foreground", className)} {...props} />
+  <div ref={ref} className={cn("text-sm text-[--fg-muted]", className)} {...props} />
 ));
 CardDescription.displayName = "CardDescription";
 

--- a/dev/frontend/components/ui/combobox.tsx
+++ b/dev/frontend/components/ui/combobox.tsx
@@ -1,0 +1,99 @@
+"use client";
+
+import * as React from "react";
+import { Check, ChevronsUpDown } from "lucide-react";
+import { cn } from "@/lib/utils";
+import { Button } from "@/components/ui/button";
+import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
+import {
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+} from "@/components/ui/command";
+
+/**
+ * Combobox — cmdk-based 搜尋選擇元件，吃 F-035 design tokens
+ *
+ * 支援 single-select。
+ */
+
+export interface ComboboxOption {
+  value: string;
+  label: string;
+}
+
+export interface ComboboxProps {
+  options: ComboboxOption[];
+  value?: string;
+  onValueChange?: (value: string) => void;
+  placeholder?: string;
+  searchPlaceholder?: string;
+  emptyText?: string;
+  disabled?: boolean;
+  className?: string;
+}
+
+export function Combobox({
+  options,
+  value,
+  onValueChange,
+  placeholder = "選擇...",
+  searchPlaceholder = "搜尋...",
+  emptyText = "無符合項目",
+  disabled,
+  className,
+}: ComboboxProps) {
+  const [open, setOpen] = React.useState(false);
+
+  const selectedOption = options.find((opt) => opt.value === value);
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger asChild>
+        <Button
+          variant="outline"
+          role="combobox"
+          aria-expanded={open}
+          disabled={disabled}
+          className={cn("w-full justify-between font-normal", className)}
+        >
+          <span className={cn(!selectedOption && "text-[--fg-subtle]")}>
+            {selectedOption ? selectedOption.label : placeholder}
+          </span>
+          <ChevronsUpDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent className="w-full p-0" align="start">
+        <Command>
+          <CommandInput placeholder={searchPlaceholder} />
+          <CommandList>
+            <CommandEmpty>{emptyText}</CommandEmpty>
+            <CommandGroup>
+              {options.map((opt) => (
+                <CommandItem
+                  key={opt.value}
+                  value={opt.value}
+                  onSelect={(currentValue) => {
+                    onValueChange?.(currentValue === value ? "" : currentValue);
+                    setOpen(false);
+                  }}
+                >
+                  <Check
+                    className={cn(
+                      "mr-2 h-4 w-4",
+                      value === opt.value ? "opacity-100" : "opacity-0",
+                    )}
+                  />
+                  {opt.label}
+                </CommandItem>
+              ))}
+            </CommandGroup>
+          </CommandList>
+        </Command>
+      </PopoverContent>
+    </Popover>
+  );
+}

--- a/dev/frontend/components/ui/command.tsx
+++ b/dev/frontend/components/ui/command.tsx
@@ -1,0 +1,141 @@
+"use client";
+
+import * as React from "react";
+import { Command as CommandPrimitive } from "cmdk";
+import { Search } from "lucide-react";
+import { cn } from "@/lib/utils";
+
+/**
+ * Command — cmdk 包裝，吃 F-035 design tokens
+ * 用於 Combobox、command palette 等場景
+ */
+
+const Command = React.forwardRef<
+  React.ElementRef<typeof CommandPrimitive>,
+  React.ComponentPropsWithoutRef<typeof CommandPrimitive>
+>(({ className, ...props }, ref) => (
+  <CommandPrimitive
+    ref={ref}
+    className={cn(
+      "flex h-full w-full flex-col overflow-hidden rounded-ed-lg",
+      "bg-[--surface] text-[--fg]",
+      className,
+    )}
+    {...props}
+  />
+));
+Command.displayName = CommandPrimitive.displayName;
+
+const CommandInput = React.forwardRef<
+  React.ElementRef<typeof CommandPrimitive.Input>,
+  React.ComponentPropsWithoutRef<typeof CommandPrimitive.Input>
+>(({ className, ...props }, ref) => (
+  <div className="flex items-center border-b border-[--border] px-3" cmdk-input-wrapper="">
+    <Search className="mr-2 h-4 w-4 shrink-0 text-[--fg-subtle]" />
+    <CommandPrimitive.Input
+      ref={ref}
+      className={cn(
+        "flex h-11 w-full rounded-md bg-transparent py-3 text-sm outline-none",
+        "placeholder:text-[--fg-subtle] text-[--fg]",
+        "disabled:cursor-not-allowed disabled:opacity-50",
+        className,
+      )}
+      {...props}
+    />
+  </div>
+));
+CommandInput.displayName = CommandPrimitive.Input.displayName;
+
+const CommandList = React.forwardRef<
+  React.ElementRef<typeof CommandPrimitive.List>,
+  React.ComponentPropsWithoutRef<typeof CommandPrimitive.List>
+>(({ className, ...props }, ref) => (
+  <CommandPrimitive.List
+    ref={ref}
+    className={cn("max-h-[300px] overflow-y-auto overflow-x-hidden", className)}
+    {...props}
+  />
+));
+CommandList.displayName = CommandPrimitive.List.displayName;
+
+const CommandEmpty = React.forwardRef<
+  React.ElementRef<typeof CommandPrimitive.Empty>,
+  React.ComponentPropsWithoutRef<typeof CommandPrimitive.Empty>
+>((props, ref) => (
+  <CommandPrimitive.Empty
+    ref={ref}
+    className="py-6 text-center text-sm text-[--fg-muted]"
+    {...props}
+  />
+));
+CommandEmpty.displayName = CommandPrimitive.Empty.displayName;
+
+const CommandGroup = React.forwardRef<
+  React.ElementRef<typeof CommandPrimitive.Group>,
+  React.ComponentPropsWithoutRef<typeof CommandPrimitive.Group>
+>(({ className, ...props }, ref) => (
+  <CommandPrimitive.Group
+    ref={ref}
+    className={cn(
+      "overflow-hidden p-1 text-[--fg]",
+      "[&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:py-1.5",
+      "[&_[cmdk-group-heading]]:text-xs [&_[cmdk-group-heading]]:font-medium [&_[cmdk-group-heading]]:text-[--fg-muted]",
+      className,
+    )}
+    {...props}
+  />
+));
+CommandGroup.displayName = CommandPrimitive.Group.displayName;
+
+const CommandSeparator = React.forwardRef<
+  React.ElementRef<typeof CommandPrimitive.Separator>,
+  React.ComponentPropsWithoutRef<typeof CommandPrimitive.Separator>
+>(({ className, ...props }, ref) => (
+  <CommandPrimitive.Separator
+    ref={ref}
+    className={cn("-mx-1 h-px bg-[--border]", className)}
+    {...props}
+  />
+));
+CommandSeparator.displayName = CommandPrimitive.Separator.displayName;
+
+const CommandItem = React.forwardRef<
+  React.ElementRef<typeof CommandPrimitive.Item>,
+  React.ComponentPropsWithoutRef<typeof CommandPrimitive.Item>
+>(({ className, ...props }, ref) => (
+  <CommandPrimitive.Item
+    ref={ref}
+    className={cn(
+      "relative flex cursor-default select-none items-center gap-2 rounded-ed-sm px-2 py-1.5 text-sm outline-none",
+      "text-[--fg]",
+      "aria-selected:bg-[--accent-soft] aria-selected:text-[--tok-accent]",
+      "data-[disabled=true]:pointer-events-none data-[disabled=true]:opacity-50",
+      "[&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
+      className,
+    )}
+    {...props}
+  />
+));
+CommandItem.displayName = CommandPrimitive.Item.displayName;
+
+const CommandShortcut = ({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLSpanElement>) => (
+  <span
+    className={cn("ml-auto text-xs tracking-widest text-[--fg-subtle]", className)}
+    {...props}
+  />
+);
+CommandShortcut.displayName = "CommandShortcut";
+
+export {
+  Command,
+  CommandInput,
+  CommandList,
+  CommandEmpty,
+  CommandGroup,
+  CommandItem,
+  CommandSeparator,
+  CommandShortcut,
+};

--- a/dev/frontend/components/ui/dialog.tsx
+++ b/dev/frontend/components/ui/dialog.tsx
@@ -17,7 +17,9 @@ const DialogOverlay = React.forwardRef<
   <DialogPrimitive.Overlay
     ref={ref}
     className={cn(
-      "fixed inset-0 z-50 bg-black/80 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
+      "fixed inset-0 z-modal bg-[--ink]/60 backdrop-blur-[2px]",
+      "data-[state=open]:animate-in data-[state=closed]:animate-out",
+      "data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
       className,
     )}
     {...props}
@@ -34,15 +36,30 @@ const DialogContent = React.forwardRef<
     <DialogPrimitive.Content
       ref={ref}
       className={cn(
-        "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 sm:rounded-lg",
+        // layout
+        "fixed left-[50%] top-[50%] z-modal grid w-full max-w-lg",
+        "translate-x-[-50%] translate-y-[-50%] gap-4",
+        // appearance — F-035 tokens
+        "border border-[--border] bg-[--surface] p-6 shadow-ed-lg rounded-ed-lg",
+        // animation
+        "duration-200",
+        "data-[state=open]:animate-in data-[state=closed]:animate-out",
+        "data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
+        "data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95",
         className,
       )}
       {...props}
     >
       {children}
-      <DialogPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none">
+      <DialogPrimitive.Close
+        className={cn(
+          "absolute right-4 top-4 rounded-ed-sm opacity-70 transition-opacity",
+          "hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-[--ring]",
+          "disabled:pointer-events-none text-[--fg-muted]",
+        )}
+      >
         <X className="h-4 w-4" />
-        <span className="sr-only">Close</span>
+        <span className="sr-only">關閉</span>
       </DialogPrimitive.Close>
     </DialogPrimitive.Content>
   </DialogPortal>
@@ -74,7 +91,10 @@ const DialogTitle = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <DialogPrimitive.Title
     ref={ref}
-    className={cn("text-lg font-semibold leading-none tracking-tight", className)}
+    className={cn(
+      "text-lg font-semibold leading-none tracking-tight text-[--fg]",
+      className,
+    )}
     {...props}
   />
 ));
@@ -86,7 +106,7 @@ const DialogDescription = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <DialogPrimitive.Description
     ref={ref}
-    className={cn("text-sm text-muted-foreground", className)}
+    className={cn("text-sm text-[--fg-muted]", className)}
     {...props}
   />
 ));

--- a/dev/frontend/components/ui/dropdown-menu.tsx
+++ b/dev/frontend/components/ui/dropdown-menu.tsx
@@ -12,6 +12,49 @@ const DropdownMenuPortal = DropdownMenuPrimitive.Portal;
 const DropdownMenuSub = DropdownMenuPrimitive.Sub;
 const DropdownMenuRadioGroup = DropdownMenuPrimitive.RadioGroup;
 
+const DropdownMenuSubTrigger = React.forwardRef<
+  React.ElementRef<typeof DropdownMenuPrimitive.SubTrigger>,
+  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.SubTrigger> & {
+    inset?: boolean;
+  }
+>(({ className, inset, children, ...props }, ref) => (
+  <DropdownMenuPrimitive.SubTrigger
+    ref={ref}
+    className={cn(
+      "flex cursor-default select-none items-center gap-2 rounded-ed-sm px-2 py-1.5 text-sm outline-none",
+      "text-[--fg] focus:bg-[--accent-soft] data-[state=open]:bg-[--accent-soft]",
+      inset && "pl-8",
+      className,
+    )}
+    {...props}
+  >
+    {children}
+    <ChevronRight className="ml-auto h-4 w-4" />
+  </DropdownMenuPrimitive.SubTrigger>
+));
+DropdownMenuSubTrigger.displayName = DropdownMenuPrimitive.SubTrigger.displayName;
+
+const DropdownMenuSubContent = React.forwardRef<
+  React.ElementRef<typeof DropdownMenuPrimitive.SubContent>,
+  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.SubContent>
+>(({ className, ...props }, ref) => (
+  <DropdownMenuPrimitive.SubContent
+    ref={ref}
+    className={cn(
+      "z-dropdown min-w-[8rem] overflow-hidden rounded-ed-md p-1",
+      "border border-[--border] bg-[--surface] text-[--fg] shadow-ed-lg",
+      "data-[state=open]:animate-in data-[state=closed]:animate-out",
+      "data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
+      "data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95",
+      "data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2",
+      "data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+      className,
+    )}
+    {...props}
+  />
+));
+DropdownMenuSubContent.displayName = DropdownMenuPrimitive.SubContent.displayName;
+
 const DropdownMenuContent = React.forwardRef<
   React.ElementRef<typeof DropdownMenuPrimitive.Content>,
   React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Content>
@@ -21,8 +64,10 @@ const DropdownMenuContent = React.forwardRef<
       ref={ref}
       sideOffset={sideOffset}
       className={cn(
-        "z-50 min-w-[8rem] overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-md",
-        "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
+        "z-dropdown min-w-[8rem] overflow-hidden rounded-ed-md p-1",
+        "border border-[--border] bg-[--surface] text-[--fg] shadow-ed-lg",
+        "data-[state=open]:animate-in data-[state=closed]:animate-out",
+        "data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
         className,
       )}
       {...props}
@@ -38,7 +83,10 @@ const DropdownMenuItem = React.forwardRef<
   <DropdownMenuPrimitive.Item
     ref={ref}
     className={cn(
-      "relative flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
+      "relative flex cursor-default select-none items-center gap-2 rounded-ed-sm px-2 py-1.5 text-sm outline-none transition-colors",
+      "text-[--fg]",
+      "focus:bg-[--accent-soft] focus:text-[--tok-accent]",
+      "data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
       inset && "pl-8",
       className,
     )}
@@ -47,13 +95,66 @@ const DropdownMenuItem = React.forwardRef<
 ));
 DropdownMenuItem.displayName = DropdownMenuPrimitive.Item.displayName;
 
+const DropdownMenuCheckboxItem = React.forwardRef<
+  React.ElementRef<typeof DropdownMenuPrimitive.CheckboxItem>,
+  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.CheckboxItem>
+>(({ className, children, checked, ...props }, ref) => (
+  <DropdownMenuPrimitive.CheckboxItem
+    ref={ref}
+    className={cn(
+      "relative flex cursor-default select-none items-center rounded-ed-sm py-1.5 pl-8 pr-2 text-sm outline-none transition-colors",
+      "text-[--fg] focus:bg-[--accent-soft] focus:text-[--tok-accent]",
+      "data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
+      className,
+    )}
+    checked={checked}
+    {...props}
+  >
+    <span className="absolute left-2 flex h-3.5 w-3.5 items-center justify-center">
+      <DropdownMenuPrimitive.ItemIndicator>
+        <Check className="h-4 w-4" />
+      </DropdownMenuPrimitive.ItemIndicator>
+    </span>
+    {children}
+  </DropdownMenuPrimitive.CheckboxItem>
+));
+DropdownMenuCheckboxItem.displayName = DropdownMenuPrimitive.CheckboxItem.displayName;
+
+const DropdownMenuRadioItem = React.forwardRef<
+  React.ElementRef<typeof DropdownMenuPrimitive.RadioItem>,
+  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.RadioItem>
+>(({ className, children, ...props }, ref) => (
+  <DropdownMenuPrimitive.RadioItem
+    ref={ref}
+    className={cn(
+      "relative flex cursor-default select-none items-center rounded-ed-sm py-1.5 pl-8 pr-2 text-sm outline-none transition-colors",
+      "text-[--fg] focus:bg-[--accent-soft] focus:text-[--tok-accent]",
+      "data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
+      className,
+    )}
+    {...props}
+  >
+    <span className="absolute left-2 flex h-3.5 w-3.5 items-center justify-center">
+      <DropdownMenuPrimitive.ItemIndicator>
+        <Circle className="h-2 w-2 fill-current" />
+      </DropdownMenuPrimitive.ItemIndicator>
+    </span>
+    {children}
+  </DropdownMenuPrimitive.RadioItem>
+));
+DropdownMenuRadioItem.displayName = DropdownMenuPrimitive.RadioItem.displayName;
+
 const DropdownMenuLabel = React.forwardRef<
   React.ElementRef<typeof DropdownMenuPrimitive.Label>,
   React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Label> & { inset?: boolean }
 >(({ className, inset, ...props }, ref) => (
   <DropdownMenuPrimitive.Label
     ref={ref}
-    className={cn("px-2 py-1.5 text-sm font-semibold", inset && "pl-8", className)}
+    className={cn(
+      "px-2 py-1.5 text-xs font-semibold text-[--fg-muted]",
+      inset && "pl-8",
+      className,
+    )}
     {...props}
   />
 ));
@@ -65,21 +166,37 @@ const DropdownMenuSeparator = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <DropdownMenuPrimitive.Separator
     ref={ref}
-    className={cn("-mx-1 my-1 h-px bg-muted", className)}
+    className={cn("-mx-1 my-1 h-px bg-[--border]", className)}
     {...props}
   />
 ));
 DropdownMenuSeparator.displayName = DropdownMenuPrimitive.Separator.displayName;
+
+const DropdownMenuShortcut = ({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLSpanElement>) => (
+  <span
+    className={cn("ml-auto text-xs tracking-widest text-[--fg-subtle]", className)}
+    {...props}
+  />
+);
+DropdownMenuShortcut.displayName = "DropdownMenuShortcut";
 
 export {
   DropdownMenu,
   DropdownMenuTrigger,
   DropdownMenuContent,
   DropdownMenuItem,
+  DropdownMenuCheckboxItem,
+  DropdownMenuRadioItem,
   DropdownMenuGroup,
   DropdownMenuPortal,
   DropdownMenuLabel,
   DropdownMenuSeparator,
+  DropdownMenuShortcut,
   DropdownMenuSub,
+  DropdownMenuSubContent,
+  DropdownMenuSubTrigger,
   DropdownMenuRadioGroup,
 };

--- a/dev/frontend/components/ui/input.tsx
+++ b/dev/frontend/components/ui/input.tsx
@@ -1,17 +1,33 @@
 import * as React from "react";
 import { cn } from "@/lib/utils";
 
-export type InputProps = React.InputHTMLAttributes<HTMLInputElement>;
+/**
+ * Input — 自寫元件，吃 F-035 design tokens
+ * 含 error state：傳入 aria-invalid="true" 或 error prop 顯示紅框
+ */
+
+export interface InputProps extends React.InputHTMLAttributes<HTMLInputElement> {
+  /** 顯示錯誤狀態（紅框） */
+  error?: boolean;
+}
 
 const Input = React.forwardRef<HTMLInputElement, InputProps>(
-  ({ className, type, ...props }, ref) => (
+  ({ className, type, error, ...props }, ref) => (
     <input
       type={type}
       ref={ref}
       className={cn(
-        "flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50",
+        "flex h-10 w-full rounded-ed-md px-3 py-2 text-sm",
+        "border border-[--border] bg-[--surface] text-[--fg]",
+        "placeholder:text-[--fg-subtle]",
+        "file:border-0 file:bg-transparent file:text-sm file:font-medium",
+        "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[--ring]",
+        "disabled:cursor-not-allowed disabled:opacity-50",
+        // error state
+        error && "border-[--danger] focus-visible:ring-[--danger]/40",
         className,
       )}
+      aria-invalid={error || props["aria-invalid"]}
       {...props}
     />
   ),

--- a/dev/frontend/components/ui/kbd.tsx
+++ b/dev/frontend/components/ui/kbd.tsx
@@ -1,0 +1,25 @@
+import * as React from "react";
+import { cn } from "@/lib/utils";
+
+/**
+ * Kbd — keyboard shortcut 視覺元件（⌘K 等提示）
+ * 自寫，吃 F-035 design tokens
+ */
+
+export interface KbdProps extends React.HTMLAttributes<HTMLElement> {}
+
+const Kbd = React.forwardRef<HTMLElement, KbdProps>(({ className, ...props }, ref) => (
+  <kbd
+    ref={ref}
+    className={cn(
+      "inline-flex items-center justify-center rounded-ed-sm px-1.5 py-0.5",
+      "border border-[--border] bg-[--bg-muted] text-[--fg-muted]",
+      "font-mono text-xs shadow-[0_1px_0_rgba(0,0,0,0.08)]",
+      className,
+    )}
+    {...props}
+  />
+));
+Kbd.displayName = "Kbd";
+
+export { Kbd };

--- a/dev/frontend/components/ui/label.tsx
+++ b/dev/frontend/components/ui/label.tsx
@@ -5,8 +5,12 @@ import * as LabelPrimitive from "@radix-ui/react-label";
 import { cva, type VariantProps } from "class-variance-authority";
 import { cn } from "@/lib/utils";
 
+/**
+ * Label — 配對 input id，吃 F-035 tokens
+ */
+
 const labelVariants = cva(
-  "text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70",
+  "text-sm font-medium leading-none text-[--fg] peer-disabled:cursor-not-allowed peer-disabled:opacity-70",
 );
 
 const Label = React.forwardRef<

--- a/dev/frontend/components/ui/popover.tsx
+++ b/dev/frontend/components/ui/popover.tsx
@@ -18,7 +18,17 @@ const PopoverContent = React.forwardRef<
       align={align}
       sideOffset={sideOffset}
       className={cn(
-        "z-50 w-72 rounded-md border bg-popover p-4 text-popover-foreground shadow-md outline-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+        // layout
+        "z-popover w-72 rounded-ed-lg p-4 outline-none",
+        // appearance — F-035 tokens
+        "border border-[--border] bg-[--surface] text-[--fg]",
+        "shadow-ed-lg",
+        // animation
+        "data-[state=open]:animate-in data-[state=closed]:animate-out",
+        "data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
+        "data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95",
+        "data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2",
+        "data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
         className,
       )}
       {...props}

--- a/dev/frontend/components/ui/select.tsx
+++ b/dev/frontend/components/ui/select.tsx
@@ -16,7 +16,12 @@ const SelectTrigger = React.forwardRef<
   <SelectPrimitive.Trigger
     ref={ref}
     className={cn(
-      "flex h-10 w-full items-center justify-between rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 [&>span]:line-clamp-1",
+      "flex h-10 w-full items-center justify-between rounded-ed-md px-3 py-2 text-sm",
+      "border border-[--border] bg-[--surface] text-[--fg]",
+      "placeholder:text-[--fg-subtle]",
+      "focus:outline-none focus:ring-2 focus:ring-[--ring]",
+      "disabled:cursor-not-allowed disabled:opacity-50",
+      "[&>span]:line-clamp-1",
       className,
     )}
     {...props}
@@ -65,7 +70,14 @@ const SelectContent = React.forwardRef<
     <SelectPrimitive.Content
       ref={ref}
       className={cn(
-        "relative z-50 max-h-96 min-w-[8rem] overflow-hidden rounded-md border bg-popover text-popover-foreground shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+        "relative z-dropdown max-h-96 min-w-[8rem] overflow-hidden rounded-ed-md",
+        "border border-[--border] bg-[--surface] text-[--fg]",
+        "shadow-ed-lg",
+        "data-[state=open]:animate-in data-[state=closed]:animate-out",
+        "data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
+        "data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95",
+        "data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2",
+        "data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
         position === "popper" &&
           "data-[side=bottom]:translate-y-1 data-[side=left]:-translate-x-1 data-[side=right]:translate-x-1 data-[side=top]:-translate-y-1",
         className,
@@ -95,7 +107,7 @@ const SelectLabel = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <SelectPrimitive.Label
     ref={ref}
-    className={cn("py-1.5 pl-8 pr-2 text-sm font-semibold", className)}
+    className={cn("py-1.5 pl-8 pr-2 text-xs font-semibold text-[--fg-muted]", className)}
     {...props}
   />
 ));
@@ -108,7 +120,10 @@ const SelectItem = React.forwardRef<
   <SelectPrimitive.Item
     ref={ref}
     className={cn(
-      "relative flex w-full cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
+      "relative flex w-full cursor-default select-none items-center rounded-ed-sm py-1.5 pl-8 pr-2 text-sm outline-none",
+      "text-[--fg]",
+      "focus:bg-[--accent-soft] focus:text-[--tok-accent]",
+      "data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
       className,
     )}
     {...props}
@@ -129,7 +144,7 @@ const SelectSeparator = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <SelectPrimitive.Separator
     ref={ref}
-    className={cn("-mx-1 my-1 h-px bg-muted", className)}
+    className={cn("-mx-1 my-1 h-px bg-[--border]", className)}
     {...props}
   />
 ));

--- a/dev/frontend/components/ui/sheet.tsx
+++ b/dev/frontend/components/ui/sheet.tsx
@@ -2,8 +2,7 @@
 
 /**
  * shadcn/ui Sheet — side drawer built on Radix Dialog primitive.
- *
- * 用於 Calendar Day Detail Sheet（F-027c）。API 對齊 shadcn 官方 sheet。
+ * F-038: 使用 F-035 editorial tokens
  */
 
 import * as React from "react";
@@ -25,7 +24,9 @@ const SheetOverlay = React.forwardRef<
   <SheetPrimitive.Overlay
     ref={ref}
     className={cn(
-      "fixed inset-0 z-50 bg-black/80 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
+      "fixed inset-0 z-modal bg-[--ink]/60 backdrop-blur-[2px]",
+      "data-[state=open]:animate-in data-[state=closed]:animate-out",
+      "data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
       className,
     )}
     {...props}
@@ -34,16 +35,16 @@ const SheetOverlay = React.forwardRef<
 SheetOverlay.displayName = SheetPrimitive.Overlay.displayName;
 
 const sheetVariants = cva(
-  "fixed z-50 gap-4 bg-background shadow-lg transition ease-in-out data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:duration-300 data-[state=open]:duration-500",
+  "fixed z-modal gap-4 bg-[--surface] shadow-ed-lg transition ease-in-out data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:duration-300 data-[state=open]:duration-500",
   {
     variants: {
       side: {
-        top: "inset-x-0 top-0 border-b data-[state=closed]:slide-out-to-top data-[state=open]:slide-in-from-top",
+        top: "inset-x-0 top-0 border-b border-[--border] data-[state=closed]:slide-out-to-top data-[state=open]:slide-in-from-top",
         bottom:
-          "inset-x-0 bottom-0 border-t data-[state=closed]:slide-out-to-bottom data-[state=open]:slide-in-from-bottom",
-        left: "inset-y-0 left-0 h-full w-3/4 border-r data-[state=closed]:slide-out-to-left data-[state=open]:slide-in-from-left sm:max-w-sm",
+          "inset-x-0 bottom-0 border-t border-[--border] data-[state=closed]:slide-out-to-bottom data-[state=open]:slide-in-from-bottom",
+        left: "inset-y-0 left-0 h-full w-3/4 border-r border-[--border] data-[state=closed]:slide-out-to-left data-[state=open]:slide-in-from-left sm:max-w-sm",
         right:
-          "inset-y-0 right-0 h-full w-3/4 border-l data-[state=closed]:slide-out-to-right data-[state=open]:slide-in-from-right sm:max-w-sm",
+          "inset-y-0 right-0 h-full w-3/4 border-l border-[--border] data-[state=closed]:slide-out-to-right data-[state=open]:slide-in-from-right sm:max-w-sm",
       },
     },
     defaultVariants: { side: "right" },
@@ -78,7 +79,11 @@ const SheetContent = React.forwardRef<
         {!hideCloseButton && (
           <SheetPrimitive.Close
             data-testid={closeTestId}
-            className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none"
+            className={cn(
+              "absolute right-4 top-4 rounded-ed-sm opacity-70 transition-opacity",
+              "hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-[--ring]",
+              "disabled:pointer-events-none text-[--fg-muted]",
+            )}
           >
             <X className="h-4 w-4" />
             <span className="sr-only">關閉</span>
@@ -121,7 +126,7 @@ const SheetTitle = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <SheetPrimitive.Title
     ref={ref}
-    className={cn("text-lg font-semibold text-foreground", className)}
+    className={cn("text-lg font-semibold text-[--fg]", className)}
     {...props}
   />
 ));
@@ -133,7 +138,7 @@ const SheetDescription = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <SheetPrimitive.Description
     ref={ref}
-    className={cn("text-sm text-muted-foreground", className)}
+    className={cn("text-sm text-[--fg-muted]", className)}
     {...props}
   />
 ));

--- a/dev/frontend/components/ui/tabs.tsx
+++ b/dev/frontend/components/ui/tabs.tsx
@@ -13,7 +13,8 @@ const TabsList = React.forwardRef<
   <TabsPrimitive.List
     ref={ref}
     className={cn(
-      "inline-flex h-9 items-center justify-center rounded-md bg-muted p-1 text-muted-foreground",
+      "inline-flex h-9 items-center justify-center rounded-ed-md p-1",
+      "bg-[--bg-muted] text-[--fg-muted]",
       className,
     )}
     {...props}
@@ -28,7 +29,12 @@ const TabsTrigger = React.forwardRef<
   <TabsPrimitive.Trigger
     ref={ref}
     className={cn(
-      "inline-flex items-center justify-center whitespace-nowrap rounded-sm px-3 py-1 text-sm font-medium ring-offset-background transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 data-[state=active]:bg-background data-[state=active]:text-foreground data-[state=active]:shadow",
+      "inline-flex items-center justify-center whitespace-nowrap rounded-ed-sm px-3 py-1 text-sm font-medium",
+      "ring-offset-transparent transition-all",
+      "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[--ring]",
+      "disabled:pointer-events-none disabled:opacity-50",
+      // active state
+      "data-[state=active]:bg-[--surface] data-[state=active]:text-[--fg] data-[state=active]:shadow-ed-sm",
       className,
     )}
     {...props}
@@ -43,7 +49,7 @@ const TabsContent = React.forwardRef<
   <TabsPrimitive.Content
     ref={ref}
     className={cn(
-      "mt-2 ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
+      "mt-2 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[--ring]",
       className,
     )}
     {...props}

--- a/dev/frontend/components/ui/tooltip.tsx
+++ b/dev/frontend/components/ui/tooltip.tsx
@@ -4,7 +4,17 @@ import * as React from "react";
 import * as TooltipPrimitive from "@radix-ui/react-tooltip";
 import { cn } from "@/lib/utils";
 
-const TooltipProvider = TooltipPrimitive.Provider;
+/**
+ * Tooltip — Radix primitive with F-035 editorial tokens.
+ *
+ * Scenario: 滑鼠停在按鈕 > 500ms → tooltip 顯示
+ * 預設 delayDuration=500，符合 spec。
+ */
+
+const TooltipProvider = ({ delayDuration = 500, ...props }: React.ComponentProps<typeof TooltipPrimitive.Provider>) => (
+  <TooltipPrimitive.Provider delayDuration={delayDuration} {...props} />
+);
+
 const Tooltip = TooltipPrimitive.Root;
 const TooltipTrigger = TooltipPrimitive.Trigger;
 
@@ -12,15 +22,26 @@ const TooltipContent = React.forwardRef<
   React.ElementRef<typeof TooltipPrimitive.Content>,
   React.ComponentPropsWithoutRef<typeof TooltipPrimitive.Content>
 >(({ className, sideOffset = 4, ...props }, ref) => (
-  <TooltipPrimitive.Content
-    ref={ref}
-    sideOffset={sideOffset}
-    className={cn(
-      "z-50 overflow-hidden rounded-md border bg-popover px-3 py-1.5 text-sm text-popover-foreground shadow-md",
-      className,
-    )}
-    {...props}
-  />
+  <TooltipPrimitive.Portal>
+    <TooltipPrimitive.Content
+      ref={ref}
+      sideOffset={sideOffset}
+      className={cn(
+        // layout
+        "z-tooltip overflow-hidden rounded-ed-md px-3 py-1.5",
+        // appearance — F-035 tokens
+        "border border-[--border] bg-[--ink] text-[--bg] text-xs",
+        "shadow-ed-md",
+        // animation
+        "animate-in fade-in-0 zoom-in-95",
+        "data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95",
+        "data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2",
+        "data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+        className,
+      )}
+      {...props}
+    />
+  </TooltipPrimitive.Portal>
 ));
 TooltipContent.displayName = TooltipPrimitive.Content.displayName;
 

--- a/dev/frontend/package-lock.json
+++ b/dev/frontend/package-lock.json
@@ -29,6 +29,7 @@
         "@tanstack/react-query-devtools": "^5.62.7",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
+        "cmdk": "^1.1.1",
         "date-fns": "^3.6.0",
         "date-fns-tz": "^3.2.0",
         "lucide-react": "^0.469.0",
@@ -4337,6 +4338,22 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/cmdk": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/cmdk/-/cmdk-1.1.1.tgz",
+      "integrity": "sha512-Vsv7kFaXm+ptHDMZ7izaRsP70GgrW9NBNGswt9OZaVBLlE0SNpDq8eu/VGXyF9r7M0azK3Wy7OlYXsuyYLFzHg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "^1.1.1",
+        "@radix-ui/react-dialog": "^1.1.6",
+        "@radix-ui/react-id": "^1.1.0",
+        "@radix-ui/react-primitive": "^2.0.2"
+      },
+      "peerDependencies": {
+        "react": "^18 || ^19 || ^19.0.0-rc",
+        "react-dom": "^18 || ^19 || ^19.0.0-rc"
       }
     },
     "node_modules/color-convert": {

--- a/dev/frontend/package.json
+++ b/dev/frontend/package.json
@@ -32,6 +32,7 @@
     "@tanstack/react-query-devtools": "^5.62.7",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
+    "cmdk": "^1.1.1",
     "date-fns": "^3.6.0",
     "date-fns-tz": "^3.2.0",
     "lucide-react": "^0.469.0",

--- a/dev/frontend/tailwind.config.ts
+++ b/dev/frontend/tailwind.config.ts
@@ -20,6 +20,38 @@ const config: Config = {
         mono: ["var(--font-mono)"],
       },
       colors: {
+        /* === F-035 Design Tokens (primary) === */
+        bg: {
+          DEFAULT: "var(--bg)",
+          subtle: "var(--bg-subtle)",
+          muted: "var(--bg-muted)",
+        },
+        fg: {
+          DEFAULT: "var(--fg)",
+          muted: "var(--fg-muted)",
+          subtle: "var(--fg-subtle)",
+        },
+        "bd": {
+          DEFAULT: "var(--border)",
+          strong: "var(--border-strong)",
+        },
+        "tok-accent": {
+          DEFAULT: "var(--accent)",
+          fg: "var(--accent-fg)",
+          soft: "var(--accent-soft)",
+        },
+        "tok-danger": {
+          DEFAULT: "var(--danger)",
+          fg: "var(--danger-fg)",
+        },
+        "tok-warning": {
+          DEFAULT: "var(--warning)",
+          fg: "var(--warning-fg)",
+        },
+        "tok-success": {
+          DEFAULT: "var(--success)",
+          fg: "var(--success-fg)",
+        },
         /* === F-035 Editorial tokens === */
         paper: {
           DEFAULT: "var(--paper)",


### PR DESCRIPTION
Closes #193

## 實作
依 `design/components/` 規格與 F-035 design tokens，整合 shadcn primitives 並覆寫紙本主題：

- Dialog / Popover / Dropdown-menu / Tooltip / Sheet / Select / Tabs / Label
- 新增 Card / Badge / Button / Input（紙本風格）
- 新增 Command / Combobox / Kbd（為 F-037 cmdk skeleton 鋪路）
- Tailwind config 與 design tokens 對齊

## 範圍說明
- 互動 a11y 邏輯保留 Radix（focus trap / keyboard nav）
- 視覺層全部用 editorial 紙本 tokens
- 不含 Pill Nav / Layout Shell（屬 F-036）