### PR TITLE
feat(api): F-039 cookie session auth + SSE skeleton

### DIFF
--- a/dev/src/dto/session.go
+++ b/dev/src/dto/session.go
@@ -1,0 +1,6 @@
+package dto
+
+// LoginRequest login request body
+type LoginRequest struct {
+	APIKey string `json:"api_key"`
+}

--- a/dev/src/handler/copilot_stream_handler.go
+++ b/dev/src/handler/copilot_stream_handler.go
@@ -1,0 +1,48 @@
+package handler
+
+import (
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/gin-gonic/gin"
+)
+
+// CopilotStreamHandler SSE 串流 handler（F-039 skeleton，完整實作屬於 F-048）
+type CopilotStreamHandler struct{}
+
+// NewCopilotStreamHandler 建立新的 CopilotStreamHandler
+func NewCopilotStreamHandler() *CopilotStreamHandler {
+	return &CopilotStreamHandler{}
+}
+
+// Stream SSE skeleton：每 15s 送 ping，並送出一個 demo event
+// GET /api/v1/copilot/stream
+func (h *CopilotStreamHandler) Stream(c *gin.Context) {
+	c.Header("Content-Type", "text/event-stream")
+	c.Header("Cache-Control", "no-cache")
+	c.Header("Connection", "keep-alive")
+	c.Header("X-Accel-Buffering", "no")
+	c.Status(http.StatusOK)
+
+	// demo event（寫死 hello）
+	msgID := "demo-001"
+	seq := 1
+	eventID := fmt.Sprintf("%s:%d", msgID, seq)
+	c.Writer.WriteString(fmt.Sprintf("id: %s\nevent: message\ndata: hello\n\n", eventID))
+	c.Writer.Flush()
+
+	ticker := time.NewTicker(15 * time.Second)
+	defer ticker.Stop()
+
+	ctx := c.Request.Context()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			c.Writer.WriteString("event: ping\ndata: {}\n\n")
+			c.Writer.Flush()
+		}
+	}
+}

--- a/dev/src/handler/session_auth_handler.go
+++ b/dev/src/handler/session_auth_handler.go
@@ -1,0 +1,141 @@
+package handler
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"net/http"
+	"os"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+	"github.com/gpwork4u/aibo/dto"
+	"github.com/gpwork4u/aibo/middleware"
+	"github.com/gpwork4u/aibo/model"
+	"github.com/gpwork4u/aibo/repository"
+)
+
+const (
+	sessionMaxAge = 30 * 24 * 60 * 60 // 30 天（秒）
+)
+
+// SessionAuthHandler cookie session 認證相關 handler
+type SessionAuthHandler struct {
+	sessionRepo *repository.SessionRepository
+}
+
+// NewSessionAuthHandler 建立新的 SessionAuthHandler
+func NewSessionAuthHandler(sessionRepo *repository.SessionRepository) *SessionAuthHandler {
+	return &SessionAuthHandler{sessionRepo: sessionRepo}
+}
+
+// Login 登入：POST /api/v1/auth/login
+// body: {"api_key": "<master_key>"}
+func (h *SessionAuthHandler) Login(c *gin.Context) {
+	var req dto.LoginRequest
+	if err := c.ShouldBindJSON(&req); err != nil || req.APIKey == "" {
+		c.JSON(http.StatusBadRequest, dto.ErrorResponse{
+			Code:    "BAD_REQUEST",
+			Message: "缺少 api_key 欄位",
+		})
+		return
+	}
+
+	// 驗證 master key（環境變數 AIBO_MASTER_KEY 或 AIBO_API_KEY）
+	masterKey := os.Getenv("AIBO_MASTER_KEY")
+	if masterKey == "" {
+		masterKey = os.Getenv("AIBO_API_KEY")
+	}
+	if masterKey == "" || req.APIKey != masterKey {
+		c.JSON(http.StatusUnauthorized, dto.ErrorResponse{
+			Code:    model.ErrCodeUnauthorized,
+			Message: "API Key 無效",
+		})
+		return
+	}
+
+	// 產生隨機 token
+	tokenBytes := make([]byte, 32)
+	if _, err := rand.Read(tokenBytes); err != nil {
+		c.JSON(http.StatusInternalServerError, dto.ErrorResponse{
+			Code:    "INTERNAL_ERROR",
+			Message: "產生 session token 失敗",
+		})
+		return
+	}
+	token := hex.EncodeToString(tokenBytes)
+	tokenHash := middleware.HashSessionToken(token)
+
+	session := &model.Session{
+		ID:        uuid.New(),
+		TokenHash: tokenHash,
+		UserLabel: "owner",
+		ExpiresAt: time.Now().Add(sessionMaxAge * time.Second),
+		CreatedAt: time.Now(),
+	}
+
+	if err := h.sessionRepo.Create(c.Request.Context(), session); err != nil {
+		c.JSON(http.StatusInternalServerError, dto.ErrorResponse{
+			Code:    "INTERNAL_ERROR",
+			Message: "建立 session 失敗",
+		})
+		return
+	}
+
+	// Set-Cookie
+	c.SetCookie(middleware.SessionCookieName, token, sessionMaxAge, "/", "", false, true)
+	c.JSON(http.StatusOK, gin.H{"label": session.UserLabel, "expires_at": session.ExpiresAt})
+}
+
+// Logout 登出：POST /api/v1/auth/logout
+func (h *SessionAuthHandler) Logout(c *gin.Context) {
+	token, err := c.Cookie(middleware.SessionCookieName)
+	if err != nil || token == "" {
+		c.JSON(http.StatusUnauthorized, dto.ErrorResponse{
+			Code:    model.ErrCodeUnauthorized,
+			Message: "未登入",
+		})
+		return
+	}
+
+	tokenHash := middleware.HashSessionToken(token)
+	if err := h.sessionRepo.Delete(c.Request.Context(), tokenHash); err != nil {
+		c.JSON(http.StatusInternalServerError, dto.ErrorResponse{
+			Code:    "INTERNAL_ERROR",
+			Message: "登出失敗",
+		})
+		return
+	}
+
+	// 清除 cookie
+	c.SetCookie(middleware.SessionCookieName, "", -1, "/", "", false, true)
+	c.JSON(http.StatusOK, gin.H{"message": "已登出"})
+}
+
+// Me 查看目前認證狀態：GET /api/v1/auth/me
+func (h *SessionAuthHandler) Me(c *gin.Context) {
+	// 從 context 取得認證資訊
+	authMethod, _ := c.Get("auth_method")
+
+	if sessionVal, exists := c.Get("session"); exists {
+		session := sessionVal.(*model.Session)
+		c.JSON(http.StatusOK, gin.H{
+			"label":       session.UserLabel,
+			"auth_method": authMethod,
+		})
+		return
+	}
+
+	if _, exists := c.Get("api_key"); exists {
+		c.JSON(http.StatusOK, gin.H{
+			"label":       "owner",
+			"auth_method": authMethod,
+		})
+		return
+	}
+
+	c.JSON(http.StatusUnauthorized, dto.ErrorResponse{
+		Code:    model.ErrCodeUnauthorized,
+		Message: "未認證",
+	})
+}

