### PR TITLE
test(sprint-14): F-040~F-043 skeleton

### DIFF
--- a/test/browser/specs/f040_inbox_triage.spec.ts
+++ b/test/browser/specs/f040_inbox_triage.spec.ts
@@ -1,0 +1,405 @@
+/**
+ * F-040: Inbox Triage View
+ *
+ * Spec: specs/features/f040-inbox-triage.md
+ * Issue: #206
+ * QA Issue: #211
+ *
+ * 涵蓋 Sprint 14 QA scenarios：
+ * - 載入 Inbox 列表
+ * - Archive 單筆（樂觀更新）
+ * - 批次 Archive（Space 選取）
+ * - 樂觀更新 rollback（後端 500）
+ * - Empty state
+ * - 鍵盤快捷鍵 J/K/A/D/E
+ */
+
+import { test, expect } from "@playwright/test";
+import { loginWithCookie } from "../helpers/cookie-auth";
+
+const FEATURE = "F-040";
+
+test.describe(`[${FEATURE}] Inbox Triage View`, () => {
+  test.beforeEach(async ({ context }) => {
+    await context.clearCookies();
+    const apiKey = process.env.AIBO_E2E_API_KEY!;
+    await loginWithCookie(context, apiKey);
+  });
+
+  // --- Happy Path ---
+
+  test("IT-1 載入 Inbox 列表：顯示 status=inbox entries，依 created_at DESC 排序", async ({
+    page,
+  }) => {
+    test.skip(true, "skeleton：等 F-040 InboxPage + GET /api/v1/entries?status=inbox 實作");
+
+    await page.route("**/api/v1/entries*", (route) => {
+      const url = new URL(route.request().url());
+      if (url.searchParams.get("status") === "inbox") {
+        route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify({
+            items: [
+              { id: "uuid-1", title: "Entry A", status: "inbox", created_at: "2026-04-28T10:00:00Z" },
+              { id: "uuid-2", title: "Entry B", status: "inbox", created_at: "2026-04-27T10:00:00Z" },
+            ],
+            total: 2,
+            page: 1,
+            per_page: 20,
+          }),
+        });
+      } else {
+        route.continue();
+      }
+    });
+
+    await page.goto("/dashboard/inbox");
+    await page.waitForLoadState("networkidle");
+
+    // THEN 顯示 2 筆 entry cards
+    await expect(page.getByTestId("inbox-card").first()).toBeVisible();
+    const cards = page.getByTestId("inbox-card");
+    await expect(cards).toHaveCount(2);
+
+    // AND Entry A（較新）排在第一
+    await expect(cards.nth(0)).toContainText("Entry A");
+    await expect(cards.nth(1)).toContainText("Entry B");
+  });
+
+  test("IT-2 Archive 單筆 entry：樂觀更新移除，toast 顯示 Archived", async ({ page }) => {
+    test.skip(true, "skeleton：等 F-040 Archive 按鈕 + 樂觀更新 + toast 實作");
+
+    let patchCalled = false;
+    await page.route("**/api/v1/entries/uuid-1", (route) => {
+      if (route.request().method() === "PATCH") {
+        patchCalled = true;
+        route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify({ id: "uuid-1", status: "archived" }),
+        });
+      } else {
+        route.continue();
+      }
+    });
+
+    await page.route("**/api/v1/entries*", (route) => {
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          items: [{ id: "uuid-1", title: "Entry A", status: "inbox", created_at: "2026-04-28T10:00:00Z" }],
+          total: 1,
+          page: 1,
+          per_page: 20,
+        }),
+      });
+    });
+
+    await page.goto("/dashboard/inbox");
+    await page.waitForLoadState("networkidle");
+
+    // WHEN 點擊 Archive 按鈕
+    await page.getByTestId("inbox-card").first().getByRole("button", { name: /archive/i }).click();
+
+    // THEN entry 從列表移除（樂觀更新）
+    await expect(page.getByTestId("inbox-card")).toHaveCount(0);
+
+    // AND toast 顯示 "Archived"
+    await expect(page.getByText(/archived/i)).toBeVisible();
+
+    // AND PATCH /api/v1/entries/:id 被呼叫
+    expect(patchCalled).toBe(true);
+  });
+
+  test("IT-3 批次 Archive 3 筆：Space 選取後 Batch Archive", async ({ page }) => {
+    test.skip(true, "skeleton：等 F-040 批次選取 + POST /api/v1/entries/batch 實作");
+
+    let batchCalled = false;
+    let batchBody: unknown;
+    await page.route("**/api/v1/entries/batch", (route) => {
+      batchCalled = true;
+      route.request().postDataJSON().then((body: unknown) => { batchBody = body; });
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ succeeded: ["uuid-1", "uuid-2", "uuid-3"], failed: [] }),
+      });
+    });
+
+    await page.route("**/api/v1/entries*", (route) => {
+      const url = new URL(route.request().url());
+      if (!url.pathname.includes("/batch")) {
+        route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify({
+            items: [
+              { id: "uuid-1", title: "Entry A", status: "inbox", created_at: "2026-04-28T10:00:00Z" },
+              { id: "uuid-2", title: "Entry B", status: "inbox", created_at: "2026-04-28T09:00:00Z" },
+              { id: "uuid-3", title: "Entry C", status: "inbox", created_at: "2026-04-28T08:00:00Z" },
+            ],
+            total: 3,
+            page: 1,
+            per_page: 20,
+          }),
+        });
+      } else {
+        route.continue();
+      }
+    });
+
+    await page.goto("/dashboard/inbox");
+    await page.waitForLoadState("networkidle");
+
+    // WHEN 以 Space 選取 3 筆
+    const cards = page.getByTestId("inbox-card");
+    for (let i = 0; i < 3; i++) {
+      await cards.nth(i).click();
+      await page.keyboard.press("Space");
+    }
+
+    // AND 點擊 Batch Archive
+    await page.getByRole("button", { name: /batch archive/i }).click();
+    await page.waitForLoadState("networkidle");
+
+    // THEN 3 筆從列表移除
+    await expect(page.getByTestId("inbox-card")).toHaveCount(0);
+    expect(batchCalled).toBe(true);
+  });
+
+  test("IT-4 Empty state：inbox 為空時顯示 'Your inbox is clear' 與 Browse Library CTA", async ({
+    page,
+  }) => {
+    test.skip(true, "skeleton：等 F-040 empty state 元件實作");
+
+    await page.route("**/api/v1/entries*", (route) => {
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ items: [], total: 0, page: 1, per_page: 20 }),
+      });
+    });
+
+    await page.goto("/dashboard/inbox");
+    await page.waitForLoadState("networkidle");
+
+    // THEN empty state
+    await expect(page.getByText(/your inbox is clear/i)).toBeVisible();
+    // AND "Browse Library" CTA
+    await expect(page.getByRole("link", { name: /browse library/i })).toBeVisible();
+  });
+
+  // --- Error Handling ---
+
+  test("IT-5 樂觀更新 rollback：後端 PATCH 500 → entry 重新出現，toast 顯示 Action failed", async ({
+    page,
+  }) => {
+    test.skip(true, "skeleton：等 F-040 樂觀更新 rollback + error toast 實作");
+
+    await page.route("**/api/v1/entries/uuid-1", (route) => {
+      if (route.request().method() === "PATCH") {
+        route.fulfill({ status: 500, body: JSON.stringify({ error: "internal server error" }) });
+      } else {
+        route.continue();
+      }
+    });
+
+    await page.route("**/api/v1/entries*", (route) => {
+      const url = new URL(route.request().url());
+      if (!url.pathname.includes("/uuid-1")) {
+        route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify({
+            items: [{ id: "uuid-1", title: "Entry A", status: "inbox", created_at: "2026-04-28T10:00:00Z" }],
+            total: 1,
+            page: 1,
+            per_page: 20,
+          }),
+        });
+      } else {
+        route.continue();
+      }
+    });
+
+    await page.goto("/dashboard/inbox");
+    await page.waitForLoadState("networkidle");
+
+    // WHEN 點擊 Archive（觸發樂觀更新）
+    await page.getByTestId("inbox-card").first().getByRole("button", { name: /archive/i }).click();
+
+    // THEN 等待 rollback：entry 重新出現
+    await expect(page.getByTestId("inbox-card")).toHaveCount(1);
+
+    // AND toast 顯示 "Action failed, please retry"
+    await expect(page.getByText(/action failed|please retry/i)).toBeVisible();
+  });
+
+  // --- 鍵盤快捷鍵 ---
+
+  test("IT-6 鍵盤 J/K：active card 游標上下移動", async ({ page }) => {
+    test.skip(true, "skeleton：等 F-040 鍵盤導航（J/K）實作");
+
+    await page.route("**/api/v1/entries*", (route) => {
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          items: [
+            { id: "uuid-1", title: "Entry A", status: "inbox", created_at: "2026-04-28T10:00:00Z" },
+            { id: "uuid-2", title: "Entry B", status: "inbox", created_at: "2026-04-27T10:00:00Z" },
+            { id: "uuid-3", title: "Entry C", status: "inbox", created_at: "2026-04-26T10:00:00Z" },
+          ],
+          total: 3,
+          page: 1,
+          per_page: 20,
+        }),
+      });
+    });
+
+    await page.goto("/dashboard/inbox");
+    await page.waitForLoadState("networkidle");
+
+    // 點擊頁面讓 inbox 取得 focus
+    await page.getByTestId("inbox-list").click();
+
+    // 第一張預設 active
+    await expect(page.getByTestId("inbox-card").nth(0)).toHaveAttribute("data-active", "true");
+
+    // WHEN 按 J → 移到下一筆
+    await page.keyboard.press("j");
+    await expect(page.getByTestId("inbox-card").nth(1)).toHaveAttribute("data-active", "true");
+    await expect(page.getByTestId("inbox-card").nth(0)).not.toHaveAttribute("data-active", "true");
+
+    // WHEN 再按 J
+    await page.keyboard.press("j");
+    await expect(page.getByTestId("inbox-card").nth(2)).toHaveAttribute("data-active", "true");
+
+    // WHEN 按 K → 往上
+    await page.keyboard.press("k");
+    await expect(page.getByTestId("inbox-card").nth(1)).toHaveAttribute("data-active", "true");
+  });
+
+  test("IT-7 鍵盤 A：active entry 執行 archive", async ({ page }) => {
+    test.skip(true, "skeleton：等 F-040 鍵盤快捷鍵 A（archive）實作");
+
+    let patchCalled = false;
+    await page.route("**/api/v1/entries/uuid-1", (route) => {
+      if (route.request().method() === "PATCH") {
+        patchCalled = true;
+        route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify({ id: "uuid-1", status: "archived" }),
+        });
+      } else {
+        route.continue();
+      }
+    });
+
+    await page.route("**/api/v1/entries*", (route) => {
+      const url = new URL(route.request().url());
+      if (!url.pathname.includes("/uuid-1")) {
+        route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify({
+            items: [{ id: "uuid-1", title: "Entry A", status: "inbox", created_at: "2026-04-28T10:00:00Z" }],
+            total: 1,
+            page: 1,
+            per_page: 20,
+          }),
+        });
+      } else {
+        route.continue();
+      }
+    });
+
+    await page.goto("/dashboard/inbox");
+    await page.waitForLoadState("networkidle");
+
+    // 讓 inbox list 取得 focus
+    await page.getByTestId("inbox-list").click();
+
+    // WHEN 按 A
+    await page.keyboard.press("a");
+
+    // THEN active entry 被 archived（樂觀更新，移除）
+    await expect(page.getByTestId("inbox-card")).toHaveCount(0);
+    expect(patchCalled).toBe(true);
+  });
+
+  test("IT-8 鍵盤 D/E：D 觸發 delete、E 觸發 edit", async ({ page }) => {
+    test.skip(true, "skeleton：等 F-040 鍵盤快捷鍵 D（delete）/ E（edit）實作");
+
+    let deleteCalled = false;
+    await page.route("**/api/v1/entries/uuid-1", (route) => {
+      if (route.request().method() === "DELETE") {
+        deleteCalled = true;
+        route.fulfill({ status: 204 });
+      } else {
+        route.continue();
+      }
+    });
+
+    await page.route("**/api/v1/entries*", (route) => {
+      const url = new URL(route.request().url());
+      if (!url.pathname.includes("/uuid-1")) {
+        route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify({
+            items: [{ id: "uuid-1", title: "Entry A", status: "inbox", created_at: "2026-04-28T10:00:00Z" }],
+            total: 1,
+            page: 1,
+            per_page: 20,
+          }),
+        });
+      } else {
+        route.continue();
+      }
+    });
+
+    await page.goto("/dashboard/inbox");
+    await page.waitForLoadState("networkidle");
+
+    await page.getByTestId("inbox-list").click();
+
+    // WHEN 按 D → 觸發 delete
+    await page.keyboard.press("d");
+    await expect(page.getByTestId("inbox-card")).toHaveCount(0);
+    expect(deleteCalled).toBe(true);
+  });
+
+  test("IT-9 鍵盤 E：active entry 進入 edit 模式", async ({ page }) => {
+    test.skip(true, "skeleton：等 F-040 鍵盤快捷鍵 E（edit）實作");
+
+    await page.route("**/api/v1/entries*", (route) => {
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          items: [{ id: "uuid-1", title: "Entry A", status: "inbox", created_at: "2026-04-28T10:00:00Z" }],
+          total: 1,
+          page: 1,
+          per_page: 20,
+        }),
+      });
+    });
+
+    await page.goto("/dashboard/inbox");
+    await page.waitForLoadState("networkidle");
+
+    await page.getByTestId("inbox-list").click();
+
+    // WHEN 按 E → 進入 edit 模式（展開 entry detail 或導向編輯頁）
+    await page.keyboard.press("e");
+
+    // THEN 顯示 entry 編輯介面
+    await expect(
+      page.getByTestId("entry-edit-sheet").or(page.getByRole("textbox", { name: /title/i })),
+    ).toBeVisible();
+  });
+});

