### PR TITLE
feat(frontend): F-036 App Shell + Routing

### DIFF
--- a/dev/frontend/app/(shell)/dashboard/@copilot/page.tsx
+++ b/dev/frontend/app/(shell)/dashboard/@copilot/page.tsx
@@ -1,0 +1,18 @@
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Bot } from "lucide-react";
+
+export default async function CopilotSlotPage() {
+  return (
+    <Card data-testid="slot-copilot">
+      <CardHeader className="pb-2">
+        <CardTitle className="flex items-center gap-2 text-sm font-medium">
+          <Bot className="h-4 w-4" />
+          Copilot
+        </CardTitle>
+      </CardHeader>
+      <CardContent>
+        <p className="text-xs text-muted-foreground">Copilot preview — F-047 Sprint 16</p>
+      </CardContent>
+    </Card>
+  );
+}

--- a/dev/frontend/app/(shell)/dashboard/@inbox/default.tsx
+++ b/dev/frontend/app/(shell)/dashboard/@inbox/default.tsx
@@ -1,0 +1,3 @@
+export default function InboxDefault() {
+  return null;
+}

--- a/dev/frontend/app/(shell)/dashboard/@inbox/error.tsx
+++ b/dev/frontend/app/(shell)/dashboard/@inbox/error.tsx
@@ -1,0 +1,13 @@
+"use client";
+
+import { ErrorCard } from "@/components/shell/error-card";
+
+export default function InboxError({ reset }: { reset: () => void }) {
+  return (
+    <ErrorCard
+      title="Inbox 載入失敗"
+      description="無法取得 Inbox 資料，請稍後再試"
+      onRetry={reset}
+    />
+  );
+}

--- a/dev/frontend/app/(shell)/dashboard/@inbox/loading.tsx
+++ b/dev/frontend/app/(shell)/dashboard/@inbox/loading.tsx
@@ -1,0 +1,5 @@
+import { Skeleton } from "@/components/ui/skeleton";
+
+export default function InboxLoading() {
+  return <Skeleton className="h-32 w-full rounded-lg" data-testid="slot-inbox-loading" />;
+}

--- a/dev/frontend/app/(shell)/dashboard/@inbox/page.tsx
+++ b/dev/frontend/app/(shell)/dashboard/@inbox/page.tsx
@@ -1,0 +1,18 @@
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Inbox } from "lucide-react";
+
+export default async function InboxSlot() {
+  return (
+    <Card data-testid="slot-inbox">
+      <CardHeader className="pb-2">
+        <CardTitle className="flex items-center gap-2 text-sm font-medium">
+          <Inbox className="h-4 w-4" />
+          Inbox
+        </CardTitle>
+      </CardHeader>
+      <CardContent>
+        <p className="text-xs text-muted-foreground">Inbox preview — F-040 Sprint 14</p>
+      </CardContent>
+    </Card>
+  );
+}

--- a/dev/frontend/app/(shell)/dashboard/@library/default.tsx
+++ b/dev/frontend/app/(shell)/dashboard/@library/default.tsx
@@ -1,0 +1,3 @@
+export default function LibraryDefault() {
+  return null;
+}

--- a/dev/frontend/app/(shell)/dashboard/@library/error.tsx
+++ b/dev/frontend/app/(shell)/dashboard/@library/error.tsx
@@ -1,0 +1,13 @@
+"use client";
+
+import { ErrorCard } from "@/components/shell/error-card";
+
+export default function LibraryError({ reset }: { reset: () => void }) {
+  return (
+    <ErrorCard
+      title="Library 載入失敗"
+      description="無法取得 Library 資料，請稍後再試"
+      onRetry={reset}
+    />
+  );
+}

--- a/dev/frontend/app/(shell)/dashboard/@library/loading.tsx
+++ b/dev/frontend/app/(shell)/dashboard/@library/loading.tsx
@@ -1,0 +1,5 @@
+import { Skeleton } from "@/components/ui/skeleton";
+
+export default function LibraryLoading() {
+  return <Skeleton className="h-32 w-full rounded-lg" data-testid="slot-library-loading" />;
+}

