### PR TITLE
docs(specs): Sprint 15 tech-lead — React Flow v12/ELK survey + 依賴圖譜

### DIFF
--- a/specs/dependencies.md
+++ b/specs/dependencies.md
@@ -1123,3 +1123,89 @@ migration 018（F-043 後端）→ F-043 前端整合
 | nuqs 與 Next.js App Router RSC 水合不一致 | URL state 閃爍 | 使用 `NuqsAdapter` 包裹 layout，`shallow: true` 避免 server re-render |
 | Today Dashboard 4 個 API 同時請求 | 頁面載入慢 | TanStack Query `Promise.all` 平行請求 + Suspense boundary per section |
 | 批次操作 partial success UX 混亂 | 使用者不知道哪些失敗 | toast 明確列出 failed ids 數量 |
+
+---
+
+# Sprint 15 依賴圖譜
+
+## 功能總覽
+
+| 編號 | 名稱 | 優先級 | 依賴 |
+|------|------|--------|------|
+| F-044 | Entry Links Backend | P0 | 無（migration 019） |
+| F-045 | Canvas Graph View | P1 | F-044（graph endpoint + links）、UI Design（EntryNode 樣式） |
+| F-046 | Relation Editor | P1 | F-044（links API）、UI Design（RelationChip 元件） |
+
+## 依賴關係圖
+
+```
+F-044 Entry Links Backend（migration 019 + CRUD API）
+├── F-045 Canvas Graph View（GET /api/v1/graph + links data）
+└── F-046 Relation Editor（POST/PATCH/DELETE /api/v1/entries/:id/links）
+
+UI Design（EntryNode、LinkEdge、RelationChip、NodeDetailSheet）
+├── F-045（Canvas 節點與邊視覺規格）
+└── F-046（RelationChip badge 顏色、link_type 色彩對應）
+```
+
+## 依賴說明
+
+**Data Model 依賴**
+- F-044 引入 migration 019（`entry_links` table、`link_type_enum`、`link_source_enum`）
+- F-045 的 `GET /api/v1/graph` endpoint 直接查詢 `entry_links` table，**必須在 F-044 migration 完成後**
+- F-046 直接呼叫 F-044 定義的所有 links CRUD endpoints
+
+**API 依賴**
+- F-045 依賴 F-044 提供：`GET /api/v1/entries/:id/links`、新增的 `GET /api/v1/graph` endpoint
+- F-046 依賴 F-044 提供：`GET /api/v1/entries/:id/links`、`POST`、`PATCH`、`DELETE` endpoints
+- F-046 另沿用既有：`GET /api/v1/entries?q=keyword`（Combobox 搜尋）
+
+**UI 依賴**
+- F-045 需要 UI Design 提供：`EntryNode` 樣式規格、`LinkEdge` 顏色與標籤樣式、`NodeDetailSheet` 版面
+- F-046 需要 UI Design 提供：`RelationChip` badge 顏色對應（link_type color map）、`AddRelationForm` 版面規格
+
+**平行開發可行性**
+- F-044 後端無 UI，可立即啟動，不依賴 UI Design
+- F-045、F-046 前端骨架可先以 mock data 開發，待 F-044 完成後整合
+- UI Design 可與 F-044 後端並行開始設計元件規格
+
+## 拓撲排序
+
+### Wave 0（立即並行啟動）
+- **F-044 Entry Links Backend**：migration 019 + CRUD API（無 UI 依賴，P0 先行）
+- **UI Design**：EntryNode、LinkEdge、RelationChip、NodeDetailSheet 樣式規格
+- **QA**：開始撰寫 F-044~F-046 e2e test scripts（不需等後端完成）
+
+### Wave 1（F-044 後端 + UI Design 完成後）
+- **F-045 Canvas Graph View**：`GET /api/v1/graph` endpoint + React Flow + ELK layout
+- **F-046 Relation Editor**：RelationChip + AddRelationForm + links CRUD 整合
+
+> F-044 後端預計 Wave 0 最快完成（純後端，無 UI）；F-045、F-046 可在 F-044 PR merge 後立即開始整合。
+> ELK bundle 使用 dynamic import，不影響 F-045 骨架開發的起始時機。
+
+### 並行甘特圖
+
+```
+Wave 0:
+F-044:     [migration 019 + link CRUD API + 雙向查詢 ──────────────────────]
+UI Design: [EntryNode + LinkEdge + RelationChip + NodeDetailSheet ──────────]
+QA:        [撰寫 F-044~F-046 e2e scenarios ───────────────────────────────]
+
+Wave 1（F-044 + UI Design 完成後）:
+F-045:     [GET /graph endpoint + React Flow + ELK layout + ego network ────]
+F-046:     [RelationEditor UI + Combobox + chip CRUD 整合 ─────────────────]
+Code Review:[逐 PR 審查 ────────────────────────────────────────────────────]
+```
+
+### 關鍵路徑
+
+F-044 migration 019 → F-045 `GET /api/v1/graph` → F-045 前端整合
+
+### 風險項目
+
+| 風險 | 影響 | 緩解 |
+|------|------|------|
+| ELK bundle 1.5 MB 影響首屏載入 | Canvas 頁首屏慢 | `next/dynamic` + dynamic `import('elkjs')` 延遲載入 |
+| ELK 計算凍結 UI（200 節點） | 操作無反應 | `new ELK({ workerFactory })` 在 Web Worker 執行 layout |
+| `node.measured` 未就緒時 layout 錯誤 | 節點重疊 | `onNodesChange` 後確認 `node.measured` 有值再觸發 ELK |
+| entry_links CASCADE 刪除效能 | 大量 entries 刪除時慢 | DB index on `from_id`、`to_id` 已定義於 migration 019 |