--- a/dev/src/middleware/cookie_auth.go
+++ b/dev/src/middleware/cookie_auth.go
@@ -1,0 +1,90 @@
+package middleware
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+	"github.com/gpwork4u/aibo/dto"
+	"github.com/gpwork4u/aibo/model"
+	"github.com/gpwork4u/aibo/repository"
+	"github.com/gpwork4u/aibo/service"
+)
+
+const (
+	SessionCookieName = "aibo_session"
+	sessionContextKey = "session"
+	authMethodKey     = "auth_method"
+)
+
+// CookieOrAPIKeyMiddleware 同時接受 cookie session 或 API Key 兩種認證方式
+func CookieOrAPIKeyMiddleware(apiKeySvc *service.ApiKeyService, sessionRepo *repository.SessionRepository) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		// 嘗試 cookie session 認證
+		token, err := c.Cookie(SessionCookieName)
+		if err == nil && token != "" {
+			hash := HashSessionToken(token)
+			session, err := sessionRepo.FindByTokenHash(c.Request.Context(), hash)
+			if err == nil && session != nil {
+				c.Set(sessionContextKey, session)
+				c.Set(authMethodKey, "cookie")
+				c.Next()
+				return
+			}
+		}
+
+		// Bootstrap 偵測：POST /api/v1/auth/api-keys 且無任何 key 時免認證
+		if c.Request.Method == http.MethodPost && c.FullPath() == "/api/v1/auth/api-keys" {
+			isBootstrap, err := apiKeySvc.IsBootstrap(c.Request.Context())
+			if err != nil {
+				c.AbortWithStatusJSON(http.StatusInternalServerError, dto.ErrorResponse{
+					Code:    "INTERNAL_ERROR",
+					Message: "伺服器內部錯誤",
+				})
+				return
+			}
+			if isBootstrap {
+				c.Set("bootstrap", true)
+				c.Next()
+				return
+			}
+		}
+
+		// 嘗試 API Key 認證
+		rawKey := c.GetHeader(apiKeyHeader)
+		if rawKey == "" {
+			c.AbortWithStatusJSON(http.StatusUnauthorized, dto.ErrorResponse{
+				Code:    model.ErrCodeUnauthorized,
+				Message: "缺少認證資訊，請提供 X-API-Key header 或有效的 session cookie",
+			})
+			return
+		}
+
+		apiKey, err := apiKeySvc.ValidateKey(c.Request.Context(), rawKey)
+		if err != nil {
+			if appErr, ok := err.(*model.AppError); ok {
+				c.AbortWithStatusJSON(appErr.Status, dto.ErrorResponse{
+					Code:    appErr.Code,
+					Message: appErr.Message,
+				})
+				return
+			}
+			c.AbortWithStatusJSON(http.StatusInternalServerError, dto.ErrorResponse{
+				Code:    "INTERNAL_ERROR",
+				Message: "伺服器內部錯誤",
+			})
+			return
+		}
+
+		c.Set("api_key", apiKey)
+		c.Set(authMethodKey, "api_key")
+		c.Next()
+	}
+}
+
+// HashSessionToken 對 session token 做 SHA-256 hash（exported，供 handler 使用）
+func HashSessionToken(token string) string {
+	h := sha256.Sum256([]byte(token))
+	return hex.EncodeToString(h[:])
+}

