### PR TITLE
feat(frontend): F-042 Today Dashboard

### DIFF
--- a/dev/frontend/__tests__/lib/hooks/use-today-date.test.ts
+++ b/dev/frontend/__tests__/lib/hooks/use-today-date.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it, vi, beforeAll, afterAll } from "vitest";
+import { renderHook } from "@testing-library/react";
+import { useTodayDate } from "@/lib/hooks/use-today-date";
+
+describe("useTodayDate", () => {
+  it("回傳 YYYY-MM-DD 格式的今日日期", () => {
+    const { result } = renderHook(() => useTodayDate());
+    const { today } = result.current;
+    // 驗證格式：YYYY-MM-DD
+    expect(today).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+  });
+
+  it("回傳的 today 是有效日期", () => {
+    const { result } = renderHook(() => useTodayDate());
+    const { today } = result.current;
+    const date = new Date(today + "T12:00:00");
+    expect(isNaN(date.getTime())).toBe(false);
+  });
+
+  it("回傳的 todayStart 是 ISO 字串", () => {
+    const { result } = renderHook(() => useTodayDate());
+    const { todayStart } = result.current;
+    // ISO UTC string: 2024-01-01T16:00:00.000Z（Asia/Taipei +8 → UTC）
+    expect(todayStart).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/);
+  });
+
+  it("todayStart 對應 Asia/Taipei 當日 00:00（UTC+8 即 UTC -8h）", () => {
+    const { result } = renderHook(() => useTodayDate());
+    const { today, todayStart } = result.current;
+
+    // Asia/Taipei 當日 00:00 = UTC 前一天 16:00
+    const startDate = new Date(todayStart);
+    // todayStart 的時間部分應該是 16:00:00 UTC（若當日未跨日）
+    expect(startDate.getUTCHours()).toBe(16);
+    expect(startDate.getUTCMinutes()).toBe(0);
+    expect(startDate.getUTCSeconds()).toBe(0);
+
+    // todayStart 的 UTC 日期 = today 的前一天（因為 UTC+8 午夜對應 UTC -8h）
+    const utcDate = startDate.toISOString().split("T")[0];
+    const dayBefore = new Date(today + "T12:00:00");
+    dayBefore.setDate(dayBefore.getDate() - 1);
+    const expectedUtcDate = dayBefore.toISOString().split("T")[0];
+    expect(utcDate).toBe(expectedUtcDate);
+  });
+
+  it("多次呼叫回傳相同結果（useMemo 穩定性）", () => {
+    const { result, rerender } = renderHook(() => useTodayDate());
+    const first = result.current;
+    rerender();
+    const second = result.current;
+    // 相同 render cycle 內應回傳相同的 today / todayStart
+    expect(first.today).toBe(second.today);
+    expect(first.todayStart).toBe(second.todayStart);
+  });
+});