--- a/specs/logs/sprint-14-log.md
+++ b/specs/logs/sprint-14-log.md
@@ -1,0 +1,48 @@
+# Sprint 14 工作日誌：Inbox + Library + Today
+
+**Milestone**: #14
+**Epic**: #187
+**Sprint Issue**: #189
+**完成日**: 2026-04-28
+
+## 交付清單
+
+| Feature | Issue | PR | 狀態 |
+|---------|-------|----|----|
+| F-040 Inbox Triage View | #206 | #215 | ✅ MERGED |
+| F-041 Library Table View | #207 | #216 | ✅ MERGED |
+| F-042 Today Dashboard | #208 | #213 | ✅ MERGED |
+| F-043 Saved Views (backend) | #209 | #217 | ⚠️ MERGED (frontend 為 follow-up) |
+| D-14 UI Components | #210 | #214 | ✅ MERGED |
+| QA-14 e2e skeleton | #211 | #212 | ✅ MERGED (test.skip) |
+
+## 重點變更
+
+### Frontend (`dev/frontend/`)
+- `app/(shell)/inbox/page.tsx` — Inbox 頁面 wire up
+- `components/inbox/`：InboxList / InboxCard / InboxToolbar / InboxActionBar / useInboxKeyboard hook（J/K/A/D/E/Space）
+- `app/(shell)/library/page.tsx` — Library 頁面（nuqs URL state）
+- `components/library/`：LibraryTable（TanStack Table v8 + Virtual v3）+ LibraryToolbar
+- `app/(shell)/today/page.tsx` + `components/today/`：4 sections（Calendar/Journal/RecentEntries/Tasks）+ per-section error boundary
+
+### Backend (`dev/src/`)
+- migration `018_create_saved_views`
+- `model.SavedView` / `dto.View*` / `repository.ViewRepository`
+- `service.ViewService`（CRUD + 50 limit + duplicate check）
+- `handler.ViewHandler`：POST/GET/PATCH/DELETE + reorder
+- entries API extension：batch ops + classify + status filter
+
+### Design (`design/`)
+- `components/inbox-card`、`library-table-chrome`、`today-section-card`、`saved-views-chip` + 範例 .tsx
+- `pages/`：f040-inbox-triage、f041-library、f042-today
+
+### Test (`test/`)
+- 27 scenarios skeleton（IT-1~9、LT-1~7、TD-1~5、SV-1~6），全 test.skip 待 features 啟用
+
+## 已知 Follow-up
+1. **F-043 frontend**：saved-views-bar UI（chip list + dnd-kit drag reorder + kebab menu）+ saved-view-dialog + 整合到 /library page
+2. **F-039 router 註冊**（前 sprint 遺留）：仍需小 PR
+3. **e2e 啟用**：features 上線後逐步解開 test.skip
+
+## 備註
+本 sprint 多次遭遇 background engineer agent stall（思考但未 commit），由 orchestrator 接手 commit/push/PR 完成。Sprint 14 共合併 6 個 PR。