--- a/dev/frontend/app/(shell)/dashboard/@library/page.tsx
+++ b/dev/frontend/app/(shell)/dashboard/@library/page.tsx
@@ -1,0 +1,18 @@
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { FileText } from "lucide-react";
+
+export default async function LibrarySlot() {
+  return (
+    <Card data-testid="slot-library">
+      <CardHeader className="pb-2">
+        <CardTitle className="flex items-center gap-2 text-sm font-medium">
+          <FileText className="h-4 w-4" />
+          Library
+        </CardTitle>
+      </CardHeader>
+      <CardContent>
+        <p className="text-xs text-muted-foreground">Library preview — F-041 Sprint 14</p>
+      </CardContent>
+    </Card>
+  );
+}

--- a/dev/frontend/app/(shell)/dashboard/@today/default.tsx
+++ b/dev/frontend/app/(shell)/dashboard/@today/default.tsx
@@ -1,0 +1,3 @@
+export default function TodayDefault() {
+  return null;
+}

--- a/dev/frontend/app/(shell)/dashboard/@today/error.tsx
+++ b/dev/frontend/app/(shell)/dashboard/@today/error.tsx
@@ -1,0 +1,13 @@
+"use client";
+
+import { ErrorCard } from "@/components/shell/error-card";
+
+export default function TodayError({ reset }: { reset: () => void }) {
+  return (
+    <ErrorCard
+      title="Today 載入失敗"
+      description="無法取得 Today 資料，請稍後再試"
+      onRetry={reset}
+    />
+  );
+}

--- a/dev/frontend/app/(shell)/dashboard/@today/loading.tsx
+++ b/dev/frontend/app/(shell)/dashboard/@today/loading.tsx
@@ -1,0 +1,5 @@
+import { Skeleton } from "@/components/ui/skeleton";
+
+export default function TodayLoading() {
+  return <Skeleton className="h-32 w-full rounded-lg" data-testid="slot-today-loading" />;
+}

--- a/dev/frontend/app/(shell)/dashboard/@today/page.tsx
+++ b/dev/frontend/app/(shell)/dashboard/@today/page.tsx
@@ -1,0 +1,18 @@
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Sun } from "lucide-react";
+
+export default async function TodaySlot() {
+  return (
+    <Card data-testid="slot-today">
+      <CardHeader className="pb-2">
+        <CardTitle className="flex items-center gap-2 text-sm font-medium">
+          <Sun className="h-4 w-4" />
+          Today
+        </CardTitle>
+      </CardHeader>
+      <CardContent>
+        <p className="text-xs text-muted-foreground">Today preview — F-042 Sprint 14</p>
+      </CardContent>
+    </Card>
+  );
+}

--- a/dev/frontend/app/(shell)/dashboard/layout.tsx
+++ b/dev/frontend/app/(shell)/dashboard/layout.tsx
@@ -1,0 +1,32 @@
+import type { ReactNode } from "react";
+
+interface DashboardLayoutProps {
+  children: ReactNode;
+  inbox: ReactNode;
+  library: ReactNode;
+  today: ReactNode;
+  copilot: ReactNode;
+}
+
+export default function DashboardLayout({
+  children,
+  inbox,
+  library,
+  today,
+  copilot,
+}: DashboardLayoutProps) {
+  return (
+    <div className="space-y-6" data-testid="dashboard-layout">
+      {children}
+      <div
+        className="grid grid-cols-1 gap-4 md:grid-cols-2 xl:grid-cols-4"
+        data-testid="dashboard-slots"
+      >
+        <div data-testid="dashboard-slot-inbox">{inbox}</div>
+        <div data-testid="dashboard-slot-library">{library}</div>
+        <div data-testid="dashboard-slot-today">{today}</div>
+        <div data-testid="dashboard-slot-copilot">{copilot}</div>
+      </div>
+    </div>
+  );
+}

--- a/dev/frontend/app/(shell)/dashboard/page.tsx
+++ b/dev/frontend/app/(shell)/dashboard/page.tsx
@@ -1,0 +1,10 @@
+export default function DashboardHubPage() {
+  return (
+    <div data-testid="dashboard-hub">
+      <h1 className="text-2xl font-semibold tracking-tight">Dashboard</h1>
+      <p className="text-sm text-muted-foreground mt-1">
+        歡迎回來，以下是今日總覽
+      </p>
+    </div>
+  );
+}