--- a/test/browser/specs/f041_library_table.spec.ts
+++ b/test/browser/specs/f041_library_table.spec.ts
@@ -1,0 +1,292 @@
+/**
+ * F-041: Library Table View
+ *
+ * Spec: specs/features/f041-library-table.md
+ * Issue: #207
+ * QA Issue: #211
+ *
+ * 涵蓋 Sprint 14 QA scenarios：
+ * - 載入 Library 預設視圖（20 筆 / 頁）
+ * - 全文搜尋 → URL 同步 ?q=
+ * - 欄位排序 → URL 同步 ?sort=&dir=
+ * - 點選 row 展開 Sheet
+ * - URL 直接含過濾參數（深連結）
+ * - 清空搜尋 → 移除 q 參數
+ * - 後端 500 → error state
+ */
+
+import { test, expect } from "@playwright/test";
+import { loginWithCookie } from "../helpers/cookie-auth";
+
+const FEATURE = "F-041";
+
+/** 產生假 entries 資料 */
+function makeEntries(count: number, overrides: Record<string, unknown> = {}) {
+  return Array.from({ length: count }, (_, i) => ({
+    id: `uuid-${i + 1}`,
+    title: `Entry ${i + 1}`,
+    summary: `Summary ${i + 1}`,
+    category: { id: "cat-uuid", name: "Programming" },
+    tags: ["go"],
+    status: "library",
+    confidence: parseFloat((0.9 - i * 0.01).toFixed(2)),
+    source_type: "manual",
+    created_at: "2026-04-28T10:00:00Z",
+    updated_at: "2026-04-28T10:00:00Z",
+    ...overrides,
+  }));
+}
+
+test.describe(`[${FEATURE}] Library Table View`, () => {
+  test.beforeEach(async ({ context }) => {
+    await context.clearCookies();
+    const apiKey = process.env.AIBO_E2E_API_KEY!;
+    await loginWithCookie(context, apiKey);
+  });
+
+  // --- Happy Path ---
+
+  test("LT-1 載入 Library 預設視圖：顯示第 1 頁 20 筆，依 updated_at DESC", async ({ page }) => {
+    test.skip(true, "skeleton：等 F-041 LibraryPage + TanStack Table 實作");
+
+    await page.route("**/api/v1/entries*", (route) => {
+      const url = new URL(route.request().url());
+      if (url.searchParams.get("status") === "library") {
+        route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify({
+            items: makeEntries(20),
+            total: 30,
+            page: 1,
+            per_page: 20,
+          }),
+        });
+      } else {
+        route.continue();
+      }
+    });
+
+    await page.goto("/library");
+    await page.waitForLoadState("networkidle");
+
+    // THEN 顯示 20 筆
+    const rows = page.getByTestId("library-row");
+    await expect(rows).toHaveCount(20);
+
+    // AND pagination 顯示 "1-20 of 30"
+    await expect(page.getByText(/1-20 of 30/i)).toBeVisible();
+  });
+
+  test("LT-2 全文搜尋：輸入 'ml' 後 URL 更新含 ?q=ml", async ({ page }) => {
+    test.skip(true, "skeleton：等 F-041 SearchInput + URL sync 實作");
+
+    let searchCalled = false;
+    await page.route("**/api/v1/entries*", (route) => {
+      const url = new URL(route.request().url());
+      const q = url.searchParams.get("q");
+      if (q === "ml") {
+        searchCalled = true;
+        route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify({
+            items: makeEntries(3),
+            total: 3,
+            page: 1,
+            per_page: 20,
+          }),
+        });
+      } else {
+        route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify({ items: makeEntries(20), total: 30, page: 1, per_page: 20 }),
+        });
+      }
+    });
+
+    await page.goto("/library");
+    await page.waitForLoadState("networkidle");
+
+    // WHEN 在 SearchInput 輸入 "ml" 並停頓 300ms
+    await page.getByRole("searchbox").fill("ml");
+    await page.waitForTimeout(400);
+
+    // THEN URL 更新含 ?q=ml
+    expect(page.url()).toContain("q=ml");
+
+    // AND 列表重新載入
+    expect(searchCalled).toBe(true);
+    await expect(page.getByTestId("library-row")).toHaveCount(3);
+  });
+
+  test("LT-3 依 confidence 排序：點擊欄位標頭，URL 更新 ?sort=confidence&dir=desc", async ({
+    page,
+  }) => {
+    test.skip(true, "skeleton：等 F-041 column sort + URL sync 實作");
+
+    let sortCalled = false;
+    await page.route("**/api/v1/entries*", (route) => {
+      const url = new URL(route.request().url());
+      const sortBy = url.searchParams.get("sort_by");
+      const sortDir = url.searchParams.get("sort_dir");
+      if (sortBy === "confidence" && sortDir === "desc") {
+        sortCalled = true;
+        // 回傳 confidence 由高到低
+        const sorted = makeEntries(5).sort((a, b) => b.confidence - a.confidence);
+        route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify({ items: sorted, total: 5, page: 1, per_page: 20 }),
+        });
+      } else {
+        route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify({ items: makeEntries(5), total: 5, page: 1, per_page: 20 }),
+        });
+      }
+    });
+
+    await page.goto("/library");
+    await page.waitForLoadState("networkidle");
+
+    // WHEN 點擊 "Confidence" 欄位標頭
+    await page.getByRole("columnheader", { name: /confidence/i }).click();
+    await page.waitForLoadState("networkidle");
+
+    // THEN URL 更新
+    expect(page.url()).toContain("sort=confidence");
+    expect(page.url()).toContain("dir=desc");
+    expect(sortCalled).toBe(true);
+  });
+
+  test("LT-4 點選 row 展開 EntryDetailSheet", async ({ page }) => {
+    test.skip(true, "skeleton：等 F-041 row click → Sheet 實作");
+
+    await page.route("**/api/v1/entries*", (route) => {
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ items: makeEntries(5), total: 5, page: 1, per_page: 20 }),
+      });
+    });
+
+    await page.goto("/library");
+    await page.waitForLoadState("networkidle");
+
+    // WHEN 點選第一個 row
+    await page.getByTestId("library-row").first().click();
+
+    // THEN 右側 Sheet 展開，顯示 entry 詳情
+    await expect(page.getByTestId("entry-detail-sheet")).toBeVisible();
+    await expect(page.getByTestId("entry-detail-sheet")).toContainText("Entry 1");
+  });
+
+  // --- URL 深連結 ---
+
+  test("LT-5 URL 直接含過濾參數：/library?status=archived&sort=created_at → FilterBar 已選中", async ({
+    page,
+  }) => {
+    test.skip(true, "skeleton：等 F-041 URL params 反向同步 FilterBar 實作");
+
+    await page.route("**/api/v1/entries*", (route) => {
+      const url = new URL(route.request().url());
+      const status = url.searchParams.get("status");
+      const sortBy = url.searchParams.get("sort_by");
+      if (status === "archived" && sortBy === "created_at") {
+        route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify({
+            items: makeEntries(3, { status: "archived" }),
+            total: 3,
+            page: 1,
+            per_page: 20,
+          }),
+        });
+      } else {
+        route.continue();
+      }
+    });
+
+    // WHEN 直接訪問含參數 URL
+    await page.goto("/library?status=archived&sort=created_at");
+    await page.waitForLoadState("networkidle");
+
+    // THEN FilterBar 顯示 status=archived 已選中
+    await expect(page.getByTestId("filter-status-archived")).toHaveAttribute("aria-selected", "true");
+
+    // AND 列表以 created_at 排序
+    await expect(page.getByTestId("library-row")).toHaveCount(3);
+  });
+
+  test("LT-6 清空搜尋：URL 移除 q 參數，列表顯示全部", async ({ page }) => {
+    test.skip(true, "skeleton：等 F-041 clear search → URL update 實作");
+
+    await page.route("**/api/v1/entries*", (route) => {
+      const url = new URL(route.request().url());
+      const q = url.searchParams.get("q");
+      if (q === "test") {
+        route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify({ items: makeEntries(2), total: 2, page: 1, per_page: 20 }),
+        });
+      } else {
+        route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify({ items: makeEntries(10), total: 10, page: 1, per_page: 20 }),
+        });
+      }
+    });
+
+    // GIVEN URL 含 ?q=test
+    await page.goto("/library?q=test");
+    await page.waitForLoadState("networkidle");
+
+    // WHEN 清空 SearchInput
+    await page.getByRole("searchbox").clear();
+    await page.waitForTimeout(400);
+
+    // THEN URL 移除 q 參數
+    expect(page.url()).not.toContain("q=");
+
+    // AND 列表顯示全部
+    await expect(page.getByTestId("library-row")).toHaveCount(10);
+  });
+
+  // --- Error Handling ---
+
+  test("LT-7 後端 500：顯示 error state，保留上次結果", async ({ page }) => {
+    test.skip(true, "skeleton：等 F-041 error boundary + stale-while-revalidate 實作");
+
+    let callCount = 0;
+    await page.route("**/api/v1/entries*", (route) => {
+      callCount++;
+      if (callCount === 1) {
+        // 第一次成功
+        route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify({ items: makeEntries(5), total: 5, page: 1, per_page: 20 }),
+        });
+      } else {
+        // 之後模擬 500
+        route.fulfill({ status: 500, body: JSON.stringify({ error: "internal server error" }) });
+      }
+    });
+
+    await page.goto("/library");
+    await page.waitForLoadState("networkidle");
+
+    // 觸發重新載入（例如搜尋）
+    await page.getByRole("searchbox").fill("trigger-reload");
+    await page.waitForTimeout(400);
+
+    // THEN 顯示 error state
+    await expect(page.getByText(/failed to load|retry/i)).toBeVisible();
+  });
+});

