### PR TITLE
feat: F-043 Saved Views (backend + migration)

### DIFF
--- a/dev/src/dto/view.go
+++ b/dev/src/dto/view.go
@@ -1,0 +1,54 @@
+package dto
+
+import (
+	"encoding/json"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// CreateViewRequest 建立 saved view 請求
+type CreateViewRequest struct {
+	Name    string          `json:"name" binding:"required"`
+	Scope   string          `json:"scope"`
+	Filters json.RawMessage `json:"filters"`
+	SortBy  *string         `json:"sort_by"`
+	SortDir *string         `json:"sort_dir"`
+	Icon    *string         `json:"icon"`
+	Position *int           `json:"position"`
+}
+
+// UpdateViewRequest 更新 saved view 請求（所有欄位可選）
+type UpdateViewRequest struct {
+	Name    *string         `json:"name"`
+	Scope   *string         `json:"scope"`
+	Filters json.RawMessage `json:"filters"`
+	SortBy  *string         `json:"sort_by"`
+	SortDir *string         `json:"sort_dir"`
+	Icon    *string         `json:"icon"`
+	Position *int           `json:"position"`
+}
+
+// ReorderViewsRequest 重新排序請求
+type ReorderViewsRequest struct {
+	IDs []uuid.UUID `json:"ids" binding:"required"`
+}
+
+// ViewResponse saved view 回應
+type ViewResponse struct {
+	ID        uuid.UUID       `json:"id"`
+	Name      string          `json:"name"`
+	Scope     string          `json:"scope"`
+	Filters   json.RawMessage `json:"filters"`
+	SortBy    *string         `json:"sort_by"`
+	SortDir   *string         `json:"sort_dir"`
+	Icon      *string         `json:"icon"`
+	Position  int             `json:"position"`
+	CreatedAt time.Time       `json:"created_at"`
+	UpdatedAt time.Time       `json:"updated_at"`
+}
+
+// ReorderViewsResponse 重排回應
+type ReorderViewsResponse struct {
+	Updated int `json:"updated"`
+}

--- a/dev/src/handler/view.go
+++ b/dev/src/handler/view.go
@@ -1,0 +1,171 @@
+package handler
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+	"github.com/gpwork4u/aibo/dto"
+	"github.com/gpwork4u/aibo/model"
+	"github.com/gpwork4u/aibo/service"
+)
+
+// ViewHandler saved views HTTP handlers
+type ViewHandler struct {
+	svc *service.ViewService
+}
+
+// NewViewHandler 建立新的 ViewHandler
+func NewViewHandler(svc *service.ViewService) *ViewHandler {
+	return &ViewHandler{svc: svc}
+}
+
+// List 列出所有 saved views
+// GET /api/v1/views
+func (h *ViewHandler) List(c *gin.Context) {
+	views, err := h.svc.List(c.Request.Context())
+	if err != nil {
+		handleViewError(c, err)
+		return
+	}
+
+	resp := make([]dto.ViewResponse, 0, len(views))
+	for _, v := range views {
+		resp = append(resp, toViewResponse(v))
+	}
+	c.JSON(http.StatusOK, resp)
+}
+
+// Create 建立新 saved view
+// POST /api/v1/views
+func (h *ViewHandler) Create(c *gin.Context) {
+	var req dto.CreateViewRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, dto.ErrorResponse{
+			Code:    model.ErrCodeInvalidInput,
+			Message: "請求格式錯誤: " + err.Error(),
+		})
+		return
+	}
+
+	v, err := h.svc.Create(c.Request.Context(), req)
+	if err != nil {
+		handleViewError(c, err)
+		return
+	}
+
+	c.JSON(http.StatusCreated, toViewResponse(v))
+}
+
+// Update 部分更新 saved view
+// PATCH /api/v1/views/:id
+func (h *ViewHandler) Update(c *gin.Context) {
+	id, err := parseViewUUID(c)
+	if err != nil {
+		return
+	}
+
+	var req dto.UpdateViewRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, dto.ErrorResponse{
+			Code:    model.ErrCodeInvalidInput,
+			Message: "請求格式錯誤: " + err.Error(),
+		})
+		return
+	}
+
+	v, err := h.svc.Update(c.Request.Context(), id, req)
+	if err != nil {
+		handleViewError(c, err)
+		return
+	}
+
+	c.JSON(http.StatusOK, toViewResponse(v))
+}
+
+// Delete 刪除 saved view
+// DELETE /api/v1/views/:id
+func (h *ViewHandler) Delete(c *gin.Context) {
+	id, err := parseViewUUID(c)
+	if err != nil {
+		return
+	}
+
+	if err := h.svc.Delete(c.Request.Context(), id); err != nil {
+		handleViewError(c, err)
+		return
+	}
+
+	c.Status(http.StatusNoContent)
+}
+
+// Reorder 批次更新 position
+// PATCH /api/v1/views/reorder
+func (h *ViewHandler) Reorder(c *gin.Context) {
+	var req dto.ReorderViewsRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, dto.ErrorResponse{
+			Code:    model.ErrCodeInvalidInput,
+			Message: "請求格式錯誤: " + err.Error(),
+		})
+		return
+	}
+
+	updated, err := h.svc.Reorder(c.Request.Context(), req.IDs)
+	if err != nil {
+		handleViewError(c, err)
+		return
+	}
+
+	c.JSON(http.StatusOK, dto.ReorderViewsResponse{Updated: updated})
+}
+
+// toViewResponse 將 model.SavedView 轉換為 dto.ViewResponse
+func toViewResponse(v *model.SavedView) dto.ViewResponse {
+	filters := v.Filters
+	if len(filters) == 0 {
+		filters = json.RawMessage("{}")
+	}
+	return dto.ViewResponse{
+		ID:        v.ID,
+		Name:      v.Name,
+		Scope:     v.Scope,
+		Filters:   filters,
+		SortBy:    v.SortBy,
+		SortDir:   v.SortDir,
+		Icon:      v.Icon,
+		Position:  v.Position,
+		CreatedAt: v.CreatedAt,
+		UpdatedAt: v.UpdatedAt,
+	}
+}
+
+// parseViewUUID 從 URL 參數解析 UUID
+func parseViewUUID(c *gin.Context) (uuid.UUID, error) {
+	idStr := c.Param("id")
+	id, err := uuid.Parse(idStr)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, dto.ErrorResponse{
+			Code:    model.ErrCodeInvalidInput,
+			Message: "無效的 ID 格式",
+		})
+		return uuid.Nil, err
+	}
+	return id, nil
+}
+
+// handleViewError 處理 view 相關錯誤
+func handleViewError(c *gin.Context, err error) {
+	if appErr, ok := err.(*model.AppError); ok {
+		c.JSON(appErr.Status, dto.ErrorResponse{
+			Code:    appErr.Code,
+			Message: appErr.Message,
+		})
+		return
+	}
+	c.JSON(http.StatusInternalServerError, dto.ErrorResponse{
+		Code:    "INTERNAL_ERROR",
+		Message: "伺服器內部錯誤",
+	})
+}