--- a/dev/frontend/app/(shell)/layout.tsx
+++ b/dev/frontend/app/(shell)/layout.tsx
@@ -1,0 +1,72 @@
+"use client";
+
+import { useState } from "react";
+import { Sidebar } from "@/components/shell/sidebar";
+import { TopBar } from "@/components/shell/top-bar";
+import { MainArea } from "@/components/shell/main-area";
+import { CopilotSlot } from "@/components/shell/copilot-slot";
+import { useQuery } from "@tanstack/react-query";
+import { apiClient } from "@/lib/api/client";
+import { useApiKey } from "@/lib/hooks/use-api-key";
+import { useEffect } from "react";
+import { useRouter } from "next/navigation";
+
+interface InboxCountResponse {
+  count?: number;
+  total?: number;
+  pagination?: { total?: number };
+}
+
+export default function ShellLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  const router = useRouter();
+  const { apiKey, hydrated } = useApiKey();
+  const [copilotOpen, setCopilotOpen] = useState(false);
+
+  useEffect(() => {
+    if (hydrated && !apiKey) {
+      router.replace("/bootstrap");
+    }
+  }, [apiKey, hydrated, router]);
+
+  const { data } = useQuery({
+    queryKey: ["inbox", "count"],
+    queryFn: async () => {
+      try {
+        return await apiClient.get<InboxCountResponse>(
+          "/api/v1/entries?category_id=null&is_archived=false&per_page=1",
+        );
+      } catch {
+        return { count: 0, pagination: { total: 0 } };
+      }
+    },
+    enabled: !!apiKey,
+    staleTime: 60_000,
+  });
+
+  const inboxCount =
+    data?.pagination?.total ?? data?.count ?? data?.total ?? 0;
+
+  if (hydrated && !apiKey) {
+    return null;
+  }
+
+  return (
+    <div className="flex h-screen w-full overflow-hidden">
+      {/* 左側 Sidebar */}
+      <Sidebar inboxCount={inboxCount} />
+
+      {/* 中間區域：TopBar + 內容 */}
+      <div className="flex min-w-0 flex-1 flex-col">
+        <TopBar />
+        <MainArea>{children}</MainArea>
+      </div>
+
+      {/* 右側 Copilot 佔位 */}
+      <CopilotSlot open={copilotOpen} onClose={() => setCopilotOpen(false)} />
+    </div>
+  );
+}

--- a/dev/frontend/components/shell/copilot-slot.tsx
+++ b/dev/frontend/components/shell/copilot-slot.tsx
@@ -1,0 +1,46 @@
+"use client";
+
+import { X, Bot } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+
+interface CopilotSlotProps {
+  open: boolean;
+  onClose: () => void;
+}
+
+export function CopilotSlot({ open, onClose }: CopilotSlotProps) {
+  return (
+    <aside
+      data-testid="copilot-slot"
+      aria-label="Copilot 助手"
+      className={cn(
+        "sticky top-0 h-screen border-l border-border bg-background transition-all duration-200 overflow-hidden flex flex-col",
+        open ? "w-80" : "w-0",
+      )}
+    >
+      {open && (
+        <>
+          <div className="flex h-14 items-center justify-between border-b px-4">
+            <div className="flex items-center gap-2">
+              <Bot className="h-4 w-4" />
+              <span className="text-sm font-medium">Copilot</span>
+            </div>
+            <Button
+              variant="ghost"
+              size="icon"
+              onClick={onClose}
+              aria-label="關閉 Copilot"
+              data-testid="copilot-close-btn"
+            >
+              <X className="h-4 w-4" />
+            </Button>
+          </div>
+          <div className="flex flex-1 items-center justify-center text-muted-foreground">
+            <p className="text-sm">Copilot SSE — F-047 Sprint 16</p>
+          </div>
+        </>
+      )}
+    </aside>
+  );
+}