--- a/dev/frontend/__tests__/today/TodayPage.test.tsx
+++ b/dev/frontend/__tests__/today/TodayPage.test.tsx
@@ -1,0 +1,340 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import type { ReactNode } from "react";
+
+// Mock next/navigation
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: vi.fn(), replace: vi.fn() }),
+  usePathname: () => "/today",
+}));
+
+// Mock API modules
+vi.mock("@/lib/api/journal", () => ({
+  getJournal: vi.fn(),
+}));
+vi.mock("@/lib/api/today", () => ({
+  listTodayTasks: vi.fn(),
+  listTodayEntries: vi.fn(),
+}));
+vi.mock("@/lib/api/gcal-settings", () => ({
+  getGcalStatus: vi.fn(),
+}));
+vi.mock("@/lib/api/calendar-day", () => ({
+  fetchCalendarDay: vi.fn(),
+}));
+
+import { getJournal } from "@/lib/api/journal";
+import { listTodayTasks, listTodayEntries } from "@/lib/api/today";
+import { getGcalStatus } from "@/lib/api/gcal-settings";
+import { fetchCalendarDay } from "@/lib/api/calendar-day";
+import { ApiError } from "@/lib/api/client";
+
+function makeWrapper() {
+  const qc = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+    },
+  });
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return <QueryClientProvider client={qc}>{children}</QueryClientProvider>;
+  };
+}
+
+// 懶載 Section 元件（避免 page.tsx 的 useTodayDate hook 在測試中出問題）
+import { JournalSection } from "@/components/today/JournalSection";
+import { TasksSection } from "@/components/today/TasksSection";
+import { RecentEntriesSection } from "@/components/today/RecentEntriesSection";
+import { CalendarSection } from "@/components/today/CalendarSection";
+import { SectionErrorBoundary } from "@/components/today/SectionErrorBoundary";
+
+const TODAY = "2026-04-28";
+const TODAY_START = "2026-04-27T16:00:00.000Z";
+
+describe("JournalSection", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("Scenario: 今日日記存在時顯示預覽和 Edit 按鈕", async () => {
+    vi.mocked(getJournal).mockResolvedValue({
+      id: "j1",
+      date: TODAY,
+      title: "今日隨筆",
+      content: "今天天氣很好，完成了許多工作。",
+      mood: "great",
+      highlights: [],
+      is_draft: false,
+      generated_by: null,
+      llm_provider_id: null,
+      source_refs: [],
+      created_at: `${TODAY}T10:00:00Z`,
+      updated_at: `${TODAY}T10:00:00Z`,
+    });
+
+    render(<JournalSection today={TODAY} />, { wrapper: makeWrapper() });
+
+    await waitFor(() => {
+      expect(screen.getByTestId("journal-preview")).toBeInTheDocument();
+    });
+    expect(screen.getByText("今日隨筆")).toBeInTheDocument();
+    expect(screen.getByTestId("journal-edit-btn")).toBeInTheDocument();
+  });
+
+  it("Scenario: 今日無日記時顯示 CTA", async () => {
+    vi.mocked(getJournal).mockRejectedValue(
+      new ApiError("Not Found", 404, null),
+    );
+
+    render(<JournalSection today={TODAY} />, { wrapper: makeWrapper() });
+
+    await waitFor(() => {
+      expect(screen.getByTestId("journal-cta")).toBeInTheDocument();
+    });
+    expect(screen.getByText(/Start today's journal/i)).toBeInTheDocument();
+  });
+
+  it("Scenario: Journal API 失敗顯示 error state", async () => {
+    vi.mocked(getJournal).mockRejectedValue(new Error("Server Error"));
+
+    render(<JournalSection today={TODAY} />, { wrapper: makeWrapper() });
+
+    await waitFor(() => {
+      expect(screen.getByTestId("journal-error")).toBeInTheDocument();
+    });
+    expect(screen.getByText(/Could not load journal/i)).toBeInTheDocument();
+  });
+});
+
+describe("TasksSection", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("Scenario: 顯示今日待辦 tasks", async () => {
+    vi.mocked(listTodayTasks).mockResolvedValue({
+      data: [
+        {
+          id: "t1",
+          project_id: "p1",
+          title: "寫完 PR",
+          description: null,
+          status: "pending",
+          priority: "high",
+          due_date: TODAY,
+          position: 0,
+          created_at: `${TODAY}T09:00:00Z`,
+          updated_at: `${TODAY}T09:00:00Z`,
+          completed_at: null,
+        },
+        {
+          id: "t2",
+          project_id: "p1",
+          title: "Review code",
+          description: null,
+          status: "pending",
+          priority: "medium",
+          due_date: TODAY,
+          position: 1,
+          created_at: `${TODAY}T09:00:00Z`,
+          updated_at: `${TODAY}T09:00:00Z`,
+          completed_at: null,
+        },
+      ],
+    });
+
+    render(<TasksSection today={TODAY} />, { wrapper: makeWrapper() });
+
+    await waitFor(() => {
+      expect(screen.getByTestId("tasks-list")).toBeInTheDocument();
+    });
+    const items = screen.getAllByTestId("task-item");
+    expect(items).toHaveLength(2);
+    expect(screen.getByText("寫完 PR")).toBeInTheDocument();
+  });
+
+  it("Scenario: Tasks API 失敗顯示 error，不影響其他 section", async () => {
+    vi.mocked(listTodayTasks).mockRejectedValue(
+      new Error("Internal Server Error"),
+    );
+
+    render(<TasksSection today={TODAY} />, { wrapper: makeWrapper() });
+
+    await waitFor(() => {
+      expect(screen.getByTestId("tasks-error")).toBeInTheDocument();
+    });
+    expect(screen.getByText(/Could not load tasks/i)).toBeInTheDocument();
+  });
+
+  it("Scenario: 沒有今日 tasks 時顯示空狀態", async () => {
+    vi.mocked(listTodayTasks).mockResolvedValue({ data: [] });
+
+    render(<TasksSection today={TODAY} />, { wrapper: makeWrapper() });
+
+    await waitFor(() => {
+      expect(screen.getByTestId("tasks-empty")).toBeInTheDocument();
+    });
+  });
+});
+
+describe("RecentEntriesSection", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("Scenario: 顯示今日更新的 entries", async () => {
+    vi.mocked(listTodayEntries).mockResolvedValue({
+      data: [
+        {
+          id: "e1",
+          title: "Golang 設計模式",
+          content_preview: "使用 interface 達成 DI",
+          category_id: null,
+          domains: [],
+          tags: [],
+          is_archived: false,
+          confidence: 0.9,
+          confirmations: 1,
+          flags_count: 0,
+          lifecycle_status: "active",
+          source_type: null,
+          created_at: `${TODAY}T10:00:00Z`,
+          updated_at: `${TODAY}T10:00:00Z`,
+        },
+      ],
+      pagination: { page: 1, per_page: 5, total: 1, total_pages: 1 },
+    });
+
+    render(<RecentEntriesSection todayStart={TODAY_START} />, {
+      wrapper: makeWrapper(),
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId("entries-list")).toBeInTheDocument();
+    });
+    expect(screen.getByText("Golang 設計模式")).toBeInTheDocument();
+  });
+
+  it("Scenario: Entries API 失敗顯示 error", async () => {
+    vi.mocked(listTodayEntries).mockRejectedValue(new Error("Network Error"));
+
+    render(<RecentEntriesSection todayStart={TODAY_START} />, {
+      wrapper: makeWrapper(),
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId("entries-error")).toBeInTheDocument();
+    });
+  });
+});
+
+describe("CalendarSection", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("Scenario: GCal 未連線時不顯示 CalendarSection", async () => {
+    vi.mocked(getGcalStatus).mockResolvedValue({
+      connected: false,
+      email: null,
+    });
+
+    const { container } = render(<CalendarSection today={TODAY} />, {
+      wrapper: makeWrapper(),
+    });
+
+    await waitFor(() => {
+      // gcal status 已回傳 false
+      expect(vi.mocked(getGcalStatus)).toHaveBeenCalled();
+    });
+
+    // CalendarSection 應該 return null，容器為空
+    await waitFor(() => {
+      expect(container.firstChild).toBeNull();
+    });
+  });
+
+  it("Scenario: GCal 已連線時顯示今日事件", async () => {
+    vi.mocked(getGcalStatus).mockResolvedValue({ connected: true });
+    vi.mocked(fetchCalendarDay).mockResolvedValue({
+      data: {
+        date: TODAY,
+        events: [
+          {
+            id: "ev1",
+            gcal_id: "gcal-ev1",
+            title: "週會",
+            start_time: `${TODAY}T09:00:00+08:00`,
+            end_time: `${TODAY}T10:00:00+08:00`,
+            all_day: false,
+            location: null,
+            calendar_id: "primary",
+          } as any,
+        ],
+        entries: [],
+        journal: null,
+        gcal_connected: true,
+        degraded: false,
+      },
+      degradedHeader: null,
+    });
+
+    render(<CalendarSection today={TODAY} />, { wrapper: makeWrapper() });
+
+    await waitFor(() => {
+      expect(screen.getByTestId("calendar-events")).toBeInTheDocument();
+    });
+    expect(screen.getByText("週會")).toBeInTheDocument();
+  });
+});
+
+describe("SectionErrorBoundary", () => {
+  it("catch render error 並顯示 error 訊息", () => {
+    const ThrowError = () => {
+      throw new Error("Render crash");
+    };
+
+    // Suppress console.error for this test
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    render(
+      <SectionErrorBoundary sectionName="tasks">
+        <ThrowError />
+      </SectionErrorBoundary>,
+    );
+
+    expect(
+      screen.getByTestId("section-error-tasks"),
+    ).toBeInTheDocument();
+    expect(screen.getByText(/Could not load tasks/i)).toBeInTheDocument();
+
+    consoleError.mockRestore();
+  });
+
+  it("不影響其他 section：一個 boundary crash 不擴散", () => {
+    const ThrowError = () => {
+      throw new Error("Crash");
+    };
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    render(
+      <div>
+        <SectionErrorBoundary sectionName="journal">
+          <div data-testid="journal-ok">Journal OK</div>
+        </SectionErrorBoundary>
+        <SectionErrorBoundary sectionName="tasks">
+          <ThrowError />
+        </SectionErrorBoundary>
+        <SectionErrorBoundary sectionName="entries">
+          <div data-testid="entries-ok">Entries OK</div>
+        </SectionErrorBoundary>
+      </div>,
+    );
+
+    expect(screen.getByTestId("journal-ok")).toBeInTheDocument();
+    expect(screen.getByTestId("section-error-tasks")).toBeInTheDocument();
+    expect(screen.getByTestId("entries-ok")).toBeInTheDocument();
+
+    consoleError.mockRestore();
+  });
+});