--- a/specs/tech-survey.md
+++ b/specs/tech-survey.md
@@ -1654,3 +1654,102 @@ F-041 Library Table、F-043 Saved Views 的 filter/sort URL 同步使用 **nuqs*
 - [nuqs — Type-safe search params state management for React](https://nuqs.dev/)
 - [Managing search parameters in Next.js with nuqs — LogRocket](https://blog.logrocket.com/managing-search-parameters-next-js-nuqs/)
 - [Stop Fighting Next.js Search Params: Use nuqs](https://dev.to/tphilus/stop-fighting-nextjs-search-params-use-nuqs-for-type-safe-url-state-2a0h)
+
+---
+
+## Sprint 15 技術調查（2026-04-28）
+
+### 調查主題：React Flow v12、ELK Layout、知識圖譜效能優化
+
+---
+
+### 1. React Flow（@xyflow/react）v12
+
+#### 版本現況
+- 最新穩定版：**12.8.4**（2025-08 更新，持續活躍維護）
+- 最近重要版本：12.6.0（2025-04）、12.7.1（2025-06）
+- npm package 已更名：`reactflow` → `@xyflow/react`（v12 起）
+- import 調整：`import { ReactFlow } from '@xyflow/react'`，樣式：`'@xyflow/react/dist/style.css'`
+
+#### v12 重大新特性
+| 特性 | 說明 |
+|------|------|
+| SSR 支援 | 可在 node.measured 前定義 width/height，支援 server-side render + client hydrate |
+| `node.measured` | 佈局計算必須改用 `node.measured.width/height`（取代舊版 `node.width/height`） |
+| Provider 初始化 | `ReactFlowProvider` 新增 `initialMinZoom`、`initialMaxZoom`、`initialFitViewOptions` |
+| 效能提升 | 近期版本內建效能優化（memoized node rendering） |
+
+#### 效能優化策略（大圖適用）
+1. **節點 memoization**：所有自定義節點 Component 必須用 `React.memo` 包裹，避免每次 viewport 移動觸發重渲染
+2. **`useCallback` / `useMemo`**：傳入 ReactFlow 的 handlers 和 nodeTypes 定義必須穩定參考
+3. **隱藏節點**：超過 200 節點時，用 `hidden: true` 動態摺疊離屏節點（非 DOM remove，保留 state）
+4. **簡化樣式**：超過 100 節點時，移除 CSS animation、box-shadow、複雜 gradient
+5. **dot-only 降級**：超過 200 節點啟動 dot-only 模式（無 label 自定義節點），降低 DOM 元素數量
+
+#### 決策
+使用 **`@xyflow/react` v12**（最新 12.8.4），自定義 `EntryNode` 和 `LinkEdge` 元件。
+
+---
+
+### 2. 佈局算法比較：ELK vs Dagre vs D3-Force
+
+| 算法 | bundle 大小 | 異步 | 適用圖形 | 配置難度 | edge routing | 適合本專案 |
+|------|-----------|------|---------|---------|-------------|-----------|
+| **Dagre** | ~40 KB | 否（同步） | DAG / tree | 簡單 | 否 | 部分（tree 視圖） |
+| **ELK.js** | ~1.5 MB | 是（async） | 任意複雜圖 | 高 | 是 | 最適合（知識圖譜） |
+| **D3-Force** | ~60 KB | 是（迭代） | 非層次關係網路 | 中 | 否 | 適合（力導向探索） |
+| **D3-Hierarchy** | ~20 KB | 否 | 單一 root tree | 低 | 否 | 不適合（非 tree） |
+
+#### ELK.js 特性詳解
+- **套件**：`elkjs`（Eclipse Layout Kernel JS port）
+- 支援多種演算法：`layered`（hierarchical）、`force`、`stress`、`mrtree`、`radial`
+- **非同步計算**：`elk.layout(graph)` 回傳 Promise，React Flow 需用 `useCallback` + `useEffect` 處理
+- **v12 整合要點**：佈局完成後，節點位置從 `node.measured` 讀取，不再從 `node` 直接讀
+- **Web Worker 可行性**：ELK 計算可在 Web Worker 執行（`new ELK({ workerFactory })` 支援 worker），避免大圖 layout 凍結 UI
+- **bundle 大小問題**：1.5 MB 較大，建議 dynamic import（`import('elkjs/lib/elk.bundled.js')`）搭配 `next/dynamic` 延遲載入
+
+#### 決策
+- **預設佈局**：ELK `layered`（hierarchical，適合有向知識圖譜）
+- **力導向佈局**：ELK `force` 或 D3-Force（探索模式切換用）
+- **ELK Web Worker**：啟用，避免 200 節點以上的 layout 計算凍結 UI
+- **dynamic import**：ELK 使用 `import('elkjs')` 延遲載入，不影響初始 bundle
+
+---
+
+### 3. 知識圖譜效能策略
+
+#### 節點數分級
+| 節點數 | 模式 | 說明 |
+|--------|------|------|
+| ≤ 50 | 完整模式 | 顯示 title、category badge、confidence、完整樣式 |
+| 51–200 | 精簡模式 | 顯示 title only，移除 badge 和 confidence，簡化邊樣式 |
+| > 200 | dot-only 模式 | 僅圓點 + hover tooltip，無 label，後端截斷並回傳 `meta.truncated: true` |
+
+#### Ego Network 策略
+- 預設 depth=2，最大 depth=3（後端強制限制）
+- 前端雙擊節點觸發：`GET /api/v1/graph?entry_id={id}&depth=2`
+- ELK layout 以雙擊節點為 root，重新計算 hierarchical layout
+
+#### 邊渲染優化
+- 使用 React Flow 內建 `BezierEdge` 作為 `LinkEdge` 基底（效能優於自定義 SVG path）
+- link_type 標籤（label）使用 `EdgeLabelRenderer` portal，避免 SVG foreignObject 效能問題
+
+---
+
+### 4. Sprint 15 依賴套件清單
+
+| 套件 | 版本 | 用途 | Feature |
+|------|------|------|---------|
+| `@xyflow/react` | ^12 | 知識圖譜渲染 | F-045 |
+| `elkjs` | ^0.9 | 圖形佈局算法 | F-045 |
+
+### 5. 參考資料
+
+- [React Flow 12 Release Blog](https://xyflow.com/blog/react-flow-12-release)
+- [React Flow Layouting Overview](https://reactflow.dev/learn/layouting/layouting)
+- [React Flow ELK.js Example](https://reactflow.dev/examples/layout/elkjs)
+- [React Flow Performance Guide](https://reactflow.dev/learn/advanced-use/performance)
+- [React Flow 12.6.0 What's New](https://reactflow.dev/whats-new/2025-04-17)
+- [GitHub: xyflow/xyflow Performance Discussion](https://github.com/xyflow/xyflow/discussions/4975)
+- [Building Complex Graph Diagrams with React Flow, ELK.js](https://dtoyoda10.medium.com/building-complex-graph-diagrams-with-react-flow-elk-js-and-dagre-js-8832f6a461c5)
+- [GitHub: kieler/elkjs](https://github.com/kieler/elkjs)


### PR DESCRIPTION
## Summary
- `specs/tech-survey.md` 新增 Sprint 15 段落：@xyflow/react v12 特性、ELK vs Dagre vs D3-Force 比較、效能分級策略（dot-only 降級）
- `specs/dependencies.md` 新增 Sprint 15 依賴圖譜：Wave 0（F-044 + UI Design + QA）、Wave 1（F-045、F-046）、關鍵路徑與風險

## Issues Created
- #219 [Feature] F-044: Entry Links Backend
- #220 [Feature] F-045: Canvas Graph View
- #221 [Feature] F-046: Relation Editor
- #222 [Design] Sprint 15 UI Components
- #223 [QA] Sprint 15 E2E Test

## Test plan
- [ ] tech-survey.md Sprint 15 段落內容正確（套件版本、比較表）
- [ ] dependencies.md Wave 0/1 依賴關係正確
- [ ] 5 個 issues 均已建立並掛上正確 milestone（Sprint 15）

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>