--- a/dev/frontend/components/shell/error-card.tsx
+++ b/dev/frontend/components/shell/error-card.tsx
@@ -1,0 +1,40 @@
+"use client";
+
+import { AlertCircle, RefreshCw } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent } from "@/components/ui/card";
+
+interface ErrorCardProps {
+  title?: string;
+  description?: string;
+  onRetry?: () => void;
+}
+
+export function ErrorCard({
+  title = "載入失敗",
+  description = "無法取得資料，請稍後再試",
+  onRetry,
+}: ErrorCardProps) {
+  return (
+    <Card data-testid="error-card" className="border-destructive/50">
+      <CardContent className="flex flex-col items-center gap-3 p-6 text-center">
+        <AlertCircle className="h-8 w-8 text-destructive" />
+        <div>
+          <p className="font-medium text-sm">{title}</p>
+          <p className="text-xs text-muted-foreground mt-1">{description}</p>
+        </div>
+        {onRetry && (
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={onRetry}
+            data-testid="error-card-retry"
+          >
+            <RefreshCw className="mr-2 h-3 w-3" />
+            重試
+          </Button>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/dev/frontend/components/shell/main-area.tsx
+++ b/dev/frontend/components/shell/main-area.tsx
@@ -1,0 +1,17 @@
+import { cn } from "@/lib/utils";
+
+interface MainAreaProps {
+  children: React.ReactNode;
+  className?: string;
+}
+
+export function MainArea({ children, className }: MainAreaProps) {
+  return (
+    <main
+      data-testid="app-main"
+      className={cn("flex-1 overflow-y-auto p-4 md:p-6 min-h-0", className)}
+    >
+      {children}
+    </main>
+  );
+}

--- a/dev/frontend/components/shell/sidebar.tsx
+++ b/dev/frontend/components/shell/sidebar.tsx
@@ -1,0 +1,239 @@
+"use client";
+
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+import {
+  Bot,
+  Calendar,
+  FileText,
+  FolderTree,
+  Github,
+  Inbox,
+  KanbanSquare,
+  Key,
+  Network,
+  Search,
+  Settings,
+  Sun,
+  ChevronLeft,
+  ChevronRight,
+} from "lucide-react";
+import { cn } from "@/lib/utils";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
+import { useLocalStorage } from "@/lib/hooks/use-local-storage";
+import { useEffect, useState } from "react";
+
+type NavItem = {
+  label: string;
+  href: string;
+  icon: React.ComponentType<{ className?: string }>;
+  badge?: number;
+  testId?: string;
+};
+
+interface SidebarProps {
+  inboxCount?: number;
+}
+
+const SIDEBAR_COLLAPSED_KEY = "aibo_sidebar_collapsed";
+
+export function useSidebarCollapsed() {
+  return useLocalStorage<boolean>(SIDEBAR_COLLAPSED_KEY, false);
+}
+
+export function Sidebar({ inboxCount = 0 }: SidebarProps) {
+  const pathname = usePathname();
+  const [collapsed, setCollapsed] = useLocalStorage<boolean>(
+    SIDEBAR_COLLAPSED_KEY,
+    false,
+  );
+  // hydration-safe: 初始 SSR 不知道 collapsed 狀態，client 載入後同步
+  const [mounted, setMounted] = useState(false);
+  useEffect(() => setMounted(true), []);
+
+  const main: NavItem[] = [
+    {
+      label: "Inbox",
+      href: "/inbox",
+      icon: Inbox,
+      badge: inboxCount || undefined,
+      testId: "nav-inbox",
+    },
+    { label: "Library", href: "/library", icon: FileText, testId: "nav-library" },
+    { label: "Today", href: "/today", icon: Sun, testId: "nav-today" },
+    { label: "Canvas", href: "/canvas", icon: Network, testId: "nav-canvas" },
+    { label: "行事曆", href: "/calendar", icon: Calendar, testId: "nav-calendar" },
+    { label: "專案", href: "/projects", icon: KanbanSquare, testId: "nav-projects" },
+    { label: "知識條目", href: "/entries", icon: FileText, testId: "nav-entries" },
+    { label: "分類管理", href: "/categories", icon: FolderTree, testId: "nav-categories" },
+    { label: "搜尋", href: "/search", icon: Search, testId: "nav-search" },
+  ];
+
+  const settingsItems: NavItem[] = [
+    { label: "設定", href: "/settings", icon: Settings, testId: "nav-settings" },
+    { label: "API Key", href: "/settings/api-keys", icon: Key, testId: "nav-api-keys" },
+    { label: "LLM Provider", href: "/settings/llm-providers", icon: Bot, testId: "nav-llm-providers" },
+    { label: "Google Calendar", href: "/settings/gcal", icon: Calendar, testId: "nav-gcal" },
+    { label: "GitHub", href: "/settings/github", icon: Github, testId: "nav-github" },
+  ];
+
+  const isCollapsed = mounted ? collapsed : false;
+
+  return (
+    <aside
+      aria-label="主要導航"
+      data-testid="app-sidebar"
+      data-collapsed={isCollapsed}
+      suppressHydrationWarning
+      className={cn(
+        "sticky top-0 flex h-screen flex-col border-r border-sidebar-border bg-sidebar text-sidebar-foreground transition-all duration-200",
+        isCollapsed ? "w-14" : "w-64",
+      )}
+    >
+      {/* Logo */}
+      <div
+        className={cn(
+          "flex h-14 items-center border-b border-sidebar-border px-3",
+          isCollapsed ? "justify-center" : "justify-between",
+        )}
+      >
+        {!isCollapsed && (
+          <div className="flex items-center gap-2">
+            <div className="flex h-8 w-8 items-center justify-center rounded-md bg-primary text-primary-foreground text-sm font-bold">
+              A
+            </div>
+            <span className="text-lg font-semibold">aibo</span>
+          </div>
+        )}
+        {isCollapsed && (
+          <div className="flex h-8 w-8 items-center justify-center rounded-md bg-primary text-primary-foreground text-sm font-bold">
+            A
+          </div>
+        )}
+        <Button
+          variant="ghost"
+          size="icon"
+          className={cn("h-7 w-7 shrink-0", isCollapsed && "hidden")}
+          onClick={() => setCollapsed(true)}
+          aria-label="收合側邊欄"
+          data-testid="sidebar-collapse-btn"
+        >
+          <ChevronLeft className="h-4 w-4" />
+        </Button>
+      </div>
+
+      {/* Nav */}
+      <nav className="flex-1 overflow-y-auto py-3 px-2 space-y-1">
+        <NavSection
+          items={main}
+          pathname={pathname}
+          collapsed={isCollapsed}
+          inboxCount={inboxCount}
+        />
+        <div className="my-2 border-t border-sidebar-border" />
+        <NavSection
+          items={settingsItems}
+          pathname={pathname}
+          collapsed={isCollapsed}
+        />
+      </nav>
+
+      {/* Footer toggle */}
+      <div className="border-t border-sidebar-border p-2 flex justify-end">
+        {isCollapsed ? (
+          <Button
+            variant="ghost"
+            size="icon"
+            className="h-7 w-7"
+            onClick={() => setCollapsed(false)}
+            aria-label="展開側邊欄"
+            data-testid="sidebar-expand-btn"
+          >
+            <ChevronRight className="h-4 w-4" />
+          </Button>
+        ) : (
+          <span className="text-xs text-muted-foreground px-1">aibo v1.0.0</span>
+        )}
+      </div>
+    </aside>
+  );
+}
+
+function NavSection({
+  items,
+  pathname,
+  collapsed,
+  inboxCount,
+}: {
+  items: NavItem[];
+  pathname: string;
+  collapsed: boolean;
+  inboxCount?: number;
+}) {
+  return (
+    <ul className="space-y-1">
+      {items.map((item) => {
+        const active =
+          pathname === item.href || pathname.startsWith(item.href + "/");
+        const Icon = item.icon;
+        const badge = item.testId === "nav-inbox" ? inboxCount : item.badge;
+
+        if (collapsed) {
+          return (
+            <li key={item.href}>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <Link
+                    href={item.href}
+                    aria-current={active ? "page" : undefined}
+                    data-testid={item.testId}
+                    className={cn(
+                      "flex h-10 w-10 items-center justify-center rounded-md text-sm font-medium transition-colors mx-auto",
+                      active
+                        ? "bg-sidebar-primary text-sidebar-primary-foreground"
+                        : "text-sidebar-foreground hover:bg-sidebar-accent hover:text-sidebar-accent-foreground",
+                    )}
+                  >
+                    <Icon className="h-4 w-4 shrink-0" />
+                  </Link>
+                </TooltipTrigger>
+                <TooltipContent side="right">{item.label}</TooltipContent>
+              </Tooltip>
+            </li>
+          );
+        }
+
+        return (
+          <li key={item.href}>
+            <Link
+              href={item.href}
+              aria-current={active ? "page" : undefined}
+              data-testid={item.testId}
+              className={cn(
+                "flex h-10 items-center gap-3 rounded-md px-3 text-sm font-medium transition-colors",
+                active
+                  ? "bg-sidebar-primary text-sidebar-primary-foreground"
+                  : "text-sidebar-foreground hover:bg-sidebar-accent hover:text-sidebar-accent-foreground",
+              )}
+            >
+              <Icon className="h-4 w-4 shrink-0" />
+              <span className="flex-1 truncate">{item.label}</span>
+              {typeof badge === "number" && badge > 0 && (
+                <Badge
+                  variant="default"
+                  aria-label={`${badge} 筆未分類條目`}
+                  data-testid="sidebar-inbox-badge"
+                  className="h-5 px-2 text-xs"
+                >
+                  {badge > 99 ? "99+" : badge}
+                </Badge>
+              )}
+            </Link>
+          </li>
+        );
+      })}
+    </ul>
+  );
+}

--- a/dev/frontend/components/shell/top-bar.tsx
+++ b/dev/frontend/components/shell/top-bar.tsx
@@ -1,0 +1,55 @@
+"use client";
+
+import { Moon, Sun, Search } from "lucide-react";
+import { useTheme } from "@/components/theme/theme-provider";
+import { Button } from "@/components/ui/button";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
+
+interface TopBarProps {
+  onSearchOpen?: () => void;
+}
+
+export function TopBar({ onSearchOpen }: TopBarProps) {
+  const { theme, setTheme } = useTheme();
+
+  return (
+    <header
+      data-testid="app-top-bar"
+      className="sticky top-0 z-10 flex h-14 items-center gap-4 border-b bg-background px-4 md:px-6"
+    >
+      <div className="flex-1" />
+
+      {/* 搜尋觸發（CmdK 由 F-037 接管） */}
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <Button
+            variant="outline"
+            size="sm"
+            className="hidden md:flex items-center gap-2 text-muted-foreground w-48 justify-start"
+            onClick={onSearchOpen}
+            data-testid="topbar-search-trigger"
+          >
+            <Search className="h-4 w-4" />
+            <span className="flex-1 text-left text-sm">搜尋...</span>
+            <kbd className="pointer-events-none hidden h-5 select-none items-center gap-1 rounded border bg-muted px-1.5 font-mono text-[10px] font-medium opacity-100 sm:flex">
+              ⌘K
+            </kbd>
+          </Button>
+        </TooltipTrigger>
+        <TooltipContent>全域搜尋（F-037）</TooltipContent>
+      </Tooltip>
+
+      {/* ThemeToggle */}
+      <Button
+        variant="ghost"
+        size="icon"
+        onClick={() => setTheme(theme === "dark" ? "light" : "dark")}
+        aria-label="切換主題"
+        data-testid="theme-toggle"
+      >
+        <Sun className="h-4 w-4 dark:hidden" />
+        <Moon className="hidden h-4 w-4 dark:block" />
+      </Button>
+    </header>
+  );
+}

--- a/dev/frontend/lib/hooks/use-local-storage.ts
+++ b/dev/frontend/lib/hooks/use-local-storage.ts
@@ -1,0 +1,37 @@
+"use client";
+
+import { useState, useEffect, useCallback } from "react";
+
+export function useLocalStorage<T>(
+  key: string,
+  initialValue: T,
+): [T, (value: T | ((prev: T) => T)) => void] {
+  const [storedValue, setStoredValue] = useState<T>(initialValue);
+
+  useEffect(() => {
+    try {
+      const item = window.localStorage.getItem(key);
+      if (item !== null) {
+        setStoredValue(JSON.parse(item) as T);
+      }
+    } catch {
+      // ignore
+    }
+  }, [key]);
+
+  const setValue = useCallback(
+    (value: T | ((prev: T) => T)) => {
+      try {
+        const valueToStore =
+          value instanceof Function ? value(storedValue) : value;
+        setStoredValue(valueToStore);
+        window.localStorage.setItem(key, JSON.stringify(valueToStore));
+      } catch {
+        // ignore
+      }
+    },
+    [key, storedValue],
+  );
+
+  return [storedValue, setValue];
+}


### PR DESCRIPTION
Closes #195

## 實作
- (shell) route group 包含 sidebar / top-bar / main-area / copilot-slot
- /dashboard hub 採 Next.js parallel routes：@inbox / @library / @today / @copilot 四個 slot
- 深連結子路由：/dashboard/inbox /library /today /canvas /settings
- shell components: sidebar / top-bar (PillNav) / main-area / copilot-slot / error-card
- use-local-storage hook