--- a/dev/src/migration/017_create_sessions.down.sql
+++ b/dev/src/migration/017_create_sessions.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS sessions;

--- a/dev/src/migration/017_create_sessions.up.sql
+++ b/dev/src/migration/017_create_sessions.up.sql
@@ -1,0 +1,11 @@
+CREATE TABLE IF NOT EXISTS sessions (
+    id          UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
+    token_hash  TEXT        NOT NULL UNIQUE,
+    user_label  TEXT        NOT NULL DEFAULT 'owner',
+    expires_at  TIMESTAMPTZ NOT NULL,
+    created_at  TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    last_seen_at TIMESTAMPTZ
+);
+
+CREATE INDEX IF NOT EXISTS idx_sessions_token_hash ON sessions(token_hash);
+CREATE INDEX IF NOT EXISTS idx_sessions_expires_at ON sessions(expires_at);

--- a/dev/src/model/session.go
+++ b/dev/src/model/session.go
@@ -1,0 +1,17 @@
+package model
+
+import (
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// Session cookie-based session
+type Session struct {
+	ID          uuid.UUID  `db:"id"`
+	TokenHash   string     `db:"token_hash"`
+	UserLabel   string     `db:"user_label"`
+	ExpiresAt   time.Time  `db:"expires_at"`
+	CreatedAt   time.Time  `db:"created_at"`
+	LastSeenAt  *time.Time `db:"last_seen_at"`
+}

--- a/dev/src/repository/sessions.go
+++ b/dev/src/repository/sessions.go
@@ -1,0 +1,61 @@
+package repository
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/gpwork4u/aibo/model"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+// SessionRepository session 資料庫操作
+type SessionRepository struct {
+	pool *pgxpool.Pool
+}
+
+// NewSessionRepository 建立新的 SessionRepository
+func NewSessionRepository(pool *pgxpool.Pool) *SessionRepository {
+	return &SessionRepository{pool: pool}
+}
+
+// Create 建立新 session
+func (r *SessionRepository) Create(ctx context.Context, s *model.Session) error {
+	_, err := r.pool.Exec(ctx,
+		`INSERT INTO sessions (id, token_hash, user_label, expires_at, created_at)
+		 VALUES ($1, $2, $3, $4, $5)`,
+		s.ID, s.TokenHash, s.UserLabel, s.ExpiresAt, s.CreatedAt,
+	)
+	return err
+}
+
+// FindByTokenHash 透過 token hash 查找 session
+func (r *SessionRepository) FindByTokenHash(ctx context.Context, tokenHash string) (*model.Session, error) {
+	s := &model.Session{}
+	err := r.pool.QueryRow(ctx,
+		`SELECT id, token_hash, user_label, expires_at, created_at, last_seen_at
+		 FROM sessions WHERE token_hash = $1 AND expires_at > NOW()`,
+		tokenHash,
+	).Scan(&s.ID, &s.TokenHash, &s.UserLabel, &s.ExpiresAt, &s.CreatedAt, &s.LastSeenAt)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return nil, nil
+	}
+	return s, err
+}
+
+// Delete 刪除 session
+func (r *SessionRepository) Delete(ctx context.Context, tokenHash string) error {
+	_, err := r.pool.Exec(ctx, "DELETE FROM sessions WHERE token_hash = $1", tokenHash)
+	return err
+}
+
+// UpdateLastSeenAt 更新最後使用時間
+func (r *SessionRepository) UpdateLastSeenAt(ctx context.Context, id uuid.UUID) error {
+	now := time.Now()
+	_, err := r.pool.Exec(ctx,
+		"UPDATE sessions SET last_seen_at = $1 WHERE id = $2", now, id,
+	)
+	return err
+}


### PR DESCRIPTION
Closes #194

## 範圍
F-039 後端 cookie session auth 與 SSE endpoint skeleton。

## 已包含
- migration 017_create_sessions
- model.Session + dto.Session*
- repository.SessionRepository
- middleware.CookieAuth (與既有 X-API-Key 並存)
- handler.SessionAuthHandler: POST /auth/login, /auth/logout, GET /auth/me
- handler.CopilotStreamHandler: SSE skeleton (15s ping, event id 格式)

## 後續
- 路由註冊（router.go + main.go）由後續 PR 補
- 完整 C1-C9 scenarios 由 QA 啟用 e2e tests 驗證
- SSE 實際 LLM 串流屬 F-048