--- a/test/browser/specs/f042_today_dashboard.spec.ts
+++ b/test/browser/specs/f042_today_dashboard.spec.ts
@@ -1,0 +1,249 @@
+/**
+ * F-042: Today Dashboard
+ *
+ * Spec: specs/features/f042-today-dashboard.md
+ * Issue: #208
+ * QA Issue: #211
+ *
+ * 涵蓋 Sprint 14 QA scenarios：
+ * - 載入完整 Today 頁面（4 個 sections 全顯示）
+ * - 今日無日記時顯示 CTA
+ * - 點擊 Journal Edit → 導向 /today/journal
+ * - GCal 未連線時 CalendarSection 不顯示
+ * - Tasks API 500 時只影響 TasksSection，其他 section 正常
+ */
+
+import { test, expect } from "@playwright/test";
+import { loginWithCookie } from "../helpers/cookie-auth";
+
+const FEATURE = "F-042";
+
+const TODAY_DATE = new Date().toISOString().slice(0, 10); // YYYY-MM-DD
+
+test.describe(`[${FEATURE}] Today Dashboard`, () => {
+  test.beforeEach(async ({ context }) => {
+    await context.clearCookies();
+    const apiKey = process.env.AIBO_E2E_API_KEY!;
+    await loginWithCookie(context, apiKey);
+  });
+
+  // --- Happy Path ---
+
+  test("TD-1 載入完整 Today 頁面：4 個 sections 全顯示，無全頁 loading spinner", async ({
+    page,
+  }) => {
+    test.skip(true, "skeleton：等 F-042 TodayPage + 4 sections 實作");
+
+    // Mock 所有 Today 頁面需要的 APIs
+    await page.route(`**/api/v1/journal/${TODAY_DATE}`, (route) => {
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ date: TODAY_DATE, content: "Today's journal content", exists: true }),
+      });
+    });
+
+    await page.route(`**/api/v1/calendar/days/${TODAY_DATE}`, (route) => {
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          events: [
+            { id: "ev-1", title: "Standup", start: `${TODAY_DATE}T09:00:00`, end: `${TODAY_DATE}T09:30:00` },
+            { id: "ev-2", title: "Planning", start: `${TODAY_DATE}T14:00:00`, end: `${TODAY_DATE}T15:00:00` },
+          ],
+        }),
+      });
+    });
+
+    await page.route("**/api/v1/tasks*", (route) => {
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          items: [
+            { id: "task-1", title: "Write tests", status: "pending", due_date: TODAY_DATE, priority: "high" },
+            { id: "task-2", title: "Review PR", status: "pending", due_date: TODAY_DATE, priority: "medium" },
+            { id: "task-3", title: "Deploy", status: "pending", due_date: TODAY_DATE, priority: "low" },
+          ],
+        }),
+      });
+    });
+
+    await page.route("**/api/v1/entries*", (route) => {
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          items: [{ id: "entry-1", title: "New finding", status: "inbox", created_at: `${TODAY_DATE}T10:00:00Z` }],
+          total: 1,
+          page: 1,
+          per_page: 5,
+        }),
+      });
+    });
+
+    await page.goto("/today");
+    await page.waitForLoadState("networkidle");
+
+    // THEN 全部 4 個 sections 顯示
+    await expect(page.getByTestId("journal-section")).toBeVisible();
+    await expect(page.getByTestId("calendar-section")).toBeVisible();
+    await expect(page.getByTestId("tasks-section")).toBeVisible();
+    await expect(page.getByTestId("recent-entries-section")).toBeVisible();
+
+    // AND 無全頁 loading spinner
+    await expect(page.getByTestId("page-loading-spinner")).not.toBeVisible();
+  });
+
+  test("TD-2 今日無日記：JournalSection 顯示 'Start today's journal' CTA", async ({ page }) => {
+    test.skip(true, "skeleton：等 F-042 JournalSection empty state + CTA 實作");
+
+    // Journal API 回傳 404（今日尚無日記）
+    await page.route(`**/api/v1/journal/${TODAY_DATE}`, (route) => {
+      route.fulfill({ status: 404, body: JSON.stringify({ error: "not found" }) });
+    });
+
+    await page.route("**/api/v1/tasks*", (route) => {
+      route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify({ items: [] }) });
+    });
+
+    await page.route("**/api/v1/entries*", (route) => {
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ items: [], total: 0, page: 1, per_page: 5 }),
+      });
+    });
+
+    await page.goto("/today");
+    await page.waitForLoadState("networkidle");
+
+    // THEN JournalSection 顯示 CTA
+    await expect(page.getByText(/start today's journal/i)).toBeVisible();
+  });
+
+  test("TD-3 點擊 JournalSection Edit → 導向 /today/journal", async ({ page }) => {
+    test.skip(true, "skeleton：等 F-042 JournalSection Edit 按鈕實作");
+
+    await page.route(`**/api/v1/journal/${TODAY_DATE}`, (route) => {
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ date: TODAY_DATE, content: "Some content", exists: true }),
+      });
+    });
+
+    await page.route("**/api/v1/tasks*", (route) => {
+      route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify({ items: [] }) });
+    });
+
+    await page.route("**/api/v1/entries*", (route) => {
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ items: [], total: 0, page: 1, per_page: 5 }),
+      });
+    });
+
+    await page.goto("/today");
+    await page.waitForLoadState("networkidle");
+
+    // WHEN 點擊 JournalSection "Edit" 按鈕
+    await page.getByTestId("journal-section").getByRole("button", { name: /edit/i }).click();
+
+    // THEN 導向 /today/journal
+    await expect(page).toHaveURL(/\/today\/journal/);
+  });
+
+  // --- Error Handling ---
+
+  test("TD-4 GCal 未連線：CalendarSection 不顯示（不報 error）", async ({ page }) => {
+    test.skip(true, "skeleton：等 F-042 CalendarSection 條件渲染（GCal 整合狀態）實作");
+
+    await page.route(`**/api/v1/journal/${TODAY_DATE}`, (route) => {
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ date: TODAY_DATE, content: "Journal content", exists: true }),
+      });
+    });
+
+    // GCal calendar API 回傳 401（未連線）
+    await page.route(`**/api/v1/calendar/**`, (route) => {
+      route.fulfill({ status: 401, body: JSON.stringify({ error: "gcal_not_connected" }) });
+    });
+
+    await page.route("**/api/v1/tasks*", (route) => {
+      route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify({ items: [] }) });
+    });
+
+    await page.route("**/api/v1/entries*", (route) => {
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ items: [], total: 0, page: 1, per_page: 5 }),
+      });
+    });
+
+    await page.goto("/today");
+    await page.waitForLoadState("networkidle");
+
+    // THEN CalendarSection 不顯示
+    await expect(page.getByTestId("calendar-section")).not.toBeVisible();
+
+    // AND 沒有 error 訊息（靜默隱藏）
+    await expect(page.getByText(/gcal.*error|calendar.*failed/i)).not.toBeVisible();
+  });
+
+  test("TD-5 Tasks API 500：只有 TasksSection 顯示 error，其他 section 正常", async ({ page }) => {
+    test.skip(true, "skeleton：等 F-042 獨立 section error boundary 實作");
+
+    await page.route(`**/api/v1/journal/${TODAY_DATE}`, (route) => {
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ date: TODAY_DATE, content: "Journal content", exists: true }),
+      });
+    });
+
+    await page.route(`**/api/v1/calendar/days/${TODAY_DATE}`, (route) => {
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          events: [{ id: "ev-1", title: "Standup", start: `${TODAY_DATE}T09:00:00`, end: `${TODAY_DATE}T09:30:00` }],
+        }),
+      });
+    });
+
+    // Tasks API 回傳 500
+    await page.route("**/api/v1/tasks*", (route) => {
+      route.fulfill({ status: 500, body: JSON.stringify({ error: "internal server error" }) });
+    });
+
+    await page.route("**/api/v1/entries*", (route) => {
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          items: [{ id: "entry-1", title: "New finding", status: "inbox", created_at: `${TODAY_DATE}T10:00:00Z` }],
+          total: 1,
+          page: 1,
+          per_page: 5,
+        }),
+      });
+    });
+
+    await page.goto("/today");
+    await page.waitForLoadState("networkidle");
+
+    // THEN TasksSection 顯示 error
+    await expect(page.getByTestId("tasks-section")).toContainText(/could not load tasks/i);
+
+    // AND 其他 sections 正常顯示
+    await expect(page.getByTestId("journal-section")).toBeVisible();
+    await expect(page.getByTestId("calendar-section")).toBeVisible();
+    await expect(page.getByTestId("recent-entries-section")).toBeVisible();
+  });
+});