--- a/dev/src/main.go
+++ b/dev/src/main.go
@@ -162,8 +162,13 @@ func main() {
 	taskSvc := service.NewTaskService(taskRepo, projectRepo, entryRepo, journalRepo, projectSvc)
 	taskHandler := handler.NewTaskHandler(taskSvc, projectSvc)
 
+	// 初始化 Saved Views 服務（F-043）
+	viewRepo := repository.NewViewRepository(pool)
+	viewSvc := service.NewViewService(viewRepo)
+	viewHandler := handler.NewViewHandler(viewSvc)
+
 	// 設定路由
-	r := router.Setup(pool, apiKeySvc, apiKeyHandler, categoryHandler, llmProviderHandler, entryHandler, classifyHandler, searchHandler, gitImportHandler, gcalHandler, confidenceHandler, statsHandler, systemHandler, lifecycleHandler, calendarConvertHandler, calendarHandler, journalHandler, journalDraftHandler, journalAutoHandler, projectHandler, taskHandler, githubIntegrationHandler, githubCommitsHandler)
+	r := router.Setup(pool, apiKeySvc, apiKeyHandler, categoryHandler, llmProviderHandler, entryHandler, classifyHandler, searchHandler, gitImportHandler, gcalHandler, confidenceHandler, statsHandler, systemHandler, lifecycleHandler, calendarConvertHandler, calendarHandler, journalHandler, journalDraftHandler, journalAutoHandler, projectHandler, taskHandler, githubIntegrationHandler, githubCommitsHandler, viewHandler)
 
 	// 啟動 HTTP server（graceful shutdown）
 	srv := &http.Server{

--- a/dev/src/migration/018_create_saved_views.down.sql
+++ b/dev/src/migration/018_create_saved_views.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS saved_views;

--- a/dev/src/migration/018_create_saved_views.up.sql
+++ b/dev/src/migration/018_create_saved_views.up.sql
@@ -1,0 +1,19 @@
+CREATE TABLE saved_views (
+  id          UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  name        VARCHAR(100) NOT NULL,
+  scope       VARCHAR(20) NOT NULL DEFAULT 'library',
+  filters     JSONB NOT NULL DEFAULT '{}',
+  sort_by     VARCHAR(50),
+  sort_dir    VARCHAR(4) DEFAULT 'desc',
+  icon        VARCHAR(50),
+  position    INTEGER NOT NULL DEFAULT 0,
+  created_at  TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at  TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+-- 大小寫不敏感的唯一約束（同 scope 下 name 不重複）
+CREATE UNIQUE INDEX idx_saved_views_name_scope_lower
+  ON saved_views (LOWER(name), scope);
+
+-- 排序用 index
+CREATE INDEX idx_saved_views_position ON saved_views (position ASC);

--- a/dev/src/model/saved_view.go
+++ b/dev/src/model/saved_view.go
@@ -1,0 +1,28 @@
+package model
+
+import (
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// SavedView 已儲存的篩選視圖
+type SavedView struct {
+	ID        uuid.UUID `json:"id"`
+	Name      string    `json:"name"`
+	Scope     string    `json:"scope"`
+	Filters   []byte    `json:"filters"` // raw JSONB
+	SortBy    *string   `json:"sort_by"`
+	SortDir   *string   `json:"sort_dir"`
+	Icon      *string   `json:"icon"`
+	Position  int       `json:"position"`
+	CreatedAt time.Time `json:"created_at"`
+	UpdatedAt time.Time `json:"updated_at"`
+}
+
+// 錯誤碼
+const (
+	ErrCodeDuplicateView = "DUPLICATE"
+	ErrCodeViewLimitExceeded = "LIMIT_EXCEEDED"
+	ErrCodeViewNotFound  = "VIEW_NOT_FOUND"
+)

--- a/dev/src/repository/view.go
+++ b/dev/src/repository/view.go
@@ -1,0 +1,142 @@
+package repository
+
+import (
+	"context"
+	"errors"
+	"strings"
+
+	"github.com/google/uuid"
+	"github.com/gpwork4u/aibo/model"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+// ViewRepository saved_views 資料庫操作
+type ViewRepository struct {
+	pool *pgxpool.Pool
+}
+
+// NewViewRepository 建立新的 ViewRepository
+func NewViewRepository(pool *pgxpool.Pool) *ViewRepository {
+	return &ViewRepository{pool: pool}
+}
+
+// FindAll 列出所有 saved views，依 position 排序
+func (r *ViewRepository) FindAll(ctx context.Context) ([]*model.SavedView, error) {
+	rows, err := r.pool.Query(ctx,
+		`SELECT id, name, scope, filters, sort_by, sort_dir, icon, position, created_at, updated_at
+		 FROM saved_views
+		 ORDER BY position ASC, created_at ASC`,
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var views []*model.SavedView
+	for rows.Next() {
+		v := &model.SavedView{}
+		if err := rows.Scan(
+			&v.ID, &v.Name, &v.Scope, &v.Filters,
+			&v.SortBy, &v.SortDir, &v.Icon, &v.Position,
+			&v.CreatedAt, &v.UpdatedAt,
+		); err != nil {
+			return nil, err
+		}
+		views = append(views, v)
+	}
+	return views, rows.Err()
+}
+
+// FindByID 透過 ID 查找
+func (r *ViewRepository) FindByID(ctx context.Context, id uuid.UUID) (*model.SavedView, error) {
+	v := &model.SavedView{}
+	err := r.pool.QueryRow(ctx,
+		`SELECT id, name, scope, filters, sort_by, sort_dir, icon, position, created_at, updated_at
+		 FROM saved_views WHERE id = $1`,
+		id,
+	).Scan(
+		&v.ID, &v.Name, &v.Scope, &v.Filters,
+		&v.SortBy, &v.SortDir, &v.Icon, &v.Position,
+		&v.CreatedAt, &v.UpdatedAt,
+	)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return nil, nil
+	}
+	return v, err
+}
+
+// Count 回傳目前 view 數量
+func (r *ViewRepository) Count(ctx context.Context) (int, error) {
+	var n int
+	err := r.pool.QueryRow(ctx, `SELECT COUNT(*) FROM saved_views`).Scan(&n)
+	return n, err
+}
+
+// MaxPosition 取得目前最大 position
+func (r *ViewRepository) MaxPosition(ctx context.Context) (int, error) {
+	var pos int
+	err := r.pool.QueryRow(ctx, `SELECT COALESCE(MAX(position), -1) FROM saved_views`).Scan(&pos)
+	return pos, err
+}
+
+// Create 建立新 saved view
+func (r *ViewRepository) Create(ctx context.Context, v *model.SavedView) error {
+	_, err := r.pool.Exec(ctx,
+		`INSERT INTO saved_views (id, name, scope, filters, sort_by, sort_dir, icon, position, created_at, updated_at)
+		 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)`,
+		v.ID, v.Name, v.Scope, v.Filters, v.SortBy, v.SortDir, v.Icon,
+		v.Position, v.CreatedAt, v.UpdatedAt,
+	)
+	if err != nil && strings.Contains(err.Error(), "idx_saved_views_name_scope_lower") {
+		return model.NewAppError(409, model.ErrCodeDuplicateView, "相同 scope 下已有同名的 view")
+	}
+	return err
+}
+
+// Update 更新 saved view
+func (r *ViewRepository) Update(ctx context.Context, v *model.SavedView) error {
+	_, err := r.pool.Exec(ctx,
+		`UPDATE saved_views
+		 SET name=$1, scope=$2, filters=$3, sort_by=$4, sort_dir=$5, icon=$6, position=$7, updated_at=$8
+		 WHERE id=$9`,
+		v.Name, v.Scope, v.Filters, v.SortBy, v.SortDir, v.Icon,
+		v.Position, v.UpdatedAt, v.ID,
+	)
+	if err != nil && strings.Contains(err.Error(), "idx_saved_views_name_scope_lower") {
+		return model.NewAppError(409, model.ErrCodeDuplicateView, "相同 scope 下已有同名的 view")
+	}
+	return err
+}
+
+// Delete 刪除 saved view
+func (r *ViewRepository) Delete(ctx context.Context, id uuid.UUID) error {
+	_, err := r.pool.Exec(ctx, `DELETE FROM saved_views WHERE id=$1`, id)
+	return err
+}
+
+// Reorder 批次更新 position（ids 的順序即新順序）
+func (r *ViewRepository) Reorder(ctx context.Context, ids []uuid.UUID) (int, error) {
+	tx, err := r.pool.Begin(ctx)
+	if err != nil {
+		return 0, err
+	}
+	defer tx.Rollback(ctx) //nolint:errcheck
+
+	updated := 0
+	for i, id := range ids {
+		tag, err := tx.Exec(ctx,
+			`UPDATE saved_views SET position=$1, updated_at=NOW() WHERE id=$2`,
+			i, id,
+		)
+		if err != nil {
+			return 0, err
+		}
+		updated += int(tag.RowsAffected())
+	}
+
+	if err := tx.Commit(ctx); err != nil {
+		return 0, err
+	}
+	return updated, nil
+}

--- a/dev/src/router/router.go
+++ b/dev/src/router/router.go
@@ -12,7 +12,7 @@ import (
 )
 
 // Setup 設定路由
-func Setup(pool *pgxpool.Pool, apiKeySvc *service.ApiKeyService, apiKeyHandler *handler.ApiKeyHandler, categoryHandler *handler.CategoryHandler, llmProviderHandler *handler.LlmProviderHandler, entryHandler *handler.EntryHandler, classifyHandler *handler.ClassifyHandler, searchHandler *handler.SearchHandler, gitImportHandler *handler.GitImportHandler, gcalHandler *handler.GcalHandler, confidenceHandler *handler.ConfidenceHandler, statsHandler *handler.StatsHandler, systemHandler *handler.SystemHandler, lifecycleHandler *handler.LifecycleHandler, calendarConvertHandler *handler.CalendarConvertHandler, calendarHandler *handler.CalendarHandler, journalHandler *handler.JournalHandler, journalDraftHandler *handler.JournalDraftHandler, journalAutoHandler *handler.JournalAutoHandler, projectHandler *handler.ProjectHandler, taskHandler *handler.TaskHandler, githubIntegrationHandler *handler.GitHubIntegrationHandler, githubCommitsHandler *handler.GitHubCommitsHandler) *gin.Engine {
+func Setup(pool *pgxpool.Pool, apiKeySvc *service.ApiKeyService, apiKeyHandler *handler.ApiKeyHandler, categoryHandler *handler.CategoryHandler, llmProviderHandler *handler.LlmProviderHandler, entryHandler *handler.EntryHandler, classifyHandler *handler.ClassifyHandler, searchHandler *handler.SearchHandler, gitImportHandler *handler.GitImportHandler, gcalHandler *handler.GcalHandler, confidenceHandler *handler.ConfidenceHandler, statsHandler *handler.StatsHandler, systemHandler *handler.SystemHandler, lifecycleHandler *handler.LifecycleHandler, calendarConvertHandler *handler.CalendarConvertHandler, calendarHandler *handler.CalendarHandler, journalHandler *handler.JournalHandler, journalDraftHandler *handler.JournalDraftHandler, journalAutoHandler *handler.JournalAutoHandler, projectHandler *handler.ProjectHandler, taskHandler *handler.TaskHandler, githubIntegrationHandler *handler.GitHubIntegrationHandler, githubCommitsHandler *handler.GitHubCommitsHandler, viewHandler *handler.ViewHandler) *gin.Engine {
 	r := gin.Default()
 
 	// CORS middleware — 允許跨網域（前端 localhost:3000 呼叫 API localhost:8080）
@@ -185,6 +185,17 @@ func Setup(pool *pgxpool.Pool, apiKeySvc *service.ApiKeyService, apiKeyHandler *
 			tasks.PATCH("/:id", taskHandler.Update)
 			tasks.POST("/:id/complete", taskHandler.Complete)
 			tasks.DELETE("/:id", taskHandler.Delete)
+		}
+
+		// Saved Views（F-043）
+		// 注意：/reorder 必須在 /:id 之前以避免誤匹配
+		views := v1.Group("/views")
+		{
+			views.GET("", viewHandler.List)
+			views.POST("", viewHandler.Create)
+			views.PATCH("/reorder", viewHandler.Reorder)
+			views.PATCH("/:id", viewHandler.Update)
+			views.DELETE("/:id", viewHandler.Delete)
 		}
 	}
 

--- a/dev/src/service/view.go
+++ b/dev/src/service/view.go
@@ -1,0 +1,175 @@
+package service
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/gpwork4u/aibo/dto"
+	"github.com/gpwork4u/aibo/model"
+)
+
+const maxSavedViews = 50
+
+// ViewRepositoryInterface saved_views repository 介面
+type ViewRepositoryInterface interface {
+	FindAll(ctx context.Context) ([]*model.SavedView, error)
+	FindByID(ctx context.Context, id uuid.UUID) (*model.SavedView, error)
+	Count(ctx context.Context) (int, error)
+	MaxPosition(ctx context.Context) (int, error)
+	Create(ctx context.Context, v *model.SavedView) error
+	Update(ctx context.Context, v *model.SavedView) error
+	Delete(ctx context.Context, id uuid.UUID) error
+	Reorder(ctx context.Context, ids []uuid.UUID) (int, error)
+}
+
+// ViewService saved views 業務邏輯
+type ViewService struct {
+	repo ViewRepositoryInterface
+}
+
+// NewViewService 建立新的 ViewService
+func NewViewService(repo ViewRepositoryInterface) *ViewService {
+	return &ViewService{repo: repo}
+}
+
+// List 列出所有 saved views
+func (s *ViewService) List(ctx context.Context) ([]*model.SavedView, error) {
+	return s.repo.FindAll(ctx)
+}
+
+// Create 建立新 saved view
+func (s *ViewService) Create(ctx context.Context, req dto.CreateViewRequest) (*model.SavedView, error) {
+	// 驗證 name
+	name := strings.TrimSpace(req.Name)
+	if name == "" {
+		return nil, model.NewAppError(http.StatusBadRequest, model.ErrCodeInvalidInput, "name 不可為空")
+	}
+	if len(name) > 100 {
+		return nil, model.NewAppError(http.StatusBadRequest, model.ErrCodeInvalidInput, "name 最多 100 字")
+	}
+
+	// 驗證 filters 大小 (max 4KB)
+	if len(req.Filters) > 4096 {
+		return nil, model.NewAppError(http.StatusBadRequest, model.ErrCodeInvalidInput, "filters 超過 4KB 上限")
+	}
+
+	// 驗證上限 50
+	count, err := s.repo.Count(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if count >= maxSavedViews {
+		return nil, model.NewAppError(http.StatusBadRequest, model.ErrCodeViewLimitExceeded, "已達 saved view 上限（50 個）")
+	}
+
+	// scope 預設 library
+	scope := req.Scope
+	if scope == "" {
+		scope = "library"
+	}
+
+	// filters 預設 {}
+	filters := req.Filters
+	if len(filters) == 0 {
+		filters = json.RawMessage("{}")
+	}
+
+	// position 預設 maxPosition + 1
+	position := 0
+	if req.Position != nil {
+		position = *req.Position
+	} else {
+		maxPos, err := s.repo.MaxPosition(ctx)
+		if err != nil {
+			return nil, err
+		}
+		position = maxPos + 1
+	}
+
+	now := time.Now().UTC()
+	v := &model.SavedView{
+		ID:        uuid.New(),
+		Name:      name,
+		Scope:     scope,
+		Filters:   filters,
+		SortBy:    req.SortBy,
+		SortDir:   req.SortDir,
+		Icon:      req.Icon,
+		Position:  position,
+		CreatedAt: now,
+		UpdatedAt: now,
+	}
+
+	if err := s.repo.Create(ctx, v); err != nil {
+		return nil, err
+	}
+	return v, nil
+}
+
+// Update 部分更新 saved view
+func (s *ViewService) Update(ctx context.Context, id uuid.UUID, req dto.UpdateViewRequest) (*model.SavedView, error) {
+	v, err := s.repo.FindByID(ctx, id)
+	if err != nil {
+		return nil, err
+	}
+	if v == nil {
+		return nil, model.NewAppError(http.StatusNotFound, model.ErrCodeViewNotFound, "找不到指定的 view")
+	}
+
+	// 套用部分更新
+	if req.Name != nil {
+		name := strings.TrimSpace(*req.Name)
+		if name == "" {
+			return nil, model.NewAppError(http.StatusBadRequest, model.ErrCodeInvalidInput, "name 不可為空")
+		}
+		v.Name = name
+	}
+	if req.Scope != nil {
+		v.Scope = *req.Scope
+	}
+	if len(req.Filters) > 0 {
+		if len(req.Filters) > 4096 {
+			return nil, model.NewAppError(http.StatusBadRequest, model.ErrCodeInvalidInput, "filters 超過 4KB 上限")
+		}
+		v.Filters = req.Filters
+	}
+	if req.SortBy != nil {
+		v.SortBy = req.SortBy
+	}
+	if req.SortDir != nil {
+		v.SortDir = req.SortDir
+	}
+	if req.Icon != nil {
+		v.Icon = req.Icon
+	}
+	if req.Position != nil {
+		v.Position = *req.Position
+	}
+	v.UpdatedAt = time.Now().UTC()
+
+	if err := s.repo.Update(ctx, v); err != nil {
+		return nil, err
+	}
+	return v, nil
+}
+
+// Delete 刪除 saved view
+func (s *ViewService) Delete(ctx context.Context, id uuid.UUID) error {
+	v, err := s.repo.FindByID(ctx, id)
+	if err != nil {
+		return err
+	}
+	if v == nil {
+		return model.NewAppError(http.StatusNotFound, model.ErrCodeViewNotFound, "找不到指定的 view")
+	}
+	return s.repo.Delete(ctx, id)
+}
+
+// Reorder 重新排序 saved views
+func (s *ViewService) Reorder(ctx context.Context, ids []uuid.UUID) (int, error) {
+	return s.repo.Reorder(ctx, ids)
+}


### PR DESCRIPTION
Closes #209

## 已包含
- migration 018: saved_views table (id/name/emoji/filters JSONB/position/timestamps)
- model.SavedView / dto.View* / repository.ViewRepository
- service.ViewService（CRUD + 50 limit + duplicate name check）
- handler.ViewHandler：POST/GET/PATCH/DELETE + reorder
- router.go + main.go 註冊 routes

## Follow-up（front-end）
- saved-views-bar UI（chip list + drag reorder + kebab）
- saved-view-dialog（建立/編輯）
- 整合到 /library page