--- a/dev/frontend/app/(shell)/dashboard/@today/page.tsx
+++ b/dev/frontend/app/(shell)/dashboard/@today/page.tsx
@@ -1,17 +1,46 @@
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
-import { Sun } from "lucide-react";
+"use client";
 
-export default async function TodaySlot() {
+import Link from "next/link";
+import { Sun, ChevronRight } from "lucide-react";
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { useTodayDate } from "@/lib/hooks/use-today-date";
+
+/**
+ * Dashboard @today slot — 精簡預覽，連結至完整 Today Dashboard（/today）。
+ * F-042 Sprint 14
+ */
+export default function TodaySlot() {
+  const { today } = useTodayDate();
+
+  const displayDate = new Intl.DateTimeFormat("zh-TW", {
+    month: "long",
+    day: "numeric",
+    weekday: "short",
+    timeZone: "Asia/Taipei",
+  }).format(new Date(`${today}T12:00:00`));
+
   return (
     <Card data-testid="slot-today">
       <CardHeader className="pb-2">
         <CardTitle className="flex items-center gap-2 text-sm font-medium">
-          <Sun className="h-4 w-4" />
+          <Sun className="h-4 w-4 text-amber-500" />
           Today
         </CardTitle>
       </CardHeader>
-      <CardContent>
-        <p className="text-xs text-muted-foreground">Today preview — F-042 Sprint 14</p>
+      <CardContent className="space-y-3">
+        <p className="text-xs text-muted-foreground">{displayDate}</p>
+        <Button asChild variant="ghost" size="sm" className="w-full justify-between">
+          <Link href="/today">
+            開啟 Today Dashboard
+            <ChevronRight className="h-4 w-4" />
+          </Link>
+        </Button>
       </CardContent>
     </Card>
   );

--- a/dev/frontend/app/(shell)/today/page.tsx
+++ b/dev/frontend/app/(shell)/today/page.tsx
@@ -1,0 +1,60 @@
+"use client";
+
+import { Suspense } from "react";
+import { useTodayDate } from "@/lib/hooks/use-today-date";
+import { TodayHeader } from "@/components/today/TodayHeader";
+import { JournalSection } from "@/components/today/JournalSection";
+import { CalendarSection } from "@/components/today/CalendarSection";
+import { TasksSection } from "@/components/today/TasksSection";
+import { RecentEntriesSection } from "@/components/today/RecentEntriesSection";
+import { SectionSkeleton } from "@/components/today/SectionSkeleton";
+import { SectionErrorBoundary } from "@/components/today/SectionErrorBoundary";
+
+/**
+ * F-042 Today Dashboard
+ *
+ * 4 個獨立 section，各自包裹 SectionErrorBoundary + Suspense：
+ *   - JournalSection：今日日記（含 CreateJournalCTA）
+ *   - CalendarSection：今日 gcal 事件（GCal 未連線時不顯示）
+ *   - TasksSection：今日 due tasks（status=pending）
+ *   - RecentEntriesSection：今日更新 entries（最多 5 筆）
+ */
+export default function TodayPage() {
+  const { today, todayStart } = useTodayDate();
+
+  return (
+    <div className="space-y-6 p-6" data-testid="today-page">
+      <TodayHeader today={today} />
+
+      <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+        {/* Journal Section */}
+        <SectionErrorBoundary sectionName="journal">
+          <Suspense fallback={<SectionSkeleton title="今日日記" rows={2} />}>
+            <JournalSection today={today} />
+          </Suspense>
+        </SectionErrorBoundary>
+
+        {/* Calendar Section（GCal 未連線時自動隱藏，非 error） */}
+        <SectionErrorBoundary sectionName="calendar">
+          <Suspense fallback={<SectionSkeleton title="今日行程" rows={3} />}>
+            <CalendarSection today={today} />
+          </Suspense>
+        </SectionErrorBoundary>
+
+        {/* Tasks Section */}
+        <SectionErrorBoundary sectionName="tasks">
+          <Suspense fallback={<SectionSkeleton title="今日待辦" rows={3} />}>
+            <TasksSection today={today} />
+          </Suspense>
+        </SectionErrorBoundary>
+
+        {/* Recent Entries Section */}
+        <SectionErrorBoundary sectionName="entries">
+          <Suspense fallback={<SectionSkeleton title="今日 Entries" rows={3} />}>
+            <RecentEntriesSection todayStart={todayStart} />
+          </Suspense>
+        </SectionErrorBoundary>
+      </div>
+    </div>
+  );
+}

--- a/dev/frontend/components/today/CalendarSection.tsx
+++ b/dev/frontend/components/today/CalendarSection.tsx
@@ -1,0 +1,123 @@
+"use client";
+
+import { useQuery } from "@tanstack/react-query";
+import { Calendar, AlertCircle, Clock } from "lucide-react";
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { fetchCalendarDay } from "@/lib/api/calendar-day";
+import { getGcalStatus } from "@/lib/api/gcal-settings";
+import type { CalendarEventSummary } from "@/lib/api/calendar";
+
+interface CalendarSectionProps {
+  today: string; // YYYY-MM-DD
+}
+
+function formatEventTime(event: CalendarEventSummary): string {
+  if (event.all_day) return "全天";
+  const start = new Date(event.start_time);
+  const end = new Date(event.end_time);
+  const fmt = (d: Date) =>
+    d.toLocaleTimeString("zh-TW", {
+      hour: "2-digit",
+      minute: "2-digit",
+      hour12: false,
+      timeZone: "Asia/Taipei",
+    });
+  return `${fmt(start)} – ${fmt(end)}`;
+}
+
+export function CalendarSection({ today }: CalendarSectionProps) {
+  // 先查 gcal 連線狀態
+  const { data: gcalStatus, isLoading: gcalLoading } = useQuery({
+    queryKey: ["gcal", "status"],
+    queryFn: () => getGcalStatus(),
+    staleTime: 60_000,
+  });
+
+  const gcalConnected = gcalStatus?.connected === true;
+
+  // 只有 gcal 連線後才抓事件
+  const {
+    data: dayResult,
+    isLoading: dayLoading,
+    error: dayError,
+  } = useQuery({
+    queryKey: ["calendar-day", today],
+    queryFn: () =>
+      fetchCalendarDay(today, "Asia/Taipei", { includeGcal: true }),
+    enabled: gcalConnected,
+    staleTime: 60_000,
+  });
+
+  // GCal 未連線：直接不顯示（條件渲染，非 error）
+  if (!gcalLoading && !gcalConnected) {
+    return null;
+  }
+
+  const isLoading = gcalLoading || (gcalConnected && dayLoading);
+  const events = dayResult?.data?.events ?? [];
+
+  return (
+    <Card data-testid="calendar-section">
+      <CardHeader className="pb-3">
+        <CardTitle className="flex items-center gap-2 text-sm font-medium">
+          <Calendar className="h-4 w-4" />
+          今日行程
+        </CardTitle>
+      </CardHeader>
+      <CardContent>
+        {isLoading && (
+          <div
+            className="text-xs text-muted-foreground animate-pulse"
+            data-testid="calendar-loading"
+          >
+            載入中…
+          </div>
+        )}
+
+        {dayError && !isLoading && (
+          <div
+            className="flex items-center gap-2 text-xs text-destructive"
+            data-testid="calendar-error"
+          >
+            <AlertCircle className="h-4 w-4" />
+            <span>Could not load calendar</span>
+          </div>
+        )}
+
+        {!isLoading && !dayError && events.length === 0 && (
+          <p
+            className="text-xs text-muted-foreground"
+            data-testid="calendar-empty"
+          >
+            今天沒有行程
+          </p>
+        )}
+
+        {!isLoading && !dayError && events.length > 0 && (
+          <ul className="space-y-2" data-testid="calendar-events">
+            {events.map((event) => (
+              <li
+                key={event.id}
+                className="flex items-start gap-2 text-sm"
+                data-testid="calendar-event-item"
+              >
+                <Clock className="h-3.5 w-3.5 mt-0.5 shrink-0 text-muted-foreground" />
+                <div className="min-w-0">
+                  <p className="font-medium truncate">{event.title}</p>
+                  <p className="text-xs text-muted-foreground">
+                    {formatEventTime(event)}
+                  </p>
+                </div>
+              </li>
+            ))}
+          </ul>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/dev/frontend/components/today/JournalSection.tsx
+++ b/dev/frontend/components/today/JournalSection.tsx
@@ -1,0 +1,106 @@
+"use client";
+
+import { useQuery } from "@tanstack/react-query";
+import { BookOpen, Edit, PenLine, AlertCircle } from "lucide-react";
+import Link from "next/link";
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { getJournal } from "@/lib/api/journal";
+import { ApiError } from "@/lib/api/client";
+
+interface JournalSectionProps {
+  today: string; // YYYY-MM-DD
+}
+
+export function JournalSection({ today }: JournalSectionProps) {
+  const { data: journal, isLoading, error } = useQuery({
+    queryKey: ["journal", today],
+    queryFn: () => getJournal(today),
+    retry: (failureCount, err) => {
+      // 404 = 今日尚無日記，是正常狀態
+      if (err instanceof ApiError && err.status === 404) return false;
+      return failureCount < 2;
+    },
+  });
+
+  const is404 = error instanceof ApiError && error.status === 404;
+  const isOtherError = error && !is404;
+
+  return (
+    <Card data-testid="journal-section">
+      <CardHeader className="pb-3">
+        <CardTitle className="flex items-center gap-2 text-sm font-medium">
+          <BookOpen className="h-4 w-4" />
+          今日日記
+        </CardTitle>
+      </CardHeader>
+      <CardContent>
+        {isLoading && (
+          <div className="text-xs text-muted-foreground animate-pulse" data-testid="journal-loading">
+            載入中…
+          </div>
+        )}
+
+        {isOtherError && (
+          <div
+            className="flex items-center gap-2 text-xs text-destructive"
+            data-testid="journal-error"
+          >
+            <AlertCircle className="h-4 w-4" />
+            <span>Could not load journal</span>
+          </div>
+        )}
+
+        {(is404 || (!isLoading && !error && !journal)) && (
+          <div
+            className="flex flex-col gap-3 text-center py-2"
+            data-testid="journal-cta"
+          >
+            <p className="text-sm text-muted-foreground">今天還沒有日記</p>
+            <Button asChild size="sm" variant="outline" className="gap-2 w-full">
+              <Link href="/today/journal">
+                <PenLine className="h-4 w-4" />
+                Start today&apos;s journal
+              </Link>
+            </Button>
+          </div>
+        )}
+
+        {journal && !isLoading && (
+          <div className="space-y-3" data-testid="journal-preview">
+            {journal.title && (
+              <p className="font-medium text-sm">{journal.title}</p>
+            )}
+            {journal.content && (
+              <p className="text-xs text-muted-foreground line-clamp-3">
+                {journal.content}
+              </p>
+            )}
+            {journal.mood && (
+              <p className="text-xs text-muted-foreground">
+                心情：{journal.mood}
+              </p>
+            )}
+            <Button
+              asChild
+              size="sm"
+              variant="outline"
+              className="gap-2 w-full"
+              data-testid="journal-edit-btn"
+            >
+              <Link href="/today/journal">
+                <Edit className="h-4 w-4" />
+                Edit
+              </Link>
+            </Button>
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/dev/frontend/components/today/RecentEntriesSection.tsx
+++ b/dev/frontend/components/today/RecentEntriesSection.tsx
@@ -1,0 +1,94 @@
+"use client";
+
+import { useQuery } from "@tanstack/react-query";
+import { Library, AlertCircle, FileText } from "lucide-react";
+import Link from "next/link";
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { listTodayEntries } from "@/lib/api/today";
+import type { EntryListItem } from "@/lib/api/today";
+
+interface RecentEntriesSectionProps {
+  todayStart: string; // ISO UTC string of today 00:00 Asia/Taipei
+}
+
+export function RecentEntriesSection({
+  todayStart,
+}: RecentEntriesSectionProps) {
+  const { data, isLoading, error } = useQuery({
+    queryKey: ["today-entries", todayStart],
+    queryFn: () => listTodayEntries(todayStart),
+    retry: 1,
+  });
+
+  const entries: EntryListItem[] = data?.data ?? [];
+
+  return (
+    <Card data-testid="recent-entries-section">
+      <CardHeader className="pb-3">
+        <CardTitle className="flex items-center gap-2 text-sm font-medium">
+          <Library className="h-4 w-4" />
+          今日 Entries
+        </CardTitle>
+      </CardHeader>
+      <CardContent>
+        {isLoading && (
+          <div
+            className="text-xs text-muted-foreground animate-pulse"
+            data-testid="entries-loading"
+          >
+            載入中…
+          </div>
+        )}
+
+        {error && !isLoading && (
+          <div
+            className="flex items-center gap-2 text-xs text-destructive"
+            data-testid="entries-error"
+          >
+            <AlertCircle className="h-4 w-4" />
+            <span>Could not load entries</span>
+          </div>
+        )}
+
+        {!isLoading && !error && entries.length === 0 && (
+          <p
+            className="text-xs text-muted-foreground"
+            data-testid="entries-empty"
+          >
+            今天還沒有更新的 entries
+          </p>
+        )}
+
+        {!isLoading && !error && entries.length > 0 && (
+          <ul className="space-y-2" data-testid="entries-list">
+            {entries.map((entry) => (
+              <li key={entry.id} data-testid="entry-item">
+                <Link
+                  href={`/entries/${entry.id}`}
+                  className="flex items-start gap-2 text-sm hover:text-foreground/80 transition-colors"
+                >
+                  <FileText className="h-3.5 w-3.5 mt-0.5 shrink-0 text-muted-foreground" />
+                  <div className="min-w-0">
+                    <p className="truncate font-medium">
+                      {entry.title || entry.content_preview || "（無標題）"}
+                    </p>
+                    {entry.content_preview && entry.title && (
+                      <p className="text-xs text-muted-foreground line-clamp-1">
+                        {entry.content_preview}
+                      </p>
+                    )}
+                  </div>
+                </Link>
+              </li>
+            ))}
+          </ul>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/dev/frontend/components/today/SectionErrorBoundary.tsx
+++ b/dev/frontend/components/today/SectionErrorBoundary.tsx
@@ -1,0 +1,50 @@
+"use client";
+
+import { Component, type ReactNode } from "react";
+import { AlertCircle } from "lucide-react";
+import { Card, CardContent } from "@/components/ui/card";
+
+interface Props {
+  children: ReactNode;
+  sectionName: string;
+}
+
+interface State {
+  hasError: boolean;
+  errorMessage: string | null;
+}
+
+/**
+ * 各 Today section 獨立 error boundary。
+ * 單一 section 的 render error 不會影響其他 section。
+ */
+export class SectionErrorBoundary extends Component<Props, State> {
+  constructor(props: Props) {
+    super(props);
+    this.state = { hasError: false, errorMessage: null };
+  }
+
+  static getDerivedStateFromError(error: unknown): State {
+    const message =
+      error instanceof Error ? error.message : "Unknown error";
+    return { hasError: true, errorMessage: message };
+  }
+
+  override render() {
+    if (this.state.hasError) {
+      return (
+        <Card
+          className="border-destructive/40"
+          data-testid={`section-error-${this.props.sectionName}`}
+        >
+          <CardContent className="flex items-center gap-2 p-4 text-sm text-destructive">
+            <AlertCircle className="h-4 w-4 shrink-0" />
+            <span>Could not load {this.props.sectionName}</span>
+          </CardContent>
+        </Card>
+      );
+    }
+
+    return this.props.children;
+  }
+}

--- a/dev/frontend/components/today/SectionSkeleton.tsx
+++ b/dev/frontend/components/today/SectionSkeleton.tsx
@@ -1,0 +1,25 @@
+import { Card, CardContent, CardHeader } from "@/components/ui/card";
+import { Skeleton } from "@/components/ui/skeleton";
+
+interface SectionSkeletonProps {
+  title?: string;
+  rows?: number;
+}
+
+export function SectionSkeleton({ title, rows = 3 }: SectionSkeletonProps) {
+  return (
+    <Card data-testid="section-skeleton">
+      <CardHeader className="pb-3">
+        <div className="flex items-center gap-2">
+          <Skeleton className="h-4 w-4 rounded" />
+          <Skeleton className="h-4 w-24" />
+        </div>
+      </CardHeader>
+      <CardContent className="space-y-2">
+        {Array.from({ length: rows }).map((_, i) => (
+          <Skeleton key={i} className="h-10 w-full" />
+        ))}
+      </CardContent>
+    </Card>
+  );
+}

--- a/dev/frontend/components/today/TasksSection.tsx
+++ b/dev/frontend/components/today/TasksSection.tsx
@@ -1,0 +1,113 @@
+"use client";
+
+import { useQuery } from "@tanstack/react-query";
+import { CheckSquare, AlertCircle, Circle } from "lucide-react";
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { listTodayTasks } from "@/lib/api/today";
+import type { TodayTask } from "@/lib/api/today";
+
+interface TasksSectionProps {
+  today: string; // YYYY-MM-DD
+}
+
+const PRIORITY_LABEL: Record<string, string> = {
+  urgent: "緊急",
+  high: "高",
+  medium: "中",
+  low: "低",
+};
+
+const PRIORITY_COLOR: Record<
+  string,
+  "destructive" | "default" | "secondary" | "outline"
+> = {
+  urgent: "destructive",
+  high: "default",
+  medium: "secondary",
+  low: "outline",
+};
+
+export function TasksSection({ today }: TasksSectionProps) {
+  const { data, isLoading, error } = useQuery({
+    queryKey: ["today-tasks", today],
+    queryFn: () => listTodayTasks(today),
+  });
+
+  const tasks: TodayTask[] = data?.data ?? [];
+
+  return (
+    <Card data-testid="tasks-section">
+      <CardHeader className="pb-3">
+        <CardTitle className="flex items-center gap-2 text-sm font-medium">
+          <CheckSquare className="h-4 w-4" />
+          今日待辦
+          {tasks.length > 0 && (
+            <span className="ml-auto text-xs font-normal text-muted-foreground">
+              {tasks.length} 項
+            </span>
+          )}
+        </CardTitle>
+      </CardHeader>
+      <CardContent>
+        {isLoading && (
+          <div
+            className="text-xs text-muted-foreground animate-pulse"
+            data-testid="tasks-loading"
+          >
+            載入中…
+          </div>
+        )}
+
+        {error && !isLoading && (
+          <div
+            className="flex items-center gap-2 text-xs text-destructive"
+            data-testid="tasks-error"
+          >
+            <AlertCircle className="h-4 w-4" />
+            <span>Could not load tasks</span>
+          </div>
+        )}
+
+        {!isLoading && !error && tasks.length === 0 && (
+          <p
+            className="text-xs text-muted-foreground"
+            data-testid="tasks-empty"
+          >
+            今天沒有待辦事項
+          </p>
+        )}
+
+        {!isLoading && !error && tasks.length > 0 && (
+          <ul className="space-y-2" data-testid="tasks-list">
+            {tasks.map((task) => (
+              <li
+                key={task.id}
+                className="flex items-start gap-2 text-sm"
+                data-testid="task-item"
+              >
+                <Circle className="h-3.5 w-3.5 mt-0.5 shrink-0 text-muted-foreground" />
+                <div className="min-w-0 flex-1">
+                  <p className="truncate">{task.title}</p>
+                </div>
+                {task.priority && task.priority !== "medium" && (
+                  <Badge
+                    variant={PRIORITY_COLOR[task.priority] ?? "outline"}
+                    className="text-xs shrink-0"
+                  >
+                    {PRIORITY_LABEL[task.priority] ?? task.priority}
+                  </Badge>
+                )}
+              </li>
+            ))}
+          </ul>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/dev/frontend/components/today/TodayHeader.tsx
+++ b/dev/frontend/components/today/TodayHeader.tsx
@@ -1,0 +1,43 @@
+"use client";
+
+import { Sun } from "lucide-react";
+
+interface TodayHeaderProps {
+  today: string; // YYYY-MM-DD
+}
+
+function formatDisplayDate(dateStr: string): string {
+  const date = new Date(`${dateStr}T12:00:00`);
+  return new Intl.DateTimeFormat("zh-TW", {
+    year: "numeric",
+    month: "long",
+    day: "numeric",
+    weekday: "long",
+    timeZone: "Asia/Taipei",
+  }).format(date);
+}
+
+function getGreeting(): string {
+  const hour = new Date().getHours();
+  if (hour < 12) return "早安";
+  if (hour < 18) return "午安";
+  return "晚安";
+}
+
+export function TodayHeader({ today }: TodayHeaderProps) {
+  const displayDate = formatDisplayDate(today);
+  const greeting = getGreeting();
+
+  return (
+    <div
+      className="flex items-center gap-3 pb-6"
+      data-testid="today-header"
+    >
+      <Sun className="h-6 w-6 text-amber-500 shrink-0" />
+      <div>
+        <h1 className="text-2xl font-bold tracking-tight">{greeting}</h1>
+        <p className="text-sm text-muted-foreground mt-0.5">{displayDate}</p>
+      </div>
+    </div>
+  );
+}

--- a/dev/frontend/lib/api/today.ts
+++ b/dev/frontend/lib/api/today.ts
@@ -1,0 +1,91 @@
+/**
+ * Today Dashboard API helpers（F-042）。
+ *
+ * 全部使用現有 endpoints，無新後端 API：
+ *   - GET /api/v1/journal/:date           → today's journal
+ *   - GET /api/v1/calendar/days/:date     → today's calendar events
+ *   - GET /api/v1/tasks                   → today's pending tasks
+ *   - GET /api/v1/entries                 → today's recent entries
+ *   - GET /api/v1/integrations/gcal/status → gcal connection status
+ */
+
+import { apiClient } from "./client";
+import type { JournalEntry } from "./journal";
+import type { EntryListItem, ListEntriesResponse } from "./entries";
+import type { GcalStatus } from "./gcal-settings";
+
+export type { JournalEntry, EntryListItem, ListEntriesResponse, GcalStatus };
+
+export interface TodayTask {
+  id: string;
+  project_id: string;
+  title: string;
+  description: string | null;
+  status: string;
+  priority: string;
+  due_date: string | null;
+  position: number;
+  created_at: string;
+  updated_at: string;
+  completed_at: string | null;
+}
+
+export interface TodayTasksResponse {
+  data: TodayTask[];
+}
+
+export interface TodayCalendarEvent {
+  id: string;
+  gcal_id: string;
+  title: string;
+  start_time: string;
+  end_time: string;
+  all_day: boolean;
+  location?: string | null;
+  description?: string | null;
+  calendar_id: string;
+}
+
+export interface TodayCalendarResponse {
+  date: string;
+  events: TodayCalendarEvent[];
+  gcal_connected: boolean;
+}
+
+/**
+ * 取得今日待辦（status=pending, due_date=today）。
+ * 後端 GET /api/v1/tasks 支援 due_date + status 過濾。
+ */
+export async function listTodayTasks(
+  today: string,
+): Promise<TodayTasksResponse> {
+  const sp = new URLSearchParams();
+  sp.set("due_date", today);
+  sp.set("status", "pending");
+  return apiClient.get<TodayTasksResponse>(
+    `/api/v1/tasks?${sp.toString()}`,
+  );
+}
+
+/**
+ * 取得今日 entries（updated_since=today_start, per_page=5）。
+ */
+export async function listTodayEntries(
+  todayStart: string,
+): Promise<ListEntriesResponse> {
+  const sp = new URLSearchParams();
+  sp.set("updated_since", todayStart);
+  sp.set("per_page", "5");
+  sp.set("sort", "updated_at");
+  sp.set("order", "desc");
+  return apiClient.get<ListEntriesResponse>(
+    `/api/v1/entries?${sp.toString()}`,
+  );
+}
+
+/**
+ * 取得 GCal 連線狀態。
+ */
+export async function getGcalConnectionStatus(): Promise<GcalStatus> {
+  return apiClient.get<GcalStatus>("/api/v1/integrations/gcal/status");
+}

--- a/dev/frontend/lib/hooks/use-today-date.ts
+++ b/dev/frontend/lib/hooks/use-today-date.ts
@@ -1,0 +1,65 @@
+"use client";
+
+import { useMemo } from "react";
+
+const TIMEZONE = "Asia/Taipei";
+
+/**
+ * 以瀏覽器 Intl.DateTimeFormat 取得今日日期（Asia/Taipei 時區）。
+ * 回傳 YYYY-MM-DD 格式字串，以及今日 00:00:00 的 ISO timestamp。
+ *
+ * 不自動追蹤日期變化；午夜後需手動 refresh 才會更新。
+ */
+export function useTodayDate() {
+  return useMemo(() => {
+    const now = new Date();
+
+    // 取得 Asia/Taipei 的今日 YYYY-MM-DD
+    const parts = new Intl.DateTimeFormat("en-CA", {
+      timeZone: TIMEZONE,
+      year: "numeric",
+      month: "2-digit",
+      day: "2-digit",
+    })
+      .format(now)
+      .split("-");
+
+    // en-CA locale 輸出 YYYY-MM-DD 格式
+    const today = parts.join("-");
+
+    // 今日 00:00:00 的 Asia/Taipei 時間轉成 UTC ISO string
+    const todayStartLocal = new Date(`${today}T00:00:00`);
+    // 利用 Intl 計算 timezone offset
+    const formatter = new Intl.DateTimeFormat("en-US", {
+      timeZone: TIMEZONE,
+      year: "numeric",
+      month: "2-digit",
+      day: "2-digit",
+      hour: "2-digit",
+      minute: "2-digit",
+      second: "2-digit",
+      hour12: false,
+    });
+
+    // 直接用 midnight in UTC for the given local date
+    // 計算 Asia/Taipei midnight 對應的 UTC 時刻
+    const todayStart = getTodayStartISO(today);
+
+    return { today, todayStart };
+  }, []);
+}
+
+/**
+ * 給定 YYYY-MM-DD（Asia/Taipei），回傳該日 00:00:00 Asia/Taipei 對應的 ISO UTC string。
+ */
+function getTodayStartISO(dateStr: string): string {
+  // 建立一個「假裝」是 Taipei 當日 00:00 的時間點
+  // 方式：在 UTC 建立時間後再加上 Taipei 的 offset（+8h）
+  // 更精確方式：用 Date.parse 配合 timezone hint
+  // Asia/Taipei 固定為 UTC+8
+  const TAIPEI_OFFSET_MS = 8 * 60 * 60 * 1000;
+  const utcMidnight = new Date(`${dateStr}T00:00:00Z`);
+  // Taipei midnight = UTC midnight - 8h offset
+  const taipeiMidnightUTC = new Date(utcMidnight.getTime() - TAIPEI_OFFSET_MS);
+  return taipeiMidnightUTC.toISOString();
+}


### PR DESCRIPTION
Closes #208

## 實作
- /today 頁面聚合 4 sections：Calendar / Journal / Recent Entries / Tasks
- 每 section 獨立 React error boundary（任一失敗其他仍顯示）
- TanStack Query parallel fetch
- Section skeleton（loading state）
- Today header + use-today-date hook