### PR TITLE
design(sprint-14): D-14 component specs — InboxCard / LibraryTable / TodaySection / SavedViews

### DIFF
--- a/design/components/inbox-card.example.tsx
+++ b/design/components/inbox-card.example.tsx
@@ -1,0 +1,243 @@
+// InboxCard 使用範例
+// 依賴：shadcn/ui Card / Checkbox / Badge / Button、Lucide Icons
+
+import { Archive, BookmarkPlus, Sparkles, Trash2 } from "lucide-react";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent } from "@/components/ui/card";
+import { Checkbox } from "@/components/ui/checkbox";
+import { cn } from "@/lib/utils";
+
+interface InboxEntry {
+  id: string;
+  title: string;
+  summary: string;
+  tags: string[];
+  source: string;
+  createdAt: string;
+  classificationStatus: "draft" | "classifying" | "classified";
+}
+
+interface InboxCardProps {
+  entry: InboxEntry;
+  isActive?: boolean;
+  isSelected?: boolean;
+  isLoading?: boolean;
+  onSelect?: (id: string) => void;
+  onArchive?: (id: string) => void;
+  onDelete?: (id: string) => void;
+  onClassify?: (id: string) => void;
+  onMoveToLibrary?: (id: string) => void;
+  onClick?: (id: string) => void;
+  className?: string;
+}
+
+const statusBadgeConfig = {
+  draft: { variant: "secondary" as const, label: "草稿" },
+  classifying: { variant: "outline" as const, label: "分類中" },
+  classified: { variant: "default" as const, label: "已分類" },
+};
+
+function InboxCard({
+  entry,
+  isActive = false,
+  isSelected = false,
+  isLoading = false,
+  onSelect,
+  onArchive,
+  onDelete,
+  onClassify,
+  onMoveToLibrary,
+  onClick,
+  className,
+}: InboxCardProps) {
+  const badgeConfig = statusBadgeConfig[entry.classificationStatus];
+  const formattedDate = new Date(entry.createdAt).toLocaleDateString("zh-TW", {
+    month: "short",
+    day: "numeric",
+  });
+
+  return (
+    <Card
+      role="article"
+      aria-label={entry.title}
+      aria-current={isActive || undefined}
+      aria-busy={isLoading || undefined}
+      tabIndex={0}
+      className={cn(
+        "group relative cursor-pointer select-none transition-colors duration-150",
+        "focus-visible:ring-2 focus-visible:ring-ring focus-visible:outline-none",
+        isActive && "border-l-[3px] border-l-primary bg-accent/30",
+        isSelected && "bg-accent/20",
+        !isActive && !isSelected && "hover:bg-accent/10",
+        className
+      )}
+      onClick={() => onClick?.(entry.id)}
+      onKeyDown={(e) => {
+        if (e.key === "Enter") onClick?.(entry.id);
+        if (e.key === " ") { e.preventDefault(); onSelect?.(entry.id); }
+      }}
+    >
+      <CardContent className="flex items-start gap-3 px-4 py-3 min-h-[80px]">
+        {/* Checkbox */}
+        <div className="flex items-center justify-center min-w-[44px] min-h-[44px]">
+          <Checkbox
+            checked={isSelected}
+            aria-label={`Select ${entry.title}`}
+            onClick={(e) => { e.stopPropagation(); onSelect?.(entry.id); }}
+          />
+        </div>
+
+        {/* Content */}
+        <div className="flex-1 min-w-0 space-y-1.5">
+          <div className="flex items-start justify-between gap-2">
+            <h3 className="text-sm font-medium leading-tight line-clamp-1 text-foreground">
+              {entry.title}
+            </h3>
+            <Badge variant={badgeConfig.variant} className="shrink-0 text-xs">
+              {entry.classificationStatus === "classifying" && (
+                <span className="mr-1 inline-block h-3 w-3 animate-spin rounded-full border border-current border-t-transparent" aria-hidden="true" />
+              )}
+              {badgeConfig.label}
+            </Badge>
+          </div>
+
+          <p className="text-xs text-muted-foreground line-clamp-2 leading-relaxed">
+            {entry.summary}
+          </p>
+
+          {entry.tags.length > 0 && (
+            <div className="flex flex-wrap gap-1.5" aria-label="標籤">
+              {entry.tags.map((tag) => (
+                <Badge key={tag} variant="secondary" className="text-xs px-1.5 py-0">
+                  {tag}
+                </Badge>
+              ))}
+            </div>
+          )}
+
+          <div className="flex items-center justify-between">
+            <span className="text-xs text-muted-foreground">
+              <Badge variant="outline" className="text-xs px-1.5 py-0 mr-1">
+                {entry.source}
+              </Badge>
+              {formattedDate}
+            </span>
+
+            {/* Action Buttons（hover 浮現） */}
+            <div
+              className={cn(
+                "flex items-center gap-0.5 transition-opacity duration-150",
+                "opacity-0 group-hover:opacity-100",
+                isLoading && "pointer-events-none"
+              )}
+              aria-hidden={isLoading}
+            >
+              <Button
+                variant="ghost"
+                size="icon"
+                className="h-8 w-8"
+                aria-label="Archive entry"
+                onClick={(e) => { e.stopPropagation(); onArchive?.(entry.id); }}
+              >
+                <Archive className="h-3.5 w-3.5" />
+              </Button>
+              <Button
+                variant="ghost"
+                size="icon"
+                className="h-8 w-8"
+                aria-label="Move to library"
+                onClick={(e) => { e.stopPropagation(); onMoveToLibrary?.(entry.id); }}
+              >
+                <BookmarkPlus className="h-3.5 w-3.5" />
+              </Button>
+              <Button
+                variant="ghost"
+                size="icon"
+                className="h-8 w-8"
+                aria-label="Classify entry"
+                onClick={(e) => { e.stopPropagation(); onClassify?.(entry.id); }}
+              >
+                <Sparkles className="h-3.5 w-3.5" />
+              </Button>
+              <Button
+                variant="ghost"
+                size="icon"
+                className="h-8 w-8 text-destructive hover:text-destructive"
+                aria-label="Delete entry"
+                onClick={(e) => { e.stopPropagation(); onDelete?.(entry.id); }}
+              >
+                <Trash2 className="h-3.5 w-3.5" />
+              </Button>
+            </div>
+          </div>
+        </div>
+      </CardContent>
+
+      {/* Shimmer Loading Overlay */}
+      {isLoading && (
+        <div
+          className="absolute inset-0 rounded-md bg-background/60 animate-pulse"
+          aria-hidden="true"
+        />
+      )}
+    </Card>
+  );
+}
+
+// --- 使用範例 ---
+
+// Default State
+const sampleEntry: InboxEntry = {
+  id: "entry-1",
+  title: "React Server Components 最佳實踐",
+  summary: "深入探討 RSC 的使用時機與效能考量，包含資料 fetching 策略與 bundle 大小最佳化。",
+  tags: ["react", "frontend", "performance"],
+  source: "manual",
+  createdAt: new Date().toISOString(),
+  classificationStatus: "classified",
+};
+
+export function DefaultCard() {
+  return <InboxCard entry={sampleEntry} />;
+}
+
+// Active（鍵盤游標）
+export function ActiveCard() {
+  return <InboxCard entry={sampleEntry} isActive />;
+}
+
+// Selected（批次勾選）
+export function SelectedCard() {
+  return <InboxCard entry={{ ...sampleEntry, classificationStatus: "draft" }} isSelected />;
+}
+
+// Loading（Classify 進行中）
+export function LoadingCard() {
+  return <InboxCard entry={{ ...sampleEntry, classificationStatus: "classifying" }} isLoading />;
+}
+
+// No Tags
+export function NoTagsCard() {
+  return (
+    <InboxCard
+      entry={{ ...sampleEntry, tags: [], classificationStatus: "draft" }}
+    />
+  );
+}
+
+// Keyboard Navigation Demo（J/K list）
+export function InboxCardList() {
+  return (
+    <div
+      role="list"
+      aria-label="Inbox 項目"
+      className="space-y-1"
+      // J/K navigation 由父層 InboxList 元件管理
+    >
+      <InboxCard entry={sampleEntry} isActive />
+      <InboxCard entry={{ ...sampleEntry, id: "2", title: "TypeScript 5.0 新功能整理" }} />
+      <InboxCard entry={{ ...sampleEntry, id: "3", title: "設計系統建構指南" }} isSelected />
+    </div>
+  );
+}

--- a/design/components/inbox-card.md
+++ b/design/components/inbox-card.md
@@ -1,0 +1,128 @@
+# InboxCard
+
+## 概述
+
+Inbox Triage 頁面的核心卡片元件。每一張卡片代表一筆尚未處理的知識項目（status = inbox）。
+基於 shadcn/ui Card primitive，搭配 editorial paper design tokens。
+
+## 用途
+
+- 展示 inbox 項目的標題、摘要、標籤、來源、建立時間
+- 提供快速操作入口（Archive、Move to Library、Delete、Classify）
+- 支援鍵盤游標（J/K）瀏覽、批次勾選
+
+## Variants / States
+
+| State | 外觀 |
+|-------|------|
+| `default` | 白底卡片，細邊框 `border` token |
+| `active`（鍵盤游標停留） | 左側 3px accent border（`ring-primary`），`bg-accent/30` 背景 |
+| `selected`（checkbox 勾選） | checkbox checked，`bg-accent/20` 背景 |
+| `loading`（Classify 進行中） | Shimmer overlay（skeleton animation），action buttons 隱藏 |
+| `hover` | action buttons 浮現，`bg-accent/10` 背景 |
+
+### 狀態 Badge
+
+卡片右上角顯示分類狀態 badge（沿用 Badge 元件）：
+
+| 值 | Badge variant | 說明 |
+|----|--------------|------|
+| `draft` | `secondary` | 草稿，尚未送出 |
+| `classifying` | `outline`（+ spinner icon） | LLM 分類中 |
+| `classified` | `default` | 已分類完成 |
+
+## Props
+
+| Prop | Type | Default | 說明 |
+|------|------|---------|------|
+| `entry` | `InboxEntry` | required | 資料物件 |
+| `isActive` | `boolean` | `false` | 鍵盤游標是否停留於此 |
+| `isSelected` | `boolean` | `false` | 批次勾選狀態 |
+| `isLoading` | `boolean` | `false` | Classify 進行中 |
+| `onSelect` | `(id: string) => void` | - | 勾選 callback |
+| `onArchive` | `(id: string) => void` | - | Archive callback |
+| `onDelete` | `(id: string) => void` | - | Delete callback |
+| `onClassify` | `(id: string) => void` | - | Classify callback |
+| `onMoveToLibrary` | `(id: string) => void` | - | Move to Library callback |
+| `onClick` | `(id: string) => void` | - | 點擊展開 preview |
+| `className` | `string` | - | 自訂 className |
+
+### InboxEntry 型別
+
+```ts
+interface InboxEntry {
+  id: string;
+  title: string;
+  summary: string;           // 最多 2 行截斷
+  tags: string[];
+  source: string;            // e.g. "manual" | "api" | "import"
+  createdAt: string;         // ISO 8601
+  classificationStatus: "draft" | "classifying" | "classified";
+}
+```
+
+## 版面結構
+
+```
+┌─────────────────────────────────────────┐
+│ [checkbox]  Title（1 行截斷）  [status badge] │
+│             Summary（2 行截斷）             │
+│             [tag chip] [tag chip] ...      │
+│             source badge    created_at     │
+│                         [action buttons]  │ ← hover 浮現
+└─────────────────────────────────────────┘
+```
+
+## 尺寸與間距
+
+- 卡片最小高度：80px（`min-h-20`）
+- 卡片水平 padding：`px-4`
+- 卡片垂直 padding：`py-3`
+- Action buttons 右邊距：`pr-3`
+- Tags 間距：`gap-1.5`
+
+## Action Buttons（Hover 浮現）
+
+| 按鈕 | Icon | Variant | aria-label |
+|------|------|---------|------------|
+| Archive | `ArchiveIcon` | `ghost` size=`icon` | "Archive entry" |
+| Move to Library | `BookmarkIcon` | `ghost` size=`icon` | "Move to library" |
+| Classify | `SparklesIcon` | `ghost` size=`icon` | "Classify entry" |
+| Delete | `TrashIcon` | `ghost` size=`icon` | "Delete entry"（destructive 色） |
+
+Hover 浮現動畫：`opacity-0 group-hover:opacity-100 transition-opacity duration-150`
+
+## Accessibility
+
+- `role="article"`，`aria-label="{entry.title}"`
+- Checkbox：`aria-label="Select {entry.title}"`
+- `isActive` 時：`aria-current="true"`
+- `isLoading` 時：`aria-busy="true"`，action buttons 加 `aria-hidden="true"`
+- 鍵盤：`tabIndex={0}`，Enter 觸發 `onClick`，Space 觸發 `onSelect`
+- Focus ring：`focus-visible:ring-2 focus-visible:ring-ring`
+
+## 觸控目標
+
+- Checkbox 觸控區：`min-w-[44px] min-h-[44px]`
+- Action buttons：`size-icon`（`h-9 w-9`）+ 外距補足 44px
+
+## Shimmer Loading State
+
+使用 `animate-pulse` skeleton overlay：
+
+```tsx
+// isLoading 時整張卡片覆蓋半透明 shimmer
+<div className="absolute inset-0 bg-background/60 rounded-md animate-pulse" />
+```
+
+## 使用範例
+
+見 `inbox-card.example.tsx`
+
+## 依賴元件
+
+- `components/ui/card`（shadcn）
+- `components/ui/checkbox`（shadcn）
+- `components/ui/badge`（shadcn）
+- `components/ui/button`（shadcn）
+- Lucide：`Archive`, `BookmarkPlus`, `Sparkles`, `Trash2`