--- a/test/browser/specs/f043_saved_views.spec.ts
+++ b/test/browser/specs/f043_saved_views.spec.ts
@@ -1,0 +1,386 @@
+/**
+ * F-043: Saved Views & Filter Bar
+ *
+ * Spec: specs/features/f043-saved-views-filter-bar.md
+ * Issue: #209
+ * QA Issue: #211
+ *
+ * 涵蓋 Sprint 14 QA scenarios：
+ * - 建立新 Saved View（POST → 出現在 sidebar）
+ * - 套用 Saved View（點擊 → Library URL 更新）
+ * - 刪除 Saved View（DELETE → 從 sidebar 移除）
+ * - 重複名稱時 409 DUPLICATE 錯誤提示
+ * - 超過 50 個 views 時 400 LIMIT_EXCEEDED 提示
+ */
+
+import { test, expect } from "@playwright/test";
+import { loginWithCookie } from "../helpers/cookie-auth";
+
+const FEATURE = "F-043";
+
+test.describe(`[${FEATURE}] Saved Views & Filter Bar`, () => {
+  test.beforeEach(async ({ context }) => {
+    await context.clearCookies();
+    const apiKey = process.env.AIBO_E2E_API_KEY!;
+    await loginWithCookie(context, apiKey);
+  });
+
+  // --- Happy Path ---
+
+  test("SV-1 建立新 Saved View：POST 201 → 新 view 出現於 sidebar", async ({ page }) => {
+    test.skip(true, "skeleton：等 F-043 Save View 對話框 + POST /api/v1/views + sidebar 更新實作");
+
+    // 初始 views 清單（空）
+    await page.route("**/api/v1/views", (route) => {
+      if (route.request().method() === "GET") {
+        route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify([]),
+        });
+      } else if (route.request().method() === "POST") {
+        route.fulfill({
+          status: 201,
+          contentType: "application/json",
+          body: JSON.stringify({
+            id: "view-uuid-1",
+            name: "Go Resources",
+            scope: "library",
+            filters: { category_id: "cat-go", tags: ["golang"] },
+            sort_by: "updated_at",
+            sort_dir: "desc",
+            icon: null,
+            position: 0,
+          }),
+        });
+      } else {
+        route.continue();
+      }
+    });
+
+    await page.route("**/api/v1/entries*", (route) => {
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ items: [], total: 0, page: 1, per_page: 20 }),
+      });
+    });
+
+    await page.goto("/library");
+    await page.waitForLoadState("networkidle");
+
+    // 設定過濾條件（假設已有 category 和 tags 選擇）
+    // WHEN 點擊 "Save View"
+    await page.getByRole("button", { name: /save view/i }).click();
+
+    // 輸入名稱
+    await page.getByRole("dialog").getByRole("textbox", { name: /name/i }).fill("Go Resources");
+    await page.getByRole("dialog").getByRole("button", { name: /save|confirm/i }).click();
+    await page.waitForLoadState("networkidle");
+
+    // THEN "Go Resources" 出現於 sidebar Views 區塊
+    await expect(page.getByTestId("sidebar-views")).toContainText("Go Resources");
+  });
+
+  test("SV-2 套用 Saved View：點擊 sidebar view → Library URL 更新 filter params", async ({
+    page,
+  }) => {
+    test.skip(true, "skeleton：等 F-043 sidebar view click → URL 更新實作");
+
+    const mockView = {
+      id: "view-uuid-1",
+      name: "Go Resources",
+      scope: "library",
+      filters: { tags: ["golang"] },
+      sort_by: "updated_at",
+      sort_dir: "desc",
+      icon: null,
+      position: 0,
+    };
+
+    await page.route("**/api/v1/views", (route) => {
+      if (route.request().method() === "GET") {
+        route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify([mockView]),
+        });
+      } else {
+        route.continue();
+      }
+    });
+
+    let filteredCalled = false;
+    await page.route("**/api/v1/entries*", (route) => {
+      const url = new URL(route.request().url());
+      const tags = url.searchParams.get("tags");
+      if (tags === "golang") {
+        filteredCalled = true;
+        route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify({
+            items: [
+              { id: "e-1", title: "Go Concurrency", tags: ["golang"], status: "library", updated_at: "2026-04-28T10:00:00Z" },
+            ],
+            total: 1,
+            page: 1,
+            per_page: 20,
+          }),
+        });
+      } else {
+        route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify({ items: [], total: 0, page: 1, per_page: 20 }),
+        });
+      }
+    });
+
+    await page.goto("/library");
+    await page.waitForLoadState("networkidle");
+
+    // WHEN 點擊 sidebar 中的 "Go Resources"
+    await page.getByTestId("sidebar-views").getByText("Go Resources").click();
+    await page.waitForLoadState("networkidle");
+
+    // THEN Library URL 更新含對應 filter params
+    expect(page.url()).toContain("tags=golang");
+
+    // AND 列表顯示符合條件的 entries
+    expect(filteredCalled).toBe(true);
+    await expect(page.getByTestId("library-row")).toContainText("Go Concurrency");
+  });
+
+  test("SV-3 刪除 Saved View：DELETE 204 → view 從 sidebar 移除", async ({ page }) => {
+    test.skip(true, "skeleton：等 F-043 view 刪除 UI（... > Delete）+ DELETE /api/v1/views/:id 實作");
+
+    const mockView = {
+      id: "view-uuid-1",
+      name: "Go Resources",
+      scope: "library",
+      filters: {},
+      sort_by: "updated_at",
+      sort_dir: "desc",
+      icon: null,
+      position: 0,
+    };
+
+    let deleteCalled = false;
+    await page.route("**/api/v1/views/view-uuid-1", (route) => {
+      if (route.request().method() === "DELETE") {
+        deleteCalled = true;
+        route.fulfill({ status: 204 });
+      } else {
+        route.continue();
+      }
+    });
+
+    await page.route("**/api/v1/views", (route) => {
+      if (route.request().method() === "GET") {
+        route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify([mockView]),
+        });
+      } else {
+        route.continue();
+      }
+    });
+
+    await page.route("**/api/v1/entries*", (route) => {
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ items: [], total: 0, page: 1, per_page: 20 }),
+      });
+    });
+
+    await page.goto("/library");
+    await page.waitForLoadState("networkidle");
+
+    // 確認 view 存在
+    await expect(page.getByTestId("sidebar-views")).toContainText("Go Resources");
+
+    // WHEN 點擊 view 旁的 "⋯" > Delete
+    await page.getByTestId("sidebar-views").getByText("Go Resources").hover();
+    await page.getByTestId("view-menu-go-resources").click();
+    await page.getByRole("menuitem", { name: /delete/i }).click();
+
+    // 確認刪除對話框
+    await page.getByRole("dialog").getByRole("button", { name: /confirm|delete/i }).click();
+    await page.waitForLoadState("networkidle");
+
+    // THEN view 從 sidebar 移除
+    await expect(page.getByTestId("sidebar-views")).not.toContainText("Go Resources");
+    expect(deleteCalled).toBe(true);
+  });
+
+  // --- Error Handling ---
+
+  test("SV-4 名稱重複：POST 409 DUPLICATE → 顯示錯誤訊息", async ({ page }) => {
+    test.skip(true, "skeleton：等 F-043 重複名稱 409 error 處理實作");
+
+    await page.route("**/api/v1/views", (route) => {
+      if (route.request().method() === "GET") {
+        route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify([
+            { id: "view-uuid-1", name: "Go Resources", scope: "library", filters: {}, position: 0 },
+          ]),
+        });
+      } else if (route.request().method() === "POST") {
+        route.fulfill({
+          status: 409,
+          contentType: "application/json",
+          body: JSON.stringify({ error: "DUPLICATE", message: "A view with this name already exists" }),
+        });
+      } else {
+        route.continue();
+      }
+    });
+
+    await page.route("**/api/v1/entries*", (route) => {
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ items: [], total: 0, page: 1, per_page: 20 }),
+      });
+    });
+
+    await page.goto("/library");
+    await page.waitForLoadState("networkidle");
+
+    // WHEN 嘗試建立同名 view
+    await page.getByRole("button", { name: /save view/i }).click();
+    await page.getByRole("dialog").getByRole("textbox", { name: /name/i }).fill("go resources");
+    await page.getByRole("dialog").getByRole("button", { name: /save|confirm/i }).click();
+    await page.waitForLoadState("networkidle");
+
+    // THEN 顯示 409 錯誤訊息
+    await expect(page.getByRole("dialog")).toContainText(/duplicate|already exists|名稱已存在/i);
+  });
+
+  // --- Edge Cases ---
+
+  test("SV-5 超過 50 個 views：POST 400 LIMIT_EXCEEDED → 顯示提示", async ({ page }) => {
+    test.skip(true, "skeleton：等 F-043 LIMIT_EXCEEDED 400 error 處理實作");
+
+    // 模擬已有 50 個 views
+    const existingViews = Array.from({ length: 50 }, (_, i) => ({
+      id: `view-uuid-${i + 1}`,
+      name: `View ${i + 1}`,
+      scope: "library",
+      filters: {},
+      position: i,
+    }));
+
+    await page.route("**/api/v1/views", (route) => {
+      if (route.request().method() === "GET") {
+        route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify(existingViews),
+        });
+      } else if (route.request().method() === "POST") {
+        route.fulfill({
+          status: 400,
+          contentType: "application/json",
+          body: JSON.stringify({ error: "LIMIT_EXCEEDED", message: "Maximum 50 views allowed" }),
+        });
+      } else {
+        route.continue();
+      }
+    });
+
+    await page.route("**/api/v1/entries*", (route) => {
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ items: [], total: 0, page: 1, per_page: 20 }),
+      });
+    });
+
+    await page.goto("/library");
+    await page.waitForLoadState("networkidle");
+
+    // WHEN 嘗試新增第 51 個 view
+    await page.getByRole("button", { name: /save view/i }).click();
+    await page.getByRole("dialog").getByRole("textbox", { name: /name/i }).fill("View 51");
+    await page.getByRole("dialog").getByRole("button", { name: /save|confirm/i }).click();
+    await page.waitForLoadState("networkidle");
+
+    // THEN 顯示 LIMIT_EXCEEDED 提示
+    await expect(
+      page.getByText(/limit exceeded|maximum.*views|已達上限/i),
+    ).toBeVisible();
+  });
+
+  test("SV-6 拖曳重排 views：PATCH /api/v1/views/reorder 更新 position", async ({ page }) => {
+    test.skip(true, "skeleton：等 F-043 drag-and-drop reorder + PATCH /views/reorder 實作");
+
+    const views = [
+      { id: "view-uuid-1", name: "View Alpha", scope: "library", filters: {}, position: 0 },
+      { id: "view-uuid-2", name: "View Beta", scope: "library", filters: {}, position: 1 },
+      { id: "view-uuid-3", name: "View Gamma", scope: "library", filters: {}, position: 2 },
+    ];
+
+    let reorderCalled = false;
+    let reorderBody: unknown;
+    await page.route("**/api/v1/views/reorder", (route) => {
+      if (route.request().method() === "PATCH") {
+        reorderCalled = true;
+        reorderBody = route.request().postDataJSON();
+        route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify({ updated: 3 }),
+        });
+      } else {
+        route.continue();
+      }
+    });
+
+    await page.route("**/api/v1/views", (route) => {
+      if (route.request().method() === "GET") {
+        route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify(views),
+        });
+      } else {
+        route.continue();
+      }
+    });
+
+    await page.route("**/api/v1/entries*", (route) => {
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ items: [], total: 0, page: 1, per_page: 20 }),
+      });
+    });
+
+    await page.goto("/library");
+    await page.waitForLoadState("networkidle");
+
+    // WHEN 拖曳第一個 view 到第三位
+    const firstView = page.getByTestId("sidebar-view-view-uuid-1");
+    const thirdView = page.getByTestId("sidebar-view-view-uuid-3");
+
+    const firstBox = await firstView.boundingBox();
+    const thirdBox = await thirdView.boundingBox();
+    if (firstBox && thirdBox) {
+      await page.mouse.move(firstBox.x + firstBox.width / 2, firstBox.y + firstBox.height / 2);
+      await page.mouse.down();
+      await page.mouse.move(thirdBox.x + thirdBox.width / 2, thirdBox.y + thirdBox.height / 2, { steps: 10 });
+      await page.mouse.up();
+    }
+
+    await page.waitForLoadState("networkidle");
+
+    // THEN PATCH /api/v1/views/reorder 被呼叫，ids 順序已更新
+    expect(reorderCalled).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

Sprint 14 Playwright browser test skeleton，涵蓋 F-040 ~ F-043 共 27 個 scenarios（全部 `test.skip`，待 engineer PR 合併後解 skip 執行）。

## 測試覆蓋

| Feature | Issue | Scenarios | 測試 ID |
|---------|-------|-----------|--------|
| F-040 Inbox Triage | #206 | 9 | IT-1 ~ IT-9 |
| F-041 Library Table | #207 | 7 | LT-1 ~ LT-7 |
| F-042 Today Dashboard | #208 | 5 | TD-1 ~ TD-5 |
| F-043 Saved Views | #209 | 6 | SV-1 ~ SV-6 |

## 測試策略

- 鍵盤快捷鍵（F-040）：`page.keyboard.press('j')` / `'k'` / `'a'` / `'d'` / `'e'`
- API Mock：`page.route()` 模擬成功 / 500 / 409 / 400 各場景
- 樂觀更新 rollback：先等 DOM 變化後 mock 500，再驗證還原
- URL 同步：`expect(page.url()).toContain('?q=...')` 驗證 URL params
- 獨立 error boundary（F-042）：mock 單一 API 500，確認其他 section 正常

## Test Files

- `test/browser/specs/f040_inbox_triage.spec.ts`
- `test/browser/specs/f041_library_table.spec.ts`
- `test/browser/specs/f042_today_dashboard.spec.ts`
- `test/browser/specs/f043_saved_views.spec.ts`

待 engineer PR 合併後解 skip 執行完整測試。

Closes #211