--- a/design/components/library-table-chrome.example.tsx
+++ b/design/components/library-table-chrome.example.tsx
@@ -1,0 +1,466 @@
+// LibraryTableChrome 使用範例
+// TanStack Table v8 + shadcn/ui Table + 自訂 chrome 樣式
+
+import {
+  flexRender,
+  getCoreRowModel,
+  getSortedRowModel,
+  useReactTable,
+  type ColumnDef,
+  type SortingState,
+} from "@tanstack/react-table";
+import { useVirtualizer } from "@tanstack/react-virtual";
+import { formatDistanceToNow } from "date-fns";
+import { zhTW } from "date-fns/locale";
+import {
+  Archive,
+  ArrowDown,
+  ArrowUp,
+  ArrowUpDown,
+  BookmarkPlus,
+  Inbox,
+  MoreHorizontal,
+  Pencil,
+  Trash2,
+} from "lucide-react";
+import { useRef, useState } from "react";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Checkbox } from "@/components/ui/checkbox";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { cn } from "@/lib/utils";
+
+// --- Types ---
+
+interface LibraryEntry {
+  id: string;
+  title: string;
+  category: { id: string; name: string } | null;
+  tags: string[];
+  status: "inbox" | "library" | "archived";
+  confidence: number;
+  updatedAt: string;
+}
+
+interface LibraryTableChromeProps {
+  data: LibraryEntry[];
+  onEdit?: (id: string) => void;
+  onArchive?: (id: string) => void;
+  onDelete?: (id: string) => void;
+  onBatchArchive?: (ids: string[]) => void;
+  onBatchMoveToLibrary?: (ids: string[]) => void;
+  onBatchDelete?: (ids: string[]) => void;
+  onRowClick?: (id: string) => void;
+}
+
+// --- Sub-components ---
+
+function SortIcon({ isSorted }: { isSorted: false | "asc" | "desc" }) {
+  if (isSorted === "asc") return <ArrowUp className="ml-1.5 h-3.5 w-3.5" />;
+  if (isSorted === "desc") return <ArrowDown className="ml-1.5 h-3.5 w-3.5" />;
+  return <ArrowUpDown className="ml-1.5 h-3.5 w-3.5 opacity-40" />;
+}
+
+function ConfidenceCell({ value }: { value: number }) {
+  const colorClass =
+    value >= 80
+      ? "text-green-700 dark:text-green-400"
+      : value >= 50
+        ? "text-amber-700 dark:text-amber-400"
+        : "text-muted-foreground";
+  return <span className={cn("text-sm tabular-nums", colorClass)}>{value}</span>;
+}
+
+function StatusBadge({ status }: { status: LibraryEntry["status"] }) {
+  if (status === "library") return <Badge variant="default" className="text-xs">Library</Badge>;
+  if (status === "inbox") return <Badge variant="secondary" className="text-xs">Inbox</Badge>;
+  return <Badge variant="outline" className="text-xs text-muted-foreground">Archived</Badge>;
+}
+
+function TagsCell({ tags }: { tags: string[] }) {
+  const visible = tags.slice(0, 3);
+  const overflow = tags.length - 3;
+  return (
+    <div className="flex flex-wrap gap-1">
+      {visible.map((tag) => (
+        <Badge key={tag} variant="outline" className="text-xs px-1.5 py-0">{tag}</Badge>
+      ))}
+      {overflow > 0 && (
+        <Badge variant="outline" className="text-xs px-1.5 py-0 text-muted-foreground">+{overflow}</Badge>
+      )}
+    </div>
+  );
+}
+
+// --- Sticky Batch Toolbar ---
+
+function BatchToolbar({
+  selectedCount,
+  onClear,
+  onArchive,
+  onMoveToLibrary,
+  onDelete,
+}: {
+  selectedCount: number;
+  onClear: () => void;
+  onArchive: () => void;
+  onMoveToLibrary: () => void;
+  onDelete: () => void;
+}) {
+  if (selectedCount === 0) return null;
+
+  return (
+    <div
+      role="toolbar"
+      aria-label="批次操作"
+      className={cn(
+        "sticky top-0 z-10 flex items-center gap-2 px-4 py-2",
+        "bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/60",
+        "border-b border-border",
+        "animate-in slide-in-from-top duration-200"
+      )}
+    >
+      <Button
+        variant="ghost"
+        size="sm"
+        onClick={onClear}
+        aria-label="Clear selection"
+        className="h-8 px-2 text-muted-foreground"
+      >
+        已選 {selectedCount} 筆 &times;
+      </Button>
+
+      <div className="flex items-center gap-1 ml-2">
+        <Button variant="outline" size="sm" onClick={onArchive} className="h-8 gap-1.5">
+          <Archive className="h-3.5 w-3.5" />
+          Archive
+        </Button>
+        <Button variant="outline" size="sm" onClick={onMoveToLibrary} className="h-8 gap-1.5">
+          <BookmarkPlus className="h-3.5 w-3.5" />
+          移至 Library
+        </Button>
+        <Button
+          variant="destructive"
+          size="sm"
+          onClick={onDelete}
+          className="h-8 gap-1.5"
+        >
+          <Trash2 className="h-3.5 w-3.5" />
+          刪除
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+// --- Empty State ---
+
+function TableEmptyState({ onReset }: { onReset?: () => void }) {
+  return (
+    <div className="flex flex-col items-center justify-center py-16 gap-3">
+      <Inbox className="h-12 w-12 text-muted-foreground/50" aria-hidden="true" />
+      <p className="text-base font-medium text-foreground">找不到符合條件的項目</p>
+      <p className="text-sm text-muted-foreground">嘗試調整篩選條件或搜尋關鍵字</p>
+      {onReset && (
+        <Button variant="outline" onClick={onReset}>
+          重置篩選
+        </Button>
+      )}
+    </div>
+  );
+}
+
+// --- Main Table Component ---
+
+export function LibraryTableChrome({
+  data,
+  onEdit,
+  onArchive,
+  onDelete,
+  onBatchArchive,
+  onBatchMoveToLibrary,
+  onBatchDelete,
+  onRowClick,
+}: LibraryTableChromeProps) {
+  const [sorting, setSorting] = useState<SortingState>([]);
+  const [rowSelection, setRowSelection] = useState<Record<string, boolean>>({});
+  const parentRef = useRef<HTMLDivElement>(null);
+
+  const columns: ColumnDef<LibraryEntry>[] = [
+    {
+      id: "select",
+      header: ({ table }) => (
+        <Checkbox
+          checked={
+            table.getIsAllPageRowsSelected() ||
+            (table.getIsSomePageRowsSelected() ? "indeterminate" : false)
+          }
+          onCheckedChange={(v) => table.toggleAllPageRowsSelected(!!v)}
+          aria-label="Select all entries"
+        />
+      ),
+      cell: ({ row }) => (
+        <Checkbox
+          checked={row.getIsSelected()}
+          onCheckedChange={(v) => row.toggleSelected(!!v)}
+          aria-label={`Select ${row.original.title}`}
+          onClick={(e) => e.stopPropagation()}
+        />
+      ),
+      size: 48,
+      enableSorting: false,
+    },
+    {
+      accessorKey: "title",
+      header: ({ column }) => (
+        <button
+          className={cn(
+            "flex items-center min-h-[44px] cursor-pointer select-none",
+            "hover:text-foreground transition-colors",
+            column.getIsSorted() ? "text-foreground font-medium" : "text-muted-foreground"
+          )}
+          onClick={() => column.toggleSorting(column.getIsSorted() === "asc")}
+          aria-sort={
+            column.getIsSorted() === "asc"
+              ? "ascending"
+              : column.getIsSorted() === "desc"
+                ? "descending"
+                : "none"
+          }
+        >
+          標題
+          <SortIcon isSorted={column.getIsSorted()} />
+        </button>
+      ),
+      cell: ({ getValue }) => (
+        <span className="text-sm font-medium line-clamp-1 cursor-pointer hover:underline">
+          {getValue() as string}
+        </span>
+      ),
+    },
+    {
+      accessorKey: "category",
+      header: "分類",
+      cell: ({ getValue }) => {
+        const cat = getValue() as LibraryEntry["category"];
+        return cat ? <Badge variant="secondary" className="text-xs">{cat.name}</Badge> : null;
+      },
+      enableSorting: false,
+    },
+    {
+      accessorKey: "tags",
+      header: "標籤",
+      cell: ({ getValue }) => <TagsCell tags={getValue() as string[]} />,
+      enableSorting: false,
+    },
+    {
+      accessorKey: "status",
+      header: "狀態",
+      cell: ({ getValue }) => <StatusBadge status={getValue() as LibraryEntry["status"]} />,
+      enableSorting: false,
+    },
+    {
+      accessorKey: "confidence",
+      header: ({ column }) => (
+        <button
+          className={cn(
+            "flex items-center min-h-[44px] cursor-pointer select-none",
+            "hover:text-foreground transition-colors",
+            column.getIsSorted() ? "text-foreground font-medium" : "text-muted-foreground"
+          )}
+          onClick={() => column.toggleSorting(column.getIsSorted() === "asc")}
+          aria-sort={column.getIsSorted() === "asc" ? "ascending" : column.getIsSorted() === "desc" ? "descending" : "none"}
+        >
+          可信度
+          <SortIcon isSorted={column.getIsSorted()} />
+        </button>
+      ),
+      cell: ({ getValue }) => <ConfidenceCell value={getValue() as number} />,
+    },
+    {
+      accessorKey: "updatedAt",
+      header: ({ column }) => (
+        <button
+          className={cn(
+            "flex items-center min-h-[44px] cursor-pointer select-none",
+            "hover:text-foreground transition-colors",
+            column.getIsSorted() ? "text-foreground font-medium" : "text-muted-foreground"
+          )}
+          onClick={() => column.toggleSorting(column.getIsSorted() === "asc")}
+          aria-sort={column.getIsSorted() === "asc" ? "ascending" : column.getIsSorted() === "desc" ? "descending" : "none"}
+        >
+          更新時間
+          <SortIcon isSorted={column.getIsSorted()} />
+        </button>
+      ),
+      cell: ({ getValue }) => (
+        <span className="text-xs text-muted-foreground">
+          {formatDistanceToNow(new Date(getValue() as string), { addSuffix: true, locale: zhTW })}
+        </span>
+      ),
+    },
+    {
+      id: "actions",
+      header: () => <span className="sr-only">Row actions</span>,
+      cell: ({ row }) => (
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <Button
+              variant="ghost"
+              size="icon"
+              className="h-8 w-8 opacity-0 group-hover/row:opacity-100 transition-opacity"
+              aria-label="Row actions"
+              onClick={(e) => e.stopPropagation()}
+            >
+              <MoreHorizontal className="h-4 w-4" />
+            </Button>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent align="end">
+            <DropdownMenuItem onClick={() => onEdit?.(row.original.id)}>
+              <Pencil className="mr-2 h-4 w-4" />
+              編輯
+            </DropdownMenuItem>
+            <DropdownMenuItem onClick={() => onArchive?.(row.original.id)}>
+              <Archive className="mr-2 h-4 w-4" />
+              Archive
+            </DropdownMenuItem>
+            <DropdownMenuItem
+              className="text-destructive focus:text-destructive"
+              onClick={() => onDelete?.(row.original.id)}
+            >
+              <Trash2 className="mr-2 h-4 w-4" />
+              刪除
+            </DropdownMenuItem>
+          </DropdownMenuContent>
+        </DropdownMenu>
+      ),
+      size: 48,
+      enableSorting: false,
+    },
+  ];
+
+  const table = useReactTable({
+    data,
+    columns,
+    state: { sorting, rowSelection },
+    onSortingChange: setSorting,
+    onRowSelectionChange: setRowSelection,
+    getCoreRowModel: getCoreRowModel(),
+    getSortedRowModel: getSortedRowModel(),
+    enableRowSelection: true,
+  });
+
+  const { rows } = table.getRowModel();
+  const selectedIds = Object.keys(rowSelection).filter((k) => rowSelection[k]);
+
+  const rowVirtualizer = useVirtualizer({
+    count: rows.length,
+    getScrollElement: () => parentRef.current,
+    estimateSize: () => 52,
+    overscan: 5,
+  });
+
+  return (
+    <div className="flex flex-col">
+      <BatchToolbar
+        selectedCount={selectedIds.length}
+        onClear={() => setRowSelection({})}
+        onArchive={() => onBatchArchive?.(selectedIds)}
+        onMoveToLibrary={() => onBatchMoveToLibrary?.(selectedIds)}
+        onDelete={() => onBatchDelete?.(selectedIds)}
+      />
+
+      <div
+        ref={parentRef}
+        className="overflow-auto"
+        style={{ height: "calc(100vh - 160px)" }}
+      >
+        <Table role="grid" aria-label="Library 知識項目">
+          <TableHeader>
+            {table.getHeaderGroups().map((headerGroup) => (
+              <TableRow key={headerGroup.id}>
+                {headerGroup.headers.map((header) => (
+                  <TableHead
+                    key={header.id}
+                    scope="col"
+                    style={{ width: header.getSize() !== 150 ? header.getSize() : undefined }}
+                    className="bg-background sticky top-0 z-[1]"
+                  >
+                    {header.isPlaceholder
+                      ? null
+                      : flexRender(header.column.columnDef.header, header.getContext())}
+                  </TableHead>
+                ))}
+              </TableRow>
+            ))}
+          </TableHeader>
+
+          <TableBody>
+            {rows.length === 0 ? (
+              <TableRow>
+                <TableCell colSpan={columns.length}>
+                  <TableEmptyState />
+                </TableCell>
+              </TableRow>
+            ) : (
+              <>
+                {/* Virtualizer spacer top */}
+                {rowVirtualizer.getVirtualItems()[0]?.start > 0 && (
+                  <tr style={{ height: rowVirtualizer.getVirtualItems()[0].start }} />
+                )}
+
+                {rowVirtualizer.getVirtualItems().map((virtualRow) => {
+                  const row = rows[virtualRow.index];
+                  return (
+                    <TableRow
+                      key={row.id}
+                      data-state={row.getIsSelected() ? "selected" : undefined}
+                      aria-selected={row.getIsSelected()}
+                      className={cn(
+                        "group/row cursor-pointer transition-colors duration-100",
+                        row.getIsSelected() && "bg-accent/20"
+                      )}
+                      onClick={() => onRowClick?.(row.original.id)}
+                      style={{ height: virtualRow.size }}
+                    >
+                      {row.getVisibleCells().map((cell) => (
+                        <TableCell key={cell.id}>
+                          {flexRender(cell.column.columnDef.cell, cell.getContext())}
+                        </TableCell>
+                      ))}
+                    </TableRow>
+                  );
+                })}
+
+                {/* Virtualizer spacer bottom */}
+                {rowVirtualizer.getTotalSize() -
+                  (rowVirtualizer.getVirtualItems().at(-1)?.end ?? 0) > 0 && (
+                  <tr
+                    style={{
+                      height:
+                        rowVirtualizer.getTotalSize() -
+                        (rowVirtualizer.getVirtualItems().at(-1)?.end ?? 0),
+                    }}
+                  />
+                )}
+              </>
+            )}
+          </TableBody>
+        </Table>
+      </div>
+    </div>
+  );
+}

--- a/design/components/library-table-chrome.md
+++ b/design/components/library-table-chrome.md
@@ -1,0 +1,150 @@
+# LibraryTableChrome
+
+## 概述
+
+Library 頁面的表格視覺層（chrome）。基於 TanStack Table v8（headless）自行樣式，搭配 editorial paper design tokens。
+不包含資料邏輯——僅定義欄位 header、row、sticky toolbar、empty state 的視覺規格。
+
+## 欄位定義
+
+| 欄位 key | 標題 | 寬度 | 可排序 | 說明 |
+|----------|------|------|--------|------|
+| `select` | — | 48px | N | 全選 Checkbox |
+| `title` | 標題 | flex-1（min 200px） | Y | 主要內容 |
+| `category` | 分類 | 140px | N | 分類名稱 badge |
+| `tags` | 標籤 | 180px | N | 最多 3 個，超出 "+N" |
+| `status` | 狀態 | 100px | N | inbox / library / archived badge |
+| `confidence` | 可信度 | 80px | Y | 0-100 數字 + 顏色指示 |
+| `updatedAt` | 更新時間 | 120px | Y | 相對時間（e.g. "3 天前"） |
+| `actions` | — | 48px | N | "..." kebab menu |
+
+## Column Header 規格
+
+### Sortable Header
+
+```
+┌──────────────────────┐
+│ 標題文字  ↑ (asc)    │  ← 有排序
+│ 標題文字  ↕ (unsorted)│ ← hover 顯示
+└──────────────────────┘
+```
+
+- 預設：文字 + 排序狀態 icon
+- 排序 icon：`ArrowUpIcon`（asc）/ `ArrowDownIcon`（desc）/ `ArrowUpDownIcon`（unsorted）
+- Hover：背景 `hover:bg-muted/50`，游標 `cursor-pointer`
+- 排序中：文字 `text-foreground font-medium`；未排序：`text-muted-foreground`
+- 觸控目標：完整欄位寬度可點擊，`min-h-[44px]`
+
+### Checkbox Header（全選）
+
+- `Checkbox` indeterminate state 當部分勾選時
+- `aria-label="Select all entries"`
+
+### Actions Header
+
+- 空白，右對齊
+- `aria-label="Row actions"`
+
+## Row 狀態規格
+
+| State | 外觀變化 |
+|-------|---------|
+| `default` | 白底，`border-b border-border` |
+| `hover` | `bg-muted/30`，action column 的 "..." button 顯示 |
+| `selected` | Checkbox checked + `bg-accent/20` |
+| `loading`（skeleton） | 全列 shimmer（`animate-pulse bg-muted rounded`） |
+
+### Row 內容規格
+
+- Title：`text-sm font-medium text-foreground line-clamp-1`，可點擊展開 Sheet
+- Category：`<Badge variant="secondary">`
+- Tags：最多 3 個 `<Badge variant="outline" className="text-xs">`，多餘顯示 `+N`
+- Status：
+  - `inbox` → `<Badge variant="secondary">Inbox</Badge>`
+  - `library` → `<Badge variant="default">Library</Badge>`
+  - `archived` → `<Badge variant="outline" className="text-muted-foreground">Archived</Badge>`
+- Confidence：
+  - >= 80：`text-success-foreground`（綠色）
+  - 50-79：`text-warning-foreground`（橘黃色）
+  - < 50：`text-muted-foreground`（灰色）
+- UpdatedAt：`formatDistanceToNow`（date-fns），`text-xs text-muted-foreground`
+
+### Row Action Menu（"..." Kebab）
+
+- Trigger：`<Button variant="ghost" size="icon">`，`opacity-0 group-hover:opacity-100`
+- 展開：`<DropdownMenu>`（shadcn）
+- 項目：Edit（`PencilIcon`）/ Archive（`ArchiveIcon`）/ Delete（`Trash2Icon`，destructive 色）
+- Delete 項目：`className="text-destructive focus:text-destructive"`
+
+## Sticky Toolbar（批次操作列）
+
+當有 row 被勾選時，表格頂部顯示 sticky toolbar，浮於 header 之上。
+
+```
+┌─────────────────────────────────────────────────────┐
+│ [x] 已選 {N} 筆    [Archive]  [Move to Library]  [Delete]  │
+└─────────────────────────────────────────────────────┘
+```
+
+- 位置：`sticky top-0 z-10`
+- 背景：`bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/60`
+- 邊框：`border-b border-border`
+- 顯示條件：`selectedCount > 0`，`animate-in slide-in-from-top duration-200`
+- 隱藏條件：`selectedCount === 0`，`animate-out slide-out-to-top duration-200`
+- X 按鈕：清除全部選取，`aria-label="Clear selection"`
+
+### Toolbar Buttons
+
+| 按鈕 | Icon | Variant |
+|------|------|---------|
+| Archive | `ArchiveIcon` | `outline` |
+| Move to Library | `BookmarkPlusIcon` | `outline` |
+| Delete | `Trash2Icon` | `destructive` |
+
+## Empty State
+
+```
+┌─────────────────────────────┐
+│                             │
+│      📭  （不用 emoji icon） │
+│  [InboxIcon]                │
+│  No entries found           │
+│  ← 找不到符合條件的項目        │
+│                             │
+│  [Reset Filters]（outline） │
+│                             │
+└─────────────────────────────┘
+```
+
+- Icon：`<InboxIcon className="h-12 w-12 text-muted-foreground/50">`
+- 標題：`text-base font-medium text-foreground`
+- 說明文字：`text-sm text-muted-foreground`
+- CTA：`<Button variant="outline">重置篩選</Button>`
+
+## Virtualized Scroll
+
+- 使用 `@tanstack/react-virtual`（rowVirtualizer）
+- 容器固定高度：`calc(100vh - {toolbar_height} - {header_height})`
+- `overscrollBehavior: "contain"`
+- Row 渲染只含可見視窗（+ overscan 5 行）
+
+## Accessibility
+
+- `<table role="grid" aria-label="Library 知識項目">`
+- `<th scope="col">`
+- 排序 header：`aria-sort="ascending" | "descending" | "none"`
+- Selected row：`aria-selected="true"`
+- 全選 checkbox：`aria-label="Select all entries"` / `aria-label="Deselect all entries"`
+- Sticky toolbar：`role="toolbar" aria-label="批次操作"` 並在出現時 focus
+
+## 使用範例
+
+見 `library-table-chrome.example.tsx`
+
+## 依賴
+
+- TanStack Table v8 (`@tanstack/react-table`)
+- TanStack Virtual (`@tanstack/react-virtual`)
+- shadcn：`Table`, `Checkbox`, `Button`, `Badge`, `DropdownMenu`
+- Lucide：`ArrowUp`, `ArrowDown`, `ArrowUpDown`, `Archive`, `BookmarkPlus`, `Trash2`, `Pencil`, `MoreHorizontal`, `Inbox`
+- date-fns：`formatDistanceToNow`

--- a/design/components/saved-views-chip.example.tsx
+++ b/design/components/saved-views-chip.example.tsx
@@ -1,0 +1,507 @@
+// SavedViewsChip 使用範例
+// Sidebar Views 區塊 + SavedViewDialog + FilterBar ActiveViewChip
+
+import {
+  DndContext,
+  DragOverlay,
+  KeyboardSensor,
+  PointerSensor,
+  closestCenter,
+  useSensor,
+  useSensors,
+  type DragEndEvent,
+} from "@dnd-kit/core";
+import {
+  SortableContext,
+  sortableKeyboardCoordinates,
+  useSortable,
+  verticalListSortingStrategy,
+} from "@dnd-kit/sortable";
+import { CSS } from "@dnd-kit/utilities";
+import { GripVertical, MoreHorizontal, Pencil, Trash2, X } from "lucide-react";
+import { useState } from "react";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { cn } from "@/lib/utils";
+
+// --- Types ---
+
+interface SavedView {
+  id: string;
+  name: string;
+  scope: "library" | "inbox";
+  icon?: string;
+  position: number;
+}
+
+interface SavedViewFormData {
+  name: string;
+  icon?: string;
+  scope: "library" | "inbox";
+}
+
+// --- Emoji Quick Select ---
+
+const QUICK_EMOJIS = ["📚", "🔬", "💡", "⚙️", "🎯", "🗂️", "📝", "🏷️", "🔖", "✨"];
+
+function EmojiGrid({
+  value,
+  onChange,
+}: {
+  value?: string;
+  onChange: (emoji: string | undefined) => void;
+}) {
+  return (
+    <div role="radiogroup" aria-label="選擇圖示" className="grid grid-cols-5 gap-1.5">
+      {QUICK_EMOJIS.map((emoji) => (
+        <button
+          key={emoji}
+          role="radio"
+          aria-checked={value === emoji}
+          type="button"
+          onClick={() => onChange(value === emoji ? undefined : emoji)}
+          className={cn(
+            "h-9 w-9 rounded-md text-base flex items-center justify-center transition-colors",
+            "hover:bg-accent",
+            value === emoji && "bg-accent border border-ring"
+          )}
+        >
+          {emoji}
+        </button>
+      ))}
+    </div>
+  );
+}
+
+// --- SavedViewDialog ---
+
+interface SavedViewDialogProps {
+  open: boolean;
+  onOpenChange: (v: boolean) => void;
+  mode?: "create" | "edit";
+  initialValues?: Partial<SavedView>;
+  onSave: (data: SavedViewFormData) => Promise<void>;
+}
+
+export function SavedViewDialog({
+  open,
+  onOpenChange,
+  mode = "create",
+  initialValues,
+  onSave,
+}: SavedViewDialogProps) {
+  const [name, setName] = useState(initialValues?.name ?? "");
+  const [icon, setIcon] = useState<string | undefined>(initialValues?.icon);
+  const [nameError, setNameError] = useState("");
+  const [isSaving, setIsSaving] = useState(false);
+
+  const handleSave = async () => {
+    if (!name.trim()) {
+      setNameError("名稱為必填欄位");
+      return;
+    }
+    if (name.length > 100) {
+      setNameError("名稱不能超過 100 個字元");
+      return;
+    }
+    setNameError("");
+    setIsSaving(true);
+    try {
+      await onSave({ name: name.trim(), icon, scope: "library" });
+      onOpenChange(false);
+    } catch {
+      // Toast error handled by parent
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-[420px]">
+        <DialogHeader>
+          <DialogTitle>{mode === "create" ? "儲存視圖" : "編輯視圖"}</DialogTitle>
+        </DialogHeader>
+
+        <div className="space-y-4 py-2">
+          {/* Name Field */}
+          <div className="space-y-1.5">
+            <Label htmlFor="view-name">名稱</Label>
+            <Input
+              id="view-name"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              placeholder="我的視圖"
+              maxLength={100}
+              aria-invalid={!!nameError}
+              aria-describedby={nameError ? "view-name-error" : undefined}
+            />
+            {nameError && (
+              <p id="view-name-error" className="text-xs text-destructive" role="alert">
+                {nameError}
+              </p>
+            )}
+            <p className="text-xs text-muted-foreground text-right">{name.length}/100</p>
+          </div>
+
+          {/* Icon Field */}
+          <div className="space-y-1.5">
+            <Label>圖示（選填）</Label>
+            <EmojiGrid value={icon} onChange={setIcon} />
+          </div>
+
+          {/* Scope（disabled for Sprint 14） */}
+          <div className="space-y-1.5">
+            <Label>範圍</Label>
+            <div className="h-10 px-3 py-2 rounded-md border bg-muted text-sm text-muted-foreground flex items-center">
+              Library
+            </div>
+            <p className="text-xs text-muted-foreground">目前僅支援 Library 範圍</p>
+          </div>
+        </div>
+
+        <DialogFooter>
+          <Button variant="outline" onClick={() => onOpenChange(false)} disabled={isSaving}>
+            取消
+          </Button>
+          <Button onClick={handleSave} disabled={isSaving} aria-busy={isSaving}>
+            {isSaving && (
+              <span className="mr-2 h-4 w-4 animate-spin rounded-full border-2 border-current border-t-transparent" aria-hidden="true" />
+            )}
+            儲存
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+// --- SavedViewChip (System) ---
+
+function SystemViewChip({
+  view,
+  isActive,
+  onSelect,
+}: {
+  view: SavedView;
+  isActive: boolean;
+  onSelect: (id: string) => void;
+}) {
+  return (
+    <button
+      role="button"
+      aria-pressed={isActive}
+      aria-current={isActive ? "page" : undefined}
+      onClick={() => onSelect(view.id)}
+      className={cn(
+        "group flex w-full items-center gap-2 rounded-md px-3 h-9 text-sm transition-colors",
+        "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
+        isActive
+          ? "border-l-[3px] border-l-primary bg-accent/40 font-medium text-foreground"
+          : "text-foreground/70 hover:bg-accent/20"
+      )}
+    >
+      {view.icon && <span aria-hidden="true">{view.icon}</span>}
+      <span className="flex-1 text-left">{view.name}</span>
+    </button>
+  );
+}
+
+// --- SavedViewChip (User, Sortable) ---
+
+function UserViewChip({
+  view,
+  isActive,
+  onSelect,
+  onEdit,
+  onDelete,
+}: {
+  view: SavedView;
+  isActive: boolean;
+  onSelect: (id: string) => void;
+  onEdit: (id: string) => void;
+  onDelete: (id: string) => void;
+}) {
+  const {
+    attributes,
+    listeners,
+    setNodeRef,
+    transform,
+    transition,
+    isDragging,
+  } = useSortable({ id: view.id });
+
+  const style = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+  };
+
+  return (
+    <div
+      ref={setNodeRef}
+      style={style}
+      className={cn(
+        "group flex w-full items-center gap-1 rounded-md px-2 h-9 text-sm transition-colors",
+        isActive
+          ? "border-l-[3px] border-l-primary bg-accent/40"
+          : "hover:bg-accent/20",
+        isDragging && "opacity-50 bg-accent/20"
+      )}
+    >
+      {/* Drag Handle */}
+      <button
+        {...attributes}
+        {...listeners}
+        className={cn(
+          "shrink-0 p-0.5 rounded cursor-grab active:cursor-grabbing",
+          "opacity-0 group-hover:opacity-60 transition-opacity duration-150",
+          "focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+        )}
+        aria-label={`Drag to reorder ${view.name}`}
+        aria-roledescription="sortable"
+        tabIndex={0}
+      >
+        <GripVertical className="h-3.5 w-3.5 text-muted-foreground" />
+      </button>
+
+      {/* Main button */}
+      <button
+        role="button"
+        aria-pressed={isActive}
+        aria-current={isActive ? "page" : undefined}
+        onClick={() => onSelect(view.id)}
+        className={cn(
+          "flex flex-1 items-center gap-2 text-sm min-w-0",
+          "focus-visible:outline-none",
+          isActive ? "font-medium text-foreground" : "text-foreground/70"
+        )}
+      >
+        {view.icon && <span aria-hidden="true">{view.icon}</span>}
+        <span className="flex-1 text-left truncate">{view.name}</span>
+      </button>
+
+      {/* Kebab Menu */}
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <Button
+            variant="ghost"
+            size="icon"
+            className={cn(
+              "h-6 w-6 shrink-0 opacity-0 group-hover:opacity-100 transition-opacity duration-150",
+              "focus-visible:opacity-100"
+            )}
+            aria-label={`View options for ${view.name}`}
+          >
+            <MoreHorizontal className="h-3.5 w-3.5" />
+          </Button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align="end" className="w-36">
+          <DropdownMenuItem onClick={() => onEdit(view.id)}>
+            <Pencil className="mr-2 h-4 w-4" />
+            編輯
+          </DropdownMenuItem>
+          <DropdownMenuItem
+            className="text-destructive focus:text-destructive"
+            onClick={() => onDelete(view.id)}
+          >
+            <Trash2 className="mr-2 h-4 w-4" />
+            刪除
+          </DropdownMenuItem>
+        </DropdownMenuContent>
+      </DropdownMenu>
+    </div>
+  );
+}
+
+// --- SavedViewsList (Full Sidebar Section) ---
+
+interface SavedViewsListProps {
+  systemViews: SavedView[];
+  userViews: SavedView[];
+  activeViewId?: string;
+  onSelect: (id: string) => void;
+  onEdit: (id: string) => void;
+  onDelete: (id: string) => void;
+  onReorder: (orderedIds: string[]) => void;
+  onCreateView: () => void;
+}
+
+export function SavedViewsList({
+  systemViews,
+  userViews,
+  activeViewId,
+  onSelect,
+  onEdit,
+  onDelete,
+  onReorder,
+  onCreateView,
+}: SavedViewsListProps) {
+  const sensors = useSensors(
+    useSensor(PointerSensor),
+    useSensor(KeyboardSensor, { coordinateGetter: sortableKeyboardCoordinates })
+  );
+
+  const [activeId, setActiveId] = useState<string | null>(null);
+
+  function handleDragEnd(event: DragEndEvent) {
+    const { active, over } = event;
+    setActiveId(null);
+    if (over && active.id !== over.id) {
+      const oldIndex = userViews.findIndex((v) => v.id === active.id);
+      const newIndex = userViews.findIndex((v) => v.id === over.id);
+      const reordered = [...userViews];
+      const [moved] = reordered.splice(oldIndex, 1);
+      reordered.splice(newIndex, 0, moved);
+      onReorder(reordered.map((v) => v.id));
+    }
+  }
+
+  const activeView = userViews.find((v) => v.id === activeId);
+
+  return (
+    <div className="space-y-0.5 px-2 py-2">
+      <div className="px-2 pb-1 text-xs font-semibold text-muted-foreground uppercase tracking-wide">
+        Views
+      </div>
+
+      {/* System Views */}
+      {systemViews.map((view) => (
+        <SystemViewChip
+          key={view.id}
+          view={view}
+          isActive={activeViewId === view.id}
+          onSelect={onSelect}
+        />
+      ))}
+
+      {/* User Views with DnD */}
+      <DndContext
+        sensors={sensors}
+        collisionDetection={closestCenter}
+        onDragStart={(e) => setActiveId(e.active.id as string)}
+        onDragEnd={handleDragEnd}
+      >
+        <SortableContext items={userViews.map((v) => v.id)} strategy={verticalListSortingStrategy}>
+          {userViews.map((view) => (
+            <UserViewChip
+              key={view.id}
+              view={view}
+              isActive={activeViewId === view.id}
+              onSelect={onSelect}
+              onEdit={onEdit}
+              onDelete={onDelete}
+            />
+          ))}
+        </SortableContext>
+
+        {/* Drag Overlay */}
+        <DragOverlay>
+          {activeView ? (
+            <div className="flex items-center gap-2 rounded-md px-3 h-9 text-sm bg-background shadow-lg border border-border opacity-90">
+              {activeView.icon && <span aria-hidden="true">{activeView.icon}</span>}
+              <span>{activeView.name}</span>
+            </div>
+          ) : null}
+        </DragOverlay>
+      </DndContext>
+
+      {/* Add View Button */}
+      <Button
+        variant="ghost"
+        size="sm"
+        className="w-full justify-start px-3 h-8 text-muted-foreground hover:text-foreground text-xs gap-2"
+        onClick={onCreateView}
+      >
+        + 新增視圖
+      </Button>
+    </div>
+  );
+}
+
+// --- ActiveViewChip（FilterBar 中使用） ---
+
+export function ActiveViewChip({
+  view,
+  onClear,
+}: {
+  view: SavedView | null;
+  onClear: () => void;
+}) {
+  if (!view) return null;
+  return (
+    <Badge variant="secondary" className="flex items-center gap-1.5 px-2.5 py-1 h-8">
+      {view.icon && <span aria-hidden="true">{view.icon}</span>}
+      <span className="text-xs">{view.name}</span>
+      <button
+        onClick={onClear}
+        aria-label="Clear view filter"
+        className="ml-0.5 rounded-sm hover:bg-accent p-0.5 transition-colors"
+      >
+        <X className="h-3 w-3" />
+      </button>
+    </Badge>
+  );
+}
+
+// --- Demo ---
+
+export function SavedViewsDemo() {
+  const [activeViewId, setActiveViewId] = useState("all");
+  const [dialogOpen, setDialogOpen] = useState(false);
+
+  const systemViews: SavedView[] = [
+    { id: "all", name: "All", scope: "library", icon: "🗂️", position: 0 },
+    { id: "inbox", name: "Inbox", scope: "inbox", icon: "📬", position: 1 },
+  ];
+
+  const [userViews, setUserViews] = useState<SavedView[]>([
+    { id: "react", name: "React 筆記", scope: "library", icon: "⚛️", position: 0 },
+    { id: "design", name: "設計資源", scope: "library", icon: "🎨", position: 1 },
+  ]);
+
+  return (
+    <div className="w-64 border rounded-lg bg-background">
+      <SavedViewsList
+        systemViews={systemViews}
+        userViews={userViews}
+        activeViewId={activeViewId}
+        onSelect={setActiveViewId}
+        onEdit={(id) => console.log("edit", id)}
+        onDelete={(id) => setUserViews((v) => v.filter((x) => x.id !== id))}
+        onReorder={(ids) =>
+          setUserViews((prev) =>
+            ids.map((id, i) => ({ ...prev.find((v) => v.id === id)!, position: i }))
+          )
+        }
+        onCreateView={() => setDialogOpen(true)}
+      />
+
+      <SavedViewDialog
+        open={dialogOpen}
+        onOpenChange={setDialogOpen}
+        mode="create"
+        onSave={async (data) => {
+          setUserViews((prev) => [
+            ...prev,
+            { id: Date.now().toString(), ...data, position: prev.length },
+          ]);
+        }}
+      />
+    </div>
+  );
+}

--- a/design/components/saved-views-chip.md
+++ b/design/components/saved-views-chip.md
@@ -1,0 +1,195 @@
+# SavedViewsChip
+
+## 概述
+
+Sidebar 的「Views」區塊中，每個 saved view 的展示單元。分為 system view（不可刪除）和 user view（可 Edit / Delete / 拖曳重排）。
+另包含 SavedViewDialog（新建 / 編輯 view 的 dialog）與 FilterBar（Library toolbar 上的 active view 篩選顯示）。
+
+## Variants
+
+| Type | 特徵 | 說明 |
+|------|------|------|
+| `system` | 無 "..." menu，無拖曳 handle | 系統預設（All / Inbox） |
+| `user` | "..." hover menu，drag handle | 使用者建立 |
+
+## SavedViewChip Props
+
+| Prop | Type | Default | 說明 |
+|------|------|---------|------|
+| `view` | `SavedView` | required | View 資料物件 |
+| `isActive` | `boolean` | `false` | 目前選中的 view |
+| `type` | `"system" \| "user"` | `"user"` | View 類型 |
+| `onSelect` | `(id: string) => void` | - | 點選 callback |
+| `onEdit` | `(id: string) => void` | - | Edit callback（user only） |
+| `onDelete` | `(id: string) => void` | - | Delete callback（user only） |
+| `isDragging` | `boolean` | `false` | 拖曳中狀態（@dnd-kit） |
+| `dragHandleProps` | `object` | - | @dnd-kit SortableItem drag handle props |
+| `className` | `string` | - | 自訂 className |
+
+### SavedView 型別
+
+```ts
+interface SavedView {
+  id: string;
+  name: string;
+  scope: "library" | "inbox";
+  icon?: string;       // emoji，e.g. "📚"
+  position: number;
+}
+```
+
+## 版面結構
+
+### User View Chip
+
+```
+┌───────────────────────────────────┐
+│ [⣿] [icon] View Name    [...]   │
+│  ^drag  ^emoji                ^kebab
+└───────────────────────────────────┘
+```
+
+- Active 時：左側 3px border `border-l-primary`，背景 `bg-accent/40`
+- Drag handle：`GripVerticalIcon`，`opacity-0 group-hover:opacity-60`，游標 `cursor-grab`
+- Drag over：`opacity-50 bg-accent/20`（dnd-kit `isDragging`）
+- "..." menu：`opacity-0 group-hover:opacity-100`
+
+### System View Chip
+
+```
+┌──────────────────────────────────┐
+│      [icon] View Name            │
+└──────────────────────────────────┘
+```
+
+- 無 drag handle，無 "..." menu
+
+## States
+
+| State | 外觀 |
+|-------|------|
+| `default` | 透明背景，`text-sm text-foreground/70` |
+| `active` | `border-l-[3px] border-l-primary bg-accent/40`，`text-foreground font-medium` |
+| `hover` | `bg-accent/20`，drag handle 和 "..." 顯示 |
+| `dragging` | `opacity-50`，`bg-accent/20`，cursor `grabbing` |
+| `focus` | `focus-visible:ring-2 focus-visible:ring-ring` |
+
+## Chip Sizes
+
+- 高度：`h-9`（36px）+ hover 觸控補足至 44px 的 py
+- 水平 padding：`px-3`
+- Icon / emoji 大小：`text-base`（16px）
+
+## "..." Kebab Menu（user view only）
+
+| 項目 | Icon | 行為 |
+|------|------|------|
+| 編輯 | `PencilIcon` | 開啟 SavedViewDialog（edit mode） |
+| 刪除 | `Trash2Icon` | 開啟 confirm dialog（destructive） |
+
+Menu trigger：`opacity-0 group-hover:opacity-100 transition-opacity duration-150`
+
+---
+
+## SavedViewDialog
+
+新建 / 編輯 saved view 的 Dialog。
+
+```
+┌─────────────────────────────────────────┐
+│ 儲存視圖 / 編輯視圖                      │
+├─────────────────────────────────────────┤
+│                                         │
+│ 名稱                                    │
+│ [___________________________]（100 chars）│
+│                                         │
+│ 圖示                                    │
+│ [📚] [🔬] [💡] [⚙️] [🎯] [🗂️] [📝] [more?]│
+│                                         │
+│ 範圍                                    │
+│ [Library ▼]（sprint 14 只有 Library）   │
+│                                         │
+│         [Cancel]      [Save]           │
+└─────────────────────────────────────────┘
+```
+
+### Dialog Props
+
+| Prop | Type | Default | 說明 |
+|------|------|---------|------|
+| `open` | `boolean` | required | Dialog 開關狀態 |
+| `onOpenChange` | `(v: boolean) => void` | required | 開關 callback |
+| `mode` | `"create" \| "edit"` | `"create"` | 模式 |
+| `initialValues` | `Partial<SavedView>` | - | 編輯時帶入初始值 |
+| `onSave` | `(data: SavedViewFormData) => Promise<void>` | required | 儲存 callback（async） |
+
+### Form Fields
+
+| 欄位 | 元件 | 驗證 |
+|------|------|------|
+| 名稱 | `<Input>` | 必填，max 100 chars，錯誤顯示於欄位下方 |
+| 圖示 | Emoji quick select grid | optional，預設無 |
+| 範圍 | `<Select>`（disabled，固定 library） | Sprint 14 只有 library |
+
+#### Emoji Quick Select Grid
+
+- 預設選項：`📚 🔬 💡 ⚙️ 🎯 🗂️ 📝 🏷️ 🔖 ✨`
+- Grid：`grid-cols-5 gap-1.5`
+- 每格：`h-9 w-9` button，hover `bg-accent`，selected `bg-accent border border-ring`
+- 使用 emoji 本身顯示（not Lucide icon）—— emoji picker 是特例
+
+### Loading / Error
+
+- Save Button 按下後：`loading` state（spinner），disabled
+- 儲存失敗：Toast error 通知
+
+---
+
+## FilterBar（Library Toolbar Active View 顯示）
+
+Library toolbar 右側顯示目前 active view 的 chip，允許快速切換或 clear。
+
+```
+┌──────────────────────────────────────────────┐
+│ [SearchInput]  [Filter chips...]  [📚 My View ×] │
+└──────────────────────────────────────────────┘
+```
+
+### ActiveViewChip Props
+
+| Prop | Type | Default | 說明 |
+|------|------|---------|------|
+| `view` | `SavedView \| null` | `null` | 目前 active view |
+| `onClear` | `() => void` | - | 清除 active view |
+
+- 外觀：`<Badge variant="secondary">` + icon + name + X 按鈕
+- X 按鈕：`aria-label="Clear view filter"`，`hover:bg-accent`
+
+---
+
+## Drag-and-Drop（@dnd-kit/sortable）
+
+- 使用 `SortableContext` + `useSortable` hook
+- Drag handle：`GripVerticalIcon`
+- Drag overlay：clone 原始 chip，`shadow-lg`
+- 拖曳結束後觸發 `PATCH /api/v1/views/:id`（更新 position）
+- `keyboard` sensor 支援（空格拾起，方向鍵移動，Enter 放下）
+
+## Accessibility
+
+- 每個 chip：`role="button"` 或 `<button>`，`aria-pressed={isActive}`
+- Active：`aria-current="page"`
+- "..." trigger：`aria-label="View options for {view.name}"`
+- Drag handle：`aria-label="Drag to reorder {view.name}"`，`aria-roledescription="sortable"`
+- Dialog：`aria-labelledby` 指向 dialog title
+- Emoji grid：`role="radiogroup" aria-label="選擇圖示"`，每個 emoji `role="radio"`
+
+## 依賴元件
+
+- shadcn：`Button`, `Dialog`, `DropdownMenu`, `Input`, `Select`, `Badge`
+- @dnd-kit：`@dnd-kit/core`, `@dnd-kit/sortable`
+- Lucide：`GripVertical`, `MoreHorizontal`, `Pencil`, `Trash2`, `X`
+
+## 使用範例
+
+見 `saved-views-chip.example.tsx`

--- a/design/components/today-section-card.example.tsx
+++ b/design/components/today-section-card.example.tsx
@@ -1,0 +1,460 @@
+// TodaySectionCard 使用範例
+// Today Dashboard 的共用 section 容器 + 四個 section 特化
+
+import { formatDistanceToNow } from "date-fns";
+import { zhTW } from "date-fns/locale";
+import {
+  AlertCircle,
+  BookOpen,
+  Calendar,
+  CheckCircle,
+  CheckSquare,
+  Layers,
+  Pencil,
+  Plus,
+} from "lucide-react";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader } from "@/components/ui/card";
+import { Checkbox } from "@/components/ui/checkbox";
+import { Separator } from "@/components/ui/separator";
+import { cn } from "@/lib/utils";
+
+// --- Base SectionCard ---
+
+interface SectionCardProps {
+  id: string;
+  icon: React.ReactNode;
+  title: string;
+  badge?: React.ReactNode;
+  children: React.ReactNode;
+  isLoading?: boolean;
+  error?: Error | null;
+  onRetry?: () => void;
+  className?: string;
+}
+
+function SectionCard({
+  id,
+  icon,
+  title,
+  badge,
+  children,
+  isLoading = false,
+  error = null,
+  onRetry,
+  className,
+}: SectionCardProps) {
+  const headingId = `${id}-heading`;
+
+  return (
+    <Card
+      component="section"
+      aria-labelledby={headingId}
+      aria-busy={isLoading}
+      className={cn("shadow-sm", className)}
+    >
+      <CardHeader className="px-5 py-4 flex flex-row items-center gap-2">
+        <span className="text-muted-foreground" aria-hidden="true">{icon}</span>
+        <h2 id={headingId} className="text-sm font-semibold text-foreground flex-1">
+          {title}
+        </h2>
+        {badge}
+      </CardHeader>
+
+      <Separator />
+
+      <CardContent className="px-5 pb-5 pt-4">
+        {error ? (
+          <SectionErrorState error={error} onRetry={onRetry} />
+        ) : isLoading ? (
+          <SectionSkeleton />
+        ) : (
+          children
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+
+// --- Skeleton ---
+
+function SectionSkeleton() {
+  return (
+    <div className="space-y-2.5" aria-hidden="true">
+      {[1, 2, 3].map((i) => (
+        <div
+          key={i}
+          className={cn(
+            "h-4 rounded bg-muted animate-pulse",
+            i === 2 && "w-3/4",
+            i === 3 && "w-1/2"
+          )}
+        />
+      ))}
+    </div>
+  );
+}
+
+// --- Error State ---
+
+function SectionErrorState({ error, onRetry }: { error: Error; onRetry?: () => void }) {
+  return (
+    <div role="alert" className="flex flex-col items-center gap-2 py-4">
+      <AlertCircle className="h-8 w-8 text-destructive/60" aria-hidden="true" />
+      <p className="text-sm font-medium text-foreground">無法載入</p>
+      {error.message && (
+        <p className="text-xs text-muted-foreground text-center">{error.message}</p>
+      )}
+      {onRetry && (
+        <Button variant="outline" size="sm" onClick={onRetry}>
+          重試
+        </Button>
+      )}
+    </div>
+  );
+}
+
+// ============================================================
+// JournalSection
+// ============================================================
+
+interface JournalSectionProps {
+  journal?: { summary: string; updatedAt: string } | null;
+  isLoading?: boolean;
+  error?: Error | null;
+  onEdit?: () => void;
+  onCreateJournal?: () => void;
+  onRetry?: () => void;
+}
+
+export function JournalSection({
+  journal,
+  isLoading,
+  error,
+  onEdit,
+  onCreateJournal,
+  onRetry,
+}: JournalSectionProps) {
+  return (
+    <SectionCard
+      id="journal"
+      icon={<BookOpen className="h-4 w-4" />}
+      title="今日日記"
+      isLoading={isLoading}
+      error={error}
+      onRetry={onRetry}
+    >
+      {journal ? (
+        <div className="space-y-3">
+          <p className="text-sm text-foreground/80 line-clamp-3 leading-relaxed">
+            {journal.summary}
+          </p>
+          <div className="flex items-center justify-between">
+            <span className="text-xs text-muted-foreground">
+              {formatDistanceToNow(new Date(journal.updatedAt), {
+                addSuffix: true,
+                locale: zhTW,
+              })}
+            </span>
+            <Button variant="ghost" size="sm" onClick={onEdit} className="h-7 gap-1.5">
+              <Pencil className="h-3.5 w-3.5" />
+              編輯
+            </Button>
+          </div>
+        </div>
+      ) : (
+        <div className="flex flex-col items-center gap-3 py-4">
+          <BookOpen className="h-10 w-10 text-muted-foreground/40" aria-hidden="true" />
+          <p className="text-sm text-muted-foreground">今天還沒有日記</p>
+          <Button variant="default" size="sm" onClick={onCreateJournal} className="gap-1.5">
+            <Plus className="h-4 w-4" />
+            開始今日日記
+          </Button>
+        </div>
+      )}
+    </SectionCard>
+  );
+}
+
+// ============================================================
+// CalendarSection
+// ============================================================
+
+interface CalendarEvent {
+  id: string;
+  title: string;
+  startTime: string; // "HH:mm"
+  color?: string;
+}
+
+interface CalendarSectionProps {
+  events?: CalendarEvent[];
+  isLoading?: boolean;
+  error?: Error | null;
+  onRetry?: () => void;
+}
+
+export function CalendarSection({
+  events = [],
+  isLoading,
+  error,
+  onRetry,
+}: CalendarSectionProps) {
+  return (
+    <SectionCard
+      id="calendar"
+      icon={<Calendar className="h-4 w-4" />}
+      title="今日行程"
+      badge={
+        events.length > 0 ? (
+          <Badge variant="secondary" className="text-xs rounded-full">
+            {events.length}
+          </Badge>
+        ) : undefined
+      }
+      isLoading={isLoading}
+      error={error}
+      onRetry={onRetry}
+    >
+      {events.length === 0 ? (
+        <p className="text-sm text-muted-foreground text-center py-3">今日無行程</p>
+      ) : (
+        <ul className="space-y-3" aria-label="今日行程列表">
+          {events.map((event) => (
+            <li key={event.id} className="flex items-center gap-3">
+              <span className="text-xs text-muted-foreground tabular-nums w-10 shrink-0">
+                {event.startTime}
+              </span>
+              <span
+                className="h-2 w-2 rounded-full shrink-0"
+                style={{ backgroundColor: event.color ?? "hsl(var(--primary))" }}
+                aria-hidden="true"
+              />
+              <span className="text-sm text-foreground line-clamp-1">{event.title}</span>
+            </li>
+          ))}
+        </ul>
+      )}
+    </SectionCard>
+  );
+}
+
+// ============================================================
+// TaskSection
+// ============================================================
+
+interface Task {
+  id: string;
+  title: string;
+  priority: "high" | "medium" | "low";
+  isDone: boolean;
+}
+
+interface TaskSectionProps {
+  tasks?: Task[];
+  isLoading?: boolean;
+  error?: Error | null;
+  onToggleTask?: (id: string, done: boolean) => void;
+  onRetry?: () => void;
+}
+
+const priorityConfig = {
+  high: { label: "High", className: "bg-destructive/90 text-destructive-foreground text-xs" },
+  medium: { label: "Med", className: "bg-warning/20 text-amber-800 dark:text-amber-200 text-xs" },
+  low: { label: "Low", className: "text-muted-foreground border text-xs" },
+};
+
+export function TaskSection({
+  tasks = [],
+  isLoading,
+  error,
+  onToggleTask,
+  onRetry,
+}: TaskSectionProps) {
+  const pending = tasks.filter((t) => !t.isDone);
+  const done = tasks.filter((t) => t.isDone);
+
+  return (
+    <SectionCard
+      id="tasks"
+      icon={<CheckSquare className="h-4 w-4" />}
+      title="今日任務"
+      badge={
+        pending.length > 0 ? (
+          <Badge variant="secondary" className="text-xs rounded-full">
+            {pending.length}
+          </Badge>
+        ) : undefined
+      }
+      isLoading={isLoading}
+      error={error}
+      onRetry={onRetry}
+    >
+      {tasks.length === 0 ? (
+        <div className="flex flex-col items-center gap-2 py-4">
+          <CheckCircle className="h-8 w-8 text-green-500/60" aria-hidden="true" />
+          <p className="text-sm text-muted-foreground">今日無待辦事項</p>
+        </div>
+      ) : (
+        <ul className="space-y-2.5" aria-label="今日任務列表">
+          {[...pending, ...done].slice(0, 5).map((task) => (
+            <li key={task.id} className="flex items-center gap-3">
+              <Checkbox
+                checked={task.isDone}
+                aria-label={task.title}
+                onCheckedChange={(v) => onToggleTask?.(task.id, !!v)}
+                className="shrink-0"
+              />
+              <span
+                className={cn(
+                  "text-sm flex-1 line-clamp-1",
+                  task.isDone && "line-through text-muted-foreground"
+                )}
+              >
+                {task.title}
+              </span>
+              <Badge
+                variant={task.priority === "low" ? "outline" : "default"}
+                className={priorityConfig[task.priority].className}
+              >
+                {priorityConfig[task.priority].label}
+              </Badge>
+            </li>
+          ))}
+          {tasks.length > 5 && (
+            <li>
+              <Button variant="link" size="sm" className="h-auto p-0 text-xs">
+                查看全部 {tasks.length} 筆
+              </Button>
+            </li>
+          )}
+        </ul>
+      )}
+    </SectionCard>
+  );
+}
+
+// ============================================================
+// RecentEntriesSection
+// ============================================================
+
+interface RecentEntry {
+  id: string;
+  title: string;
+  updatedAt: string;
+}
+
+interface RecentEntriesSectionProps {
+  entries?: RecentEntry[];
+  isLoading?: boolean;
+  error?: Error | null;
+  onEntryClick?: (id: string) => void;
+  onRetry?: () => void;
+}
+
+export function RecentEntriesSection({
+  entries = [],
+  isLoading,
+  error,
+  onEntryClick,
+  onRetry,
+}: RecentEntriesSectionProps) {
+  return (
+    <SectionCard
+      id="recent-entries"
+      icon={<Layers className="h-4 w-4" />}
+      title="最近更新"
+      isLoading={isLoading}
+      error={error}
+      onRetry={onRetry}
+    >
+      {entries.length === 0 ? (
+        <p className="text-sm text-muted-foreground text-center py-3">
+          今日尚無新增或更新的項目
+        </p>
+      ) : (
+        <ul className="space-y-2.5" aria-label="最近更新項目">
+          {entries.slice(0, 5).map((entry) => (
+            <li
+              key={entry.id}
+              className="flex items-center gap-3 cursor-pointer hover:text-foreground group"
+              onClick={() => onEntryClick?.(entry.id)}
+              role="button"
+              tabIndex={0}
+              onKeyDown={(e) => e.key === "Enter" && onEntryClick?.(entry.id)}
+            >
+              <span className="text-sm font-medium line-clamp-1 flex-1 group-hover:underline">
+                {entry.title}
+              </span>
+              <span className="text-xs text-muted-foreground shrink-0">
+                {formatDistanceToNow(new Date(entry.updatedAt), {
+                  addSuffix: true,
+                  locale: zhTW,
+                })}
+              </span>
+            </li>
+          ))}
+        </ul>
+      )}
+    </SectionCard>
+  );
+}
+
+// ============================================================
+// Today Page 組合示範
+// ============================================================
+
+export function TodayPageDemo() {
+  return (
+    <div className="grid grid-cols-1 gap-4 lg:grid-cols-2">
+      <JournalSection
+        journal={{
+          summary: "今天完成了 Sprint 14 的設計工作，專注在 inbox 和 library 的視覺改善。",
+          updatedAt: new Date().toISOString(),
+        }}
+      />
+      <CalendarSection
+        events={[
+          { id: "1", title: "Morning standup", startTime: "09:00", color: "#4285f4" },
+          { id: "2", title: "Design review", startTime: "14:00", color: "#0f9d58" },
+        ]}
+      />
+      <TaskSection
+        tasks={[
+          { id: "1", title: "完成 sprint review", priority: "high", isDone: false },
+          { id: "2", title: "回覆客戶 email", priority: "low", isDone: true },
+        ]}
+      />
+      <RecentEntriesSection
+        entries={[
+          { id: "1", title: "React Server Components 最佳實踐", updatedAt: new Date().toISOString() },
+        ]}
+      />
+    </div>
+  );
+}
+
+// Loading state demo
+export function TodayPageLoadingDemo() {
+  return (
+    <div className="grid grid-cols-1 gap-4 lg:grid-cols-2">
+      <JournalSection isLoading />
+      <CalendarSection isLoading />
+      <TaskSection isLoading />
+      <RecentEntriesSection isLoading />
+    </div>
+  );
+}
+
+// Error state demo
+export function TodayPageErrorDemo() {
+  return (
+    <div className="grid grid-cols-1 gap-4 lg:grid-cols-2">
+      <JournalSection error={new Error("Network error")} onRetry={() => {}} />
+      <CalendarSection error={new Error("Google Calendar 連線失敗")} onRetry={() => {}} />
+      <TaskSection />
+      <RecentEntriesSection />
+    </div>
+  );
+}

--- a/design/components/today-section-card.md
+++ b/design/components/today-section-card.md
@@ -1,0 +1,217 @@
+# TodaySectionCard
+
+## 概述
+
+Today Dashboard 的共用 section 容器元件，以及四個 section 特化變體的規格。
+各 section 獨立 loading / error state，互不干擾（各自 Suspense boundary）。
+
+## 共用 Section 結構
+
+```
+┌────────────────────────────────────────┐
+│  [Icon] 標題               [badge]     │  ← Section Header
+├────────────────────────────────────────┤
+│                                        │
+│  [Content Area]                        │  ← Section Body
+│                                        │
+└────────────────────────────────────────┘
+```
+
+## SectionCard Props
+
+| Prop | Type | Default | 說明 |
+|------|------|---------|------|
+| `icon` | `ReactNode` | required | Lucide icon |
+| `title` | `string` | required | Section 標題 |
+| `badge` | `ReactNode` | - | 右側 badge（task count、event count） |
+| `children` | `ReactNode` | required | Section 內容 |
+| `isLoading` | `boolean` | `false` | Skeleton loading state |
+| `error` | `Error \| null` | `null` | Error boundary state |
+| `onRetry` | `() => void` | - | Error 時 Retry callback |
+| `className` | `string` | - | 自訂 className |
+
+## Section States
+
+### Loading State（Skeleton）
+
+```
+┌────────────────────────────────────────┐
+│  [Icon] 標題                            │
+├────────────────────────────────────────┤
+│  ████████████████████  (h-4, rounded)  │
+│  ██████████████        (h-4, rounded)  │
+│  ████████████████████  (h-4, rounded)  │
+└────────────────────────────────────────┘
+```
+
+- 三列 skeleton，使用 `animate-pulse bg-muted rounded`
+- 高度模擬對應 section 內容行高
+
+### Error State
+
+```
+┌────────────────────────────────────────┐
+│  [Icon] 標題                            │
+├────────────────────────────────────────┤
+│                                        │
+│  [AlertCircleIcon]                     │
+│  Could not load（標題）                 │
+│  （副文字：optional message）           │
+│  [Retry]（outline button）             │
+│                                        │
+└────────────────────────────────────────┘
+```
+
+- Icon：`AlertCircleIcon`，`text-destructive/60 h-8 w-8`
+- 標題：`text-sm font-medium text-foreground`
+- 說明：`text-xs text-muted-foreground`
+- Retry Button：`<Button variant="outline" size="sm">`
+
+### Empty State（各 Section 特化）
+
+見各 section 特化說明。
+
+## 樣式規格
+
+- 外框：`<Card>` 元件（shadcn），`shadow-sm`
+- Section header padding：`px-5 py-4`
+- Section body padding：`px-5 pb-5`
+- 兩者以 `<Separator>` 分隔（`hr className="border-border"`)
+- Icon 大小：`h-4 w-4`，顏色 `text-muted-foreground`
+- 標題：`text-sm font-semibold text-foreground`
+- Badge：`<Badge variant="secondary" className="text-xs rounded-full"`
+
+---
+
+## JournalSection 特化
+
+### 有日記時
+
+```
+┌─ [BookOpenIcon] 今日日記 ─────────────────┐
+│  日記摘要文字（最多 3 行截斷）              │
+│  更新時間（相對）                          │
+│                          [Edit]（ghost）  │
+└───────────────────────────────────────────┘
+```
+
+- 摘要：`text-sm text-foreground/80 line-clamp-3 leading-relaxed`
+- Edit CTA：`<Button variant="ghost" size="sm">`，右對齊
+- Edit icon：`PencilIcon`
+
+### 無日記時（Empty CTA）
+
+```
+┌─ [BookOpenIcon] 今日日記 ─────────────────┐
+│                                           │
+│    [BookOpenIcon]（large, muted）         │
+│    今天還沒有日記                          │
+│    [開始今日日記]（primary button）        │
+│                                           │
+└───────────────────────────────────────────┘
+```
+
+- CTA Button：`<Button variant="default" size="sm">`，icon `PlusIcon`
+
+---
+
+## CalendarSection 特化
+
+僅在 GCal 已連線時顯示。
+
+### 有 Events
+
+```
+┌─ [CalendarIcon] 今日行程  [3]（badge）───┐
+│                                         │
+│  09:00  [dot]  Morning standup          │
+│  14:00  [dot]  Design review            │
+│  17:00  [dot]  Team sync                │
+│                                         │
+└─────────────────────────────────────────┘
+```
+
+Event 列規格：
+- 時間：`text-xs text-muted-foreground tabular-nums w-10 shrink-0`
+- 顏色 dot：`h-2 w-2 rounded-full`，顏色來自 event calendar color
+- Title：`text-sm text-foreground line-clamp-1`
+- 每列間距：`gap-y-3`
+
+### 無 Events Empty State
+
+- 文字：「今日無行程」，`text-sm text-muted-foreground`，置中
+
+---
+
+## TaskSection 特化
+
+### 有 Tasks
+
+```
+┌─ [CheckSquareIcon] 今日任務  [2]（badge）─┐
+│                                          │
+│  [ ] 完成 sprint review          [High]  │
+│  [x] 回覆客戶 email               [Low]  │
+│  [ ] 更新文件                    [Med]   │
+│                                          │
+└──────────────────────────────────────────┘
+```
+
+Task 列規格：
+- Checkbox：`<Checkbox>`（shadcn），勾選觸發 API `PATCH /tasks/:id`
+- Title：`text-sm`，完成時 `line-through text-muted-foreground`
+- Priority Badge：
+  - `high` → `<Badge variant="destructive" className="text-xs">`
+  - `medium` → `<Badge className="bg-warning/20 text-warning-foreground text-xs">`
+  - `low` → `<Badge variant="outline" className="text-xs text-muted-foreground">`
+- 已完成 task 排後方顯示
+- 超過 5 筆顯示 "查看全部 {N} 筆" link
+
+### 無 Tasks Empty State
+
+- 文字：「今日無待辦事項」，icon `CheckCircleIcon`（success 色）
+
+---
+
+## RecentEntriesSection 特化
+
+### 有 Entries
+
+```
+┌─ [LayersIcon] 最近更新 ─────────────────┐
+│                                         │
+│  Entry Title 1            2 分鐘前      │
+│  Entry Title 2            1 小時前      │
+│  Entry Title 3            剛剛          │
+│                                         │
+└─────────────────────────────────────────┘
+```
+
+Entry 列規格：
+- Title：`text-sm font-medium line-clamp-1 flex-1`，可點擊開啟 Sheet
+- 時間：`text-xs text-muted-foreground shrink-0`（`formatDistanceToNow`）
+- 最多顯示 5 筆
+
+### 無 Entries Empty State
+
+- 文字：「今日尚無新增或更新的項目」
+
+---
+
+## Accessibility
+
+- `<section aria-labelledby="{section}-heading">`
+- heading：`<h2 id="{section}-heading">`
+- Error state：`role="alert"` 當 error 出現時
+- Loading：`aria-busy="true"` 於 section wrapper
+- Task checkbox：`aria-label="{task.title}"`
+
+## 依賴元件
+
+- shadcn：`Card`, `Badge`, `Button`, `Checkbox`, `Separator`
+- Lucide：`BookOpen`, `Calendar`, `CheckSquare`, `Layers`, `AlertCircle`, `Pencil`, `Plus`, `CheckCircle`
+- date-fns：`formatDistanceToNow`
+
+## 使用範例
+
+見 `today-section-card.example.tsx`

--- a/design/pages/f040-inbox-triage.md
+++ b/design/pages/f040-inbox-triage.md
@@ -1,0 +1,111 @@
+# Inbox Triage Page（Sprint 14）
+
+## 對應 Feature
+
+#206 F-040: Inbox Triage View
+
+## 路由
+
+`/dashboard/inbox`
+
+## 版型
+
+```
+┌────────────────────────────────────────────────────────────────┐
+│  App Shell Navbar (h-14)                                       │
+├──────────┬─────────────────────────────┬───────────────────────┤
+│ Sidebar  │  InboxToolbar (sticky h-14) │                       │
+│ (w-60)   ├─────────────────────────────┤  EntryPreviewPane     │
+│          │  InboxList (virtualized)    │  (w-80, collapsible)  │
+│ [All]    │                             │                       │
+│ [Inbox]*─┤  [InboxCard]               │  Entry 標題            │
+│ ─────    │  [InboxCard active]         │  Entry 正文摘要        │
+│ [Views]  │  [InboxCard selected]       │  Tags / Metadata      │
+│          │  [InboxCard loading]        │  ─────────────────    │
+│          │  ...                        │  [Archive] [Library]  │
+│          │                             │  [Classify] [Delete]  │
+│          │                             │                       │
+│          ├─────────────────────────────┴───────────────────────┤
+│          │  InboxActionBar (sticky bottom, 選取時顯示, h-14)   │
+└──────────┴─────────────────────────────────────────────────────┘
+```
+
+## 區塊規格
+
+### InboxToolbar
+
+- 高度：`h-14`，`sticky top-0 z-10`
+- 背景：`bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/60`
+- 邊框：`border-b border-border`
+- 左側：Tabs（`全部` / `未分類` / `今日`）— shadcn `<Tabs>`
+- 右側：
+  - 全選 Checkbox（`aria-label="Select all"`）
+  - Entry count badge
+  - Sort dropdown（建立時間 / 更新時間 asc/desc）
+  - Preview toggle（`PanelRightCloseIcon` / `PanelRightOpenIcon`）
+
+### InboxList
+
+- 容器：`flex-1 overflow-hidden`
+- 虛擬化：`@tanstack/react-virtual`，容器高度 `calc(100vh - 56px - 56px - 56px)`
+- padding：`px-3 py-2`，items 間距 `gap-1`
+- 鍵盤支援：J 下 / K 上 / A Archive / D Delete / E Edit / Enter 展開 Preview
+
+### EntryPreviewPane
+
+- 寬度：`w-80 shrink-0`（fixed，不隨 list resize）
+- 收合：`w-0 overflow-hidden transition-all duration-200`
+- 內容：
+  - Sticky header：entry title + close button
+  - Body：正文（markdown render）
+  - Metadata bar：source / tags / created_at / classification status
+  - Action buttons：Archive / Move to Library / Classify / Delete
+- Mobile：改為 shadcn `<Sheet>` 從右側 slide-in
+
+### InboxActionBar（批次操作）
+
+- 顯示條件：`selectedCount > 0`
+- 高度：`h-14`，`sticky bottom-0`
+- 背景：`bg-background border-t border-border`
+- 動畫：`animate-in slide-in-from-bottom duration-200`
+- 內容：已選 {N} 筆 + [Archive] [Library] [Classify] [Delete（destructive）]
+
+## States
+
+| State | 呈現方式 |
+|-------|---------|
+| Loading（首次） | `InboxCard` skeleton × 5 |
+| Empty | `InboxIcon`（large, muted）+ "Inbox 清空了" + 說明文字 |
+| Error | `AlertCircleIcon` + "載入失敗" + [Retry] |
+| Loading More | 底部 `LoaderCircle` spinner |
+
+## URL 同步
+
+- `?filter=all|unclassified|today`（Tabs 狀態）
+- `?entry={id}`（開啟 PreviewPane）
+- `?sort=created_at|updated_at&dir=asc|desc`
+
+## 響應式
+
+| 斷點 | 版型變化 |
+|------|---------|
+| >= 1024px | 三欄（Sidebar + List + Preview） |
+| 768–1023px | Sidebar 收合按鈕，Preview = Sheet |
+| < 768px | 只有 List，Preview = 全螢幕 Sheet；Sidebar = 漢堡 |
+
+## Accessibility
+
+- `<main aria-label="Inbox">`
+- 列表：`role="list" aria-label="Inbox 項目"`（共 {N} 筆）
+- 工具列：`role="toolbar" aria-label="Inbox 篩選"`
+- ActionBar：`role="toolbar" aria-label="批次操作"`，`aria-live="polite"` 宣告選取數量
+
+## 使用的元件
+
+| 元件 | 規格來源 |
+|------|---------|
+| `InboxCard` | `design/components/inbox-card.md` |
+| `SavedViewsList` | `design/components/saved-views-chip.md` |
+| `Tabs` | shadcn |
+| `Sheet`（mobile preview） | shadcn |
+| `Button` | shadcn |

--- a/design/pages/f041-library.md
+++ b/design/pages/f041-library.md
@@ -1,0 +1,117 @@
+# Library Page（Sprint 14）
+
+## 對應 Feature
+
+#207 F-041: Library Table View
+
+## 路由
+
+`/library`
+
+## 版型
+
+```
+┌────────────────────────────────────────────────────────────────┐
+│  App Shell Navbar (h-14)                                       │
+├──────────┬─────────────────────────────────────────────────────┤
+│ Sidebar  │  LibraryToolbar (sticky h-14)                       │
+│ (w-60)   │  [Search]  [Filters...]  [Sort ▼]  [View ▼][View*] │
+│          ├─────────────────────────────────────────────────────┤
+│ [All]*   │  BatchToolbar (sticky h-10, 選取時浮現)             │
+│ [Inbox]  ├─────────────────────────────────────────────────────┤
+│ ─────    │  LibraryTable                                       │
+│ [Views]  │  ┌──┬──────────┬──────┬──────┬─────┬──────┬─────┐  │
+│          │  │☐ │ 標題 ↕  │ 分類 │ 標籤 │ 狀態│ 信度│ 時間│  │
+│          │  ├──┼──────────┼──────┼──────┼─────┼──────┼─────┤  │
+│          │  │☐ │ Title 1  │ cat  │ tags │ lib │  87 │ 3d  │  │
+│          │  │☐ │ Title 2  │ cat  │ tags │ lib │  52 │ 1h  │  │
+│          │  │  │ ...      │      │      │     │     │     │  │
+│          │  └──┴──────────┴──────┴──────┴─────┴──────┴─────┘  │
+│          │  (virtualized scroll)                               │
+└──────────┴─────────────────────────────────────────────────────┘
+```
+
+## 區塊規格
+
+### LibraryToolbar
+
+- 高度：`h-14`，`sticky top-0 z-10`
+- 背景：`bg-background/95 backdrop-blur`，`border-b border-border`
+- 左側：`SearchInput`（`w-64` desktop，`w-full` mobile）
+- 中間：FilterBar chips（status / category / tags / date range）
+- 右側：
+  - Sort Dropdown（建立時間 / 更新時間 / 標題 / 可信度）
+  - View Toggle（Table / Card）
+  - `ActiveViewChip`（若有 active saved view）
+
+### BatchToolbar
+
+- 顯示條件：`selectedCount > 0`，`sticky top-14 z-10`（toolbar 下方）
+- 高度：`h-10`
+- 動畫：`animate-in slide-in-from-top duration-200`
+- 內容：已選 {N} 筆 × + [Archive] [Library] [Delete]
+- 參考：`design/components/library-table-chrome.md` BatchToolbar
+
+### LibraryTable
+
+- 容器：`flex-1 overflow-hidden`，高度 `calc(100vh - 56px - [batch 40px?] - 8px)`
+- 欄位：checkbox | title | category | tags | status | confidence | updatedAt | actions
+- 虛擬化：`@tanstack/react-virtual`，row 高度 52px，overscan 5
+- Row 點擊：開啟 `EntryDetailSheet`（shadcn Sheet 從右側滑出）
+- Empty state：`InboxIcon` + "找不到符合條件的項目" + [重置篩選]
+- 欄位 header / row / empty state 完整規格：`design/components/library-table-chrome.md`
+
+### EntryDetailSheet
+
+- shadcn `<Sheet side="right">`
+- 寬度：`w-[480px]`（desktop），`w-full`（mobile）
+- 內容：完整 entry 標題 + 正文 + metadata + edit / archive / delete actions
+
+### FilterBar（inline chips）
+
+- 每個篩選條件顯示為 `<Badge variant="secondary">` + X 清除
+- 加號按鈕展開 Filter Popover（status / category / tags / date range）
+- URL params 同步：`?status=library&category_id=xxx&tags=a,b&q=keyword`
+
+## States
+
+| State | 呈現方式 |
+|-------|---------|
+| Loading（首次） | 5 列 row skeleton（`animate-pulse`） |
+| Empty（無過濾） | `InboxIcon` + "Library 空空如也" + 引導文字 |
+| Empty（有過濾） | `InboxIcon` + "找不到符合條件的項目" + [重置篩選] |
+| Error | `AlertCircleIcon` + "載入失敗" + [Retry] |
+
+## URL 同步
+
+- `?q=keyword`（搜尋）
+- `?status=library,inbox`
+- `?category_id=uuid`
+- `?tags=tag1,tag2`
+- `?sort_by=updated_at&sort_dir=desc`
+- `?view={view_id}`（active saved view）
+- `?entry={id}`（開啟 Sheet）
+
+## 響應式
+
+| 斷點 | 版型變化 |
+|------|---------|
+| >= 1024px | Sidebar + Table 全寬，Sheet 側開 |
+| 768–1023px | Sidebar 收合，標籤欄位隱藏 |
+| < 768px | Card view（Table 切換為 Card 列表）；Sidebar 漢堡 |
+
+## Accessibility
+
+- `<main aria-label="Library">`
+- 參考 `design/components/library-table-chrome.md` 表格 accessibility 規格
+- FilterBar：`role="search" aria-label="篩選條件"`
+
+## 使用的元件
+
+| 元件 | 規格來源 |
+|------|---------|
+| `LibraryTableChrome` | `design/components/library-table-chrome.md` |
+| `SavedViewsList` / `ActiveViewChip` | `design/components/saved-views-chip.md` |
+| `Sheet` | shadcn |
+| `Button` | shadcn |
+| `Badge` | shadcn |

--- a/design/pages/f042-today.md
+++ b/design/pages/f042-today.md
@@ -1,0 +1,108 @@
+# Today Dashboard Page（Sprint 14）
+
+## 對應 Feature
+
+#208 F-042: Today Dashboard
+
+## 路由
+
+`/today`
+
+## 版型
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│  App Shell Navbar (h-14)                                    │
+├──────────┬──────────────────────────────────────────────────┤
+│ Sidebar  │  TodayHeader (h-20)                              │
+│ (w-60)   │  今天，2026年4月28日 星期二     [早安，用戶名稱]  │
+│          ├──────────────────────────────────────────────────┤
+│ [All]    │  2-column grid (lg) / 1-column (sm)              │
+│ [Inbox]  │                                                  │
+│ [Today]* │  ┌─────────────────────┐ ┌───────────────────┐  │
+│ ─────    │  │ JournalSection      │ │ CalendarSection   │  │
+│ [Views]  │  │                     │ │                   │  │
+│          │  │ 今日日記摘要...      │ │ 09:00 standup     │  │
+│          │  │                     │ │ 14:00 review      │  │
+│          │  │ [Edit]              │ │                   │  │
+│          │  └─────────────────────┘ └───────────────────┘  │
+│          │                                                  │
+│          │  ┌─────────────────────┐ ┌───────────────────┐  │
+│          │  │ TaskSection    [2]  │ │ RecentEntries     │  │
+│          │  │                     │ │                   │  │
+│          │  │ [ ] 完成 review     │ │ RSC 最佳實踐  2m   │  │
+│          │  │ [x] 回覆 email      │ │ 設計系統  1h      │  │
+│          │  │                     │ │                   │  │
+│          │  └─────────────────────┘ └───────────────────┘  │
+│          │                                                  │
+└──────────┴──────────────────────────────────────────────────┘
+```
+
+## 區塊規格
+
+### TodayHeader
+
+- 高度：`h-20`，padding `px-6 py-4`
+- 左側：
+  - 日期：`text-2xl font-semibold`（e.g. "今天，2026 年 4 月 28 日"）
+  - 星期：`text-sm text-muted-foreground`
+- 右側：
+  - 問候語：`text-sm text-muted-foreground`（早上好 / 午安 / 晚安，根據時段）
+- 邊框：`border-b border-border`
+
+### Section Grid
+
+- 版型：`grid grid-cols-1 gap-4 lg:grid-cols-2`
+- Section 順序（固定）：Journal、Calendar、Tasks、RecentEntries
+- CalendarSection：僅在 GCal 連線時渲染；無 GCal 時 grid 變為單欄全寬 journal + 右側兩個 section 堆疊
+
+### 各 Section Card
+
+完整規格見 `design/components/today-section-card.md`
+
+| Section | 資料來源 | empty state |
+|---------|---------|-------------|
+| JournalSection | GET /api/v1/journal/:date | CreateJournal CTA |
+| CalendarSection | GET /api/v1/calendar/days/:date | "今日無行程" |
+| TaskSection | GET /api/v1/tasks?due_date=today | CheckCircle + "今日無待辦" |
+| RecentEntriesSection | GET /api/v1/entries?updated_since | "今日尚無更新" |
+
+### 各 Section Suspense Boundary
+
+每個 section 都有獨立 `<Suspense>` + error boundary：
+- Loading：`isLoading` skeleton（3 行 animate-pulse）
+- Error：`AlertCircleIcon` + "無法載入" + [重試]
+- 單一 section 失敗不影響其他 section 渲染
+
+## States（整頁）
+
+| State | 呈現方式 |
+|-------|---------|
+| 首次載入 | 4 個 section 同時顯示 skeleton |
+| 部分失敗 | 失敗的 section 顯示 error state，其他正常 |
+| GCal 未連線 | CalendarSection 直接不渲染（非 error） |
+
+## 響應式
+
+| 斷點 | 版型變化 |
+|------|---------|
+| >= 1024px | 2-column grid |
+| < 1024px | 1-column stack |
+| < 768px | Sidebar 漢堡；Header 縮小至 h-14 |
+
+## Accessibility
+
+- `<main aria-label="Today Dashboard">`
+- TodayHeader：`<header>`
+- 日期：`<time dateTime="2026-04-28">`
+- Section 使用 `<section aria-labelledby>` 參考 `today-section-card.md`
+
+## 使用的元件
+
+| 元件 | 規格來源 |
+|------|---------|
+| `JournalSection` | `design/components/today-section-card.md` |
+| `CalendarSection` | `design/components/today-section-card.md` |
+| `TaskSection` | `design/components/today-section-card.md` |
+| `RecentEntriesSection` | `design/components/today-section-card.md` |
+| `SavedViewsList` | `design/components/saved-views-chip.md` |


### PR DESCRIPTION
## Summary

Sprint 14 UI Component Dataset，供前端 engineer 實作 F-040~F-043 使用。

- **InboxCard**：5 種狀態（default/active/selected/loading/hover），批次操作 action buttons，keyboard J/K 支援
- **LibraryTableChrome**：TanStack Table v8 chrome，sticky batch toolbar，virtualized scroll，empty state，row kebab menu
- **TodaySectionCard**：共用 SectionCard 容器（skeleton/error/empty states）+ JournalSection / CalendarSection / TaskSection / RecentEntriesSection 四個特化
- **SavedViewsChip**：system/user chip，@dnd-kit drag-and-drop 重排，SavedViewDialog（emoji picker + form validation），ActiveViewChip for FilterBar

## Pages

| 頁面 | Layout 規格 |
|------|------------|
| Inbox Triage | `design/pages/f040-inbox-triage.md` |
| Library | `design/pages/f041-library.md` |
| Today Dashboard | `design/pages/f042-today.md` |

## Components

| 元件 | Spec | Example |
|------|------|---------|
| InboxCard | `design/components/inbox-card.md` | inbox-card.example.tsx |
| LibraryTableChrome | `design/components/library-table-chrome.md` | library-table-chrome.example.tsx |
| TodaySectionCard | `design/components/today-section-card.md` | today-section-card.example.tsx |
| SavedViewsChip | `design/components/saved-views-chip.md` | saved-views-chip.example.tsx |

## Checklist

- [x] 無 emoji icon（全部使用 Lucide icons，SavedViewDialog emoji picker 為特例）
- [x] 44×44pt 觸控目標（checkbox / action buttons）
- [x] WCAG AA focus ring（`focus-visible:ring-2 focus-visible:ring-ring`）
- [x] ARIA labels、roles、aria-current、aria-busy
- [x] 鍵盤 nav 支援（Tab / Enter / Space / J / K）
- [x] Mobile-first 響應式斷點規格
- [x] Semantic color tokens（無寫死色碼）
- [x] Loading / Error / Empty states 完整
- [x] 動畫 150-300ms，transform/opacity only

Closes #210