### PR TITLE
test(sprint-15): F-044~F-046 e2e skeleton

### DIFF
--- a/test/browser/specs/f044_entry_links.spec.ts
+++ b/test/browser/specs/f044_entry_links.spec.ts
@@ -1,0 +1,291 @@
+/**
+ * F-044: Entry Links Backend
+ *
+ * Spec: specs/features/f044-entry-links.md
+ * Issue: #219
+ * QA Issue: #223
+ *
+ * 涵蓋 Sprint 15 QA scenarios：
+ * - 建立 derives_from 連結
+ * - 查詢雙向連結（outgoing + incoming）
+ * - self-link 拒絕（422 SELF_LINK）
+ * - 重複連結拒絕（409 DUPLICATE）
+ * - 同 pair 不同 link_type 允許
+ * - Entry 刪除時 links cascade
+ * - 更新 link_type（PATCH）
+ * - 刪除連結（DELETE）
+ */
+
+import { test, expect } from "@playwright/test";
+import { loginWithCookie } from "../helpers/cookie-auth";
+
+const FEATURE = "F-044";
+const API_BASE = process.env.API_BASE_URL || "http://localhost:8081";
+
+// --- Helper: 模擬 entry links API 回應 ---
+
+function makeLinkResponse(overrides: Record<string, unknown> = {}) {
+  return {
+    id: "link-uuid-1",
+    from_id: "entry-a",
+    to_id: "entry-b",
+    link_type: "derives_from",
+    relation: "測試關係",
+    confidence: 1.0,
+    source: "manual",
+    created_at: "2026-04-28T10:00:00Z",
+    ...overrides,
+  };
+}
+
+function makeBidirectionalLinks() {
+  return {
+    outgoing: [
+      makeLinkResponse({ id: "link-1", from_id: "entry-a", to_id: "entry-b", link_type: "derives_from" }),
+    ],
+    incoming: [
+      makeLinkResponse({ id: "link-2", from_id: "entry-c", to_id: "entry-a", link_type: "references" }),
+    ],
+  };
+}
+
+test.describe(`[${FEATURE}] Entry Links Backend`, () => {
+  test.beforeEach(async ({ context }) => {
+    await context.clearCookies();
+    const apiKey = process.env.AIBO_E2E_API_KEY!;
+    await loginWithCookie(context, apiKey);
+  });
+
+  // --- Happy Path ---
+
+  test("EL-1 建立 derives_from 連結：POST 回傳 201 含完整欄位", async ({ page }) => {
+    test.skip(true, "skeleton：等 F-044 entry links API 實作");
+
+    await page.route(`${API_BASE}/api/v1/entries/entry-a/links`, (route) => {
+      if (route.request().method() === "POST") {
+        route.fulfill({
+          status: 201,
+          contentType: "application/json",
+          body: JSON.stringify(makeLinkResponse()),
+        });
+      } else {
+        route.continue();
+      }
+    });
+
+    const resp = await page.request.post(`${API_BASE}/api/v1/entries/entry-a/links`, {
+      data: { to_id: "entry-b", link_type: "derives_from", relation: "測試關係" },
+    });
+
+    expect(resp.status()).toBe(201);
+    const body = await resp.json();
+    expect(body.link_type).toBe("derives_from");
+    expect(body.confidence).toBe(1.0);
+    expect(body.source).toBe("manual");
+  });
+
+  test("EL-2 查詢雙向連結：GET /entries/A/links 同時回傳 outgoing + incoming", async ({ page }) => {
+    test.skip(true, "skeleton：等 F-044 entry links API 實作");
+
+    await page.route(`${API_BASE}/api/v1/entries/entry-a/links`, (route) => {
+      if (route.request().method() === "GET") {
+        route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify(makeBidirectionalLinks()),
+        });
+      } else {
+        route.continue();
+      }
+    });
+
+    const resp = await page.request.get(`${API_BASE}/api/v1/entries/entry-a/links`);
+
+    expect(resp.status()).toBe(200);
+    const body = await resp.json();
+    expect(body.outgoing[0].link_type).toBe("derives_from");
+    expect(body.incoming[0].link_type).toBe("references");
+  });
+
+  test("EL-3 同 pair 不同 link_type 允許：A→B contradicts 建立成功且 outgoing 含兩條", async ({ page }) => {
+    test.skip(true, "skeleton：等 F-044 entry links API 實作");
+
+    let callCount = 0;
+    await page.route(`${API_BASE}/api/v1/entries/entry-a/links`, (route) => {
+      if (route.request().method() === "POST") {
+        callCount++;
+        route.fulfill({
+          status: 201,
+          contentType: "application/json",
+          body: JSON.stringify(makeLinkResponse({ id: `link-${callCount}`, link_type: "contradicts" })),
+        });
+      } else if (route.request().method() === "GET") {
+        route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify({
+            outgoing: [
+              makeLinkResponse({ link_type: "derives_from" }),
+              makeLinkResponse({ id: "link-2", link_type: "contradicts" }),
+            ],
+            incoming: [],
+          }),
+        });
+      } else {
+        route.continue();
+      }
+    });
+
+    // 建立第二條（不同 link_type）
+    const postResp = await page.request.post(`${API_BASE}/api/v1/entries/entry-a/links`, {
+      data: { to_id: "entry-b", link_type: "contradicts" },
+    });
+    expect(postResp.status()).toBe(201);
+
+    // 驗證 outgoing 含兩條
+    const getResp = await page.request.get(`${API_BASE}/api/v1/entries/entry-a/links`);
+    const body = await getResp.json();
+    expect(body.outgoing).toHaveLength(2);
+  });
+
+  test("EL-4 更新 link_type：PATCH /entries/links/L1 回傳 200 含新 link_type", async ({ page }) => {
+    test.skip(true, "skeleton：等 F-044 entry links PATCH API 實作");
+
+    await page.route(`${API_BASE}/api/v1/entries/links/link-1`, (route) => {
+      if (route.request().method() === "PATCH") {
+        route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify(makeLinkResponse({ id: "link-1", link_type: "derives_from" })),
+        });
+      } else {
+        route.continue();
+      }
+    });
+
+    const resp = await page.request.patch(`${API_BASE}/api/v1/entries/links/link-1`, {
+      data: { link_type: "derives_from" },
+    });
+
+    expect(resp.status()).toBe(200);
+    const body = await resp.json();
+    expect(body.link_type).toBe("derives_from");
+  });
+
+  test("EL-5 刪除連結：DELETE /entries/links/L1 回傳 204，GET 不含 L1", async ({ page }) => {
+    test.skip(true, "skeleton：等 F-044 entry links DELETE API 實作");
+
+    await page.route(`${API_BASE}/api/v1/entries/links/link-1`, (route) => {
+      if (route.request().method() === "DELETE") {
+        route.fulfill({ status: 204 });
+      } else {
+        route.continue();
+      }
+    });
+
+    await page.route(`${API_BASE}/api/v1/entries/entry-a/links`, (route) => {
+      if (route.request().method() === "GET") {
+        route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify({ outgoing: [], incoming: [] }),
+        });
+      } else {
+        route.continue();
+      }
+    });
+
+    const deleteResp = await page.request.delete(`${API_BASE}/api/v1/entries/links/link-1`);
+    expect(deleteResp.status()).toBe(204);
+
+    const getResp = await page.request.get(`${API_BASE}/api/v1/entries/entry-a/links`);
+    const body = await getResp.json();
+    expect(body.outgoing).toHaveLength(0);
+  });
+
+  // --- Edge Cases / Error Handling ---
+
+  test("EL-6 self-link 拒絕：POST to_id = from_id 回傳 422 SELF_LINK", async ({ page }) => {
+    test.skip(true, "skeleton：等 F-044 entry links 驗證邏輯實作");
+
+    await page.route(`${API_BASE}/api/v1/entries/entry-a/links`, (route) => {
+      if (route.request().method() === "POST") {
+        route.fulfill({
+          status: 422,
+          contentType: "application/json",
+          body: JSON.stringify({ code: "SELF_LINK", message: "不能建立自我連結" }),
+        });
+      } else {
+        route.continue();
+      }
+    });
+
+    const resp = await page.request.post(`${API_BASE}/api/v1/entries/entry-a/links`, {
+      data: { to_id: "entry-a", link_type: "derives_from" },
+    });
+
+    expect(resp.status()).toBe(422);
+    const body = await resp.json();
+    expect(body.code).toBe("SELF_LINK");
+  });
+
+  test("EL-7 重複連結拒絕：相同 pair + link_type 再次 POST 回傳 409 DUPLICATE", async ({ page }) => {
+    test.skip(true, "skeleton：等 F-044 entry links 唯一性約束實作");
+
+    await page.route(`${API_BASE}/api/v1/entries/entry-a/links`, (route) => {
+      if (route.request().method() === "POST") {
+        route.fulfill({
+          status: 409,
+          contentType: "application/json",
+          body: JSON.stringify({ code: "DUPLICATE", message: "連結已存在" }),
+        });
+      } else {
+        route.continue();
+      }
+    });
+
+    const resp = await page.request.post(`${API_BASE}/api/v1/entries/entry-a/links`, {
+      data: { to_id: "entry-b", link_type: "derives_from" },
+    });
+
+    expect(resp.status()).toBe(409);
+    const body = await resp.json();
+    expect(body.code).toBe("DUPLICATE");
+  });
+
+  test("EL-8 Entry 刪除時 links cascade：DELETE entry B 後 A 的 outgoing 不含 B", async ({ page }) => {
+    test.skip(true, "skeleton：等 F-044 CASCADE DELETE migration 實作");
+
+    await page.route(`${API_BASE}/api/v1/entries/entry-b`, (route) => {
+      if (route.request().method() === "DELETE") {
+        route.fulfill({ status: 204 });
+      } else {
+        route.continue();
+      }
+    });
+
+    await page.route(`${API_BASE}/api/v1/entries/entry-a/links`, (route) => {
+      if (route.request().method() === "GET") {
+        // B 刪除後，A 的 outgoing 不含 B 相關 links
+        route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify({ outgoing: [], incoming: [] }),
+        });
+      } else {
+        route.continue();
+      }
+    });
+
+    const deleteResp = await page.request.delete(`${API_BASE}/api/v1/entries/entry-b`);
+    expect(deleteResp.status()).toBe(204);
+
+    const getResp = await page.request.get(`${API_BASE}/api/v1/entries/entry-a/links`);
+    const body = await getResp.json();
+    // 確認 B 相關連結已被 CASCADE 移除
+    const bLinks = body.outgoing.filter(
+      (l: { to_id: string }) => l.to_id === "entry-b",
+    );
+    expect(bLinks).toHaveLength(0);
+  });
+});

--- a/test/browser/specs/f045_canvas_graph.spec.ts
+++ b/test/browser/specs/f045_canvas_graph.spec.ts
@@ -1,0 +1,197 @@
+/**
+ * F-045: Canvas Graph View
+ *
+ * Spec: specs/features/f045-canvas-graph.md
+ * Issue: #220
+ * QA Issue: #223
+ *
+ * 涵蓋 Sprint 15 QA scenarios：
+ * - 載入全局圖譜（ReactFlow canvas + entryNode 至少 1 個）
+ * - 點選節點展開 NodeDetailSheet
+ * - 雙擊節點切換 Ego Network（帶 entry_id + depth 參數）
+ * - 過濾 link_type（前端過濾，無 API 重新呼叫）
+ * - >200 nodes 時顯示 truncated warning banner
+ */
+
+import { test, expect } from "@playwright/test";
+import { loginWithCookie } from "../helpers/cookie-auth";
+
+const FEATURE = "F-045";
+const API_BASE = process.env.API_BASE_URL || "http://localhost:8081";
+
+// --- Helper: 產生假圖譜資料 ---
+
+function makeGraphData(nodeCount = 3) {
+  const nodes = Array.from({ length: nodeCount }, (_, i) => ({
+    id: `entry-${i + 1}`,
+    title: `Entry ${i + 1}`,
+    category: "Programming",
+    tags: ["go"],
+  }));
+
+  const edges = nodeCount > 1
+    ? [{ id: "link-1", from_id: "entry-1", to_id: "entry-2", link_type: "derives_from" }]
+    : [];
+
+  return { nodes, edges, meta: { truncated: false, total: nodeCount } };
+}
+
+function makeTruncatedGraphData() {
+  const data = makeGraphData(200);
+  return { ...data, meta: { truncated: true, total: 350 } };
+}
+
+test.describe(`[${FEATURE}] Canvas Graph View`, () => {
+  test.beforeEach(async ({ context }) => {
+    await context.clearCookies();
+    const apiKey = process.env.AIBO_E2E_API_KEY!;
+    await loginWithCookie(context, apiKey);
+  });
+
+  // --- Happy Path ---
+
+  test("CG-1 載入全局圖譜：/canvas 顯示 ReactFlow canvas 及至少 1 個 entryNode", async ({ page }) => {
+    test.skip(true, "skeleton：等 F-045 CanvasPage + React Flow 元件實作");
+
+    await page.route(`${API_BASE}/api/v1/graph*`, (route) => {
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify(makeGraphData(3)),
+      });
+    });
+
+    await page.goto("/canvas");
+    await page.waitForLoadState("networkidle");
+
+    // ReactFlow canvas 容器
+    await expect(page.locator(".react-flow")).toBeVisible();
+
+    // 至少一個 entry node
+    const entryNodes = page.locator("[data-testid='entry-node']");
+    await expect(entryNodes.first()).toBeVisible();
+
+    // 無 JS console error（基本健康檢查）
+    const errors: string[] = [];
+    page.on("console", (msg) => {
+      if (msg.type() === "error") errors.push(msg.text());
+    });
+    expect(errors).toHaveLength(0);
+  });
+
+  test("CG-2 點選節點展開 NodeDetailSheet：sheet 顯示該 entry title", async ({ page }) => {
+    test.skip(true, "skeleton：等 F-045 NodeDetailSheet 元件實作");
+
+    await page.route(`${API_BASE}/api/v1/graph*`, (route) => {
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify(makeGraphData(2)),
+      });
+    });
+
+    await page.goto("/canvas");
+    await page.waitForLoadState("networkidle");
+
+    // 點選第一個 entry node
+    const firstNode = page.locator("[data-testid='entry-node']").first();
+    await firstNode.click();
+
+    // NodeDetailSheet 從右側出現
+    const sheet = page.getByTestId("node-detail-sheet");
+    await expect(sheet).toBeVisible();
+
+    // sheet 顯示對應 entry 的 title
+    await expect(sheet.getByText("Entry 1")).toBeVisible();
+  });
+
+  test("CG-3 雙擊節點切換 Ego Network：request 含 entry_id + depth=2，toolbar 顯示 Centered on:", async ({ page }) => {
+    test.skip(true, "skeleton：等 F-045 Ego Network 模式實作");
+
+    let egoRequestUrl = "";
+    await page.route(`${API_BASE}/api/v1/graph*`, (route) => {
+      egoRequestUrl = route.request().url();
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify(makeGraphData(5)),
+      });
+    });
+
+    await page.goto("/canvas");
+    await page.waitForLoadState("networkidle");
+
+    // 雙擊第一個 node 觸發 ego network
+    const firstNode = page.locator("[data-testid='entry-node']").first();
+    await firstNode.dblclick();
+    await page.waitForLoadState("networkidle");
+
+    // 驗證 request 含 entry_id 和 depth=2
+    expect(egoRequestUrl).toContain("entry_id=entry-1");
+    expect(egoRequestUrl).toContain("depth=2");
+
+    // toolbar 顯示 "Centered on:"
+    await expect(page.getByText(/Centered on:/i)).toBeVisible();
+  });
+
+  test("CG-4 過濾 link_type（前端過濾）：取消 references 後邊消失，無 API 重新呼叫", async ({ page }) => {
+    test.skip(true, "skeleton：等 F-045 link_type filter toolbar 實作");
+
+    let apiCallCount = 0;
+    await page.route(`${API_BASE}/api/v1/graph*`, (route) => {
+      apiCallCount++;
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          nodes: [
+            { id: "entry-1", title: "Entry 1" },
+            { id: "entry-2", title: "Entry 2" },
+            { id: "entry-3", title: "Entry 3" },
+          ],
+          edges: [
+            { id: "link-1", from_id: "entry-1", to_id: "entry-2", link_type: "derives_from" },
+            { id: "link-2", from_id: "entry-1", to_id: "entry-3", link_type: "references" },
+          ],
+          meta: { truncated: false, total: 3 },
+        }),
+      });
+    });
+
+    await page.goto("/canvas");
+    await page.waitForLoadState("networkidle");
+
+    const initialCallCount = apiCallCount;
+
+    // 取消勾選 references filter
+    const referencesFilter = page.getByTestId("filter-references");
+    await referencesFilter.uncheck();
+
+    // references 邊不可見
+    const referencesEdges = page.locator("[data-testid='edge-references']");
+    await expect(referencesEdges).toHaveCount(0);
+
+    // 沒有額外的 API 呼叫（純前端過濾）
+    expect(apiCallCount).toBe(initialCallCount);
+  });
+
+  // --- Edge Cases ---
+
+  test("CG-5 truncated warning banner：API 回傳 meta.truncated=true 時顯示 'Showing 200'", async ({ page }) => {
+    test.skip(true, "skeleton：等 F-045 truncated warning banner 實作");
+
+    await page.route(`${API_BASE}/api/v1/graph*`, (route) => {
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify(makeTruncatedGraphData()),
+      });
+    });
+
+    await page.goto("/canvas");
+    await page.waitForLoadState("networkidle");
+
+    // 顯示包含 "Showing 200" 的 warning banner
+    await expect(page.getByText(/Showing 200/i)).toBeVisible();
+  });
+});

--- a/test/browser/specs/f046_relation_editor.spec.ts
+++ b/test/browser/specs/f046_relation_editor.spec.ts
@@ -1,0 +1,416 @@
+/**
+ * F-046: Relation Editor
+ *
+ * Spec: specs/features/f046-relation-editor.md
+ * Issue: #221
+ * QA Issue: #223
+ *
+ * 涵蓋 Sprint 15 QA scenarios：
+ * - 新增 derives_from 連結（E2E：搜尋→選擇→Add→chip 出現）
+ * - Combobox autocomplete（輸入後顯示搜尋結果）
+ * - self-link 前端阻止（Add button disabled）
+ * - 刪除 manual link（含確認對話框）
+ * - 編輯 link_type（chip badge 更新）
+ * - incoming links 唯讀（無 Edit/Delete 按鈕）
+ * - 樂觀更新 rollback（API 500 → chip 先出現後消失 + toast）
+ * - confidence < 0.7 的 LLM chip 顯示虛線外框
+ */
+
+import { test, expect } from "@playwright/test";
+import { loginWithCookie } from "../helpers/cookie-auth";
+
+const FEATURE = "F-046";
+const API_BASE = process.env.API_BASE_URL || "http://localhost:8081";
+const CURRENT_ENTRY_ID = "entry-current";
+const TARGET_ENTRY_ID = "entry-b";
+
+// --- Helper: 假資料 ---
+
+function makeSearchResults() {
+  return {
+    items: [
+      { id: "entry-b", title: "Machine Learning Basics", category: "AI" },
+      { id: "entry-c", title: "Machine Learning Advanced", category: "AI" },
+    ],
+    total: 2,
+  };
+}
+
+function makeLinkChip(overrides: Record<string, unknown> = {}) {
+  return {
+    id: "link-uuid-1",
+    from_id: CURRENT_ENTRY_ID,
+    to_id: "entry-b",
+    to_title: "Machine Learning Basics",
+    link_type: "derives_from",
+    relation: "",
+    confidence: 1.0,
+    source: "manual",
+    created_at: "2026-04-28T10:00:00Z",
+    ...overrides,
+  };
+}
+
+function makeIncomingChip() {
+  return {
+    id: "link-incoming-1",
+    from_id: "entry-c",
+    from_title: "Some Other Entry",
+    to_id: CURRENT_ENTRY_ID,
+    link_type: "references",
+    confidence: 0.9,
+    source: "manual",
+    created_at: "2026-04-28T10:00:00Z",
+  };
+}
+
+test.describe(`[${FEATURE}] Relation Editor`, () => {
+  test.beforeEach(async ({ context }) => {
+    await context.clearCookies();
+    const apiKey = process.env.AIBO_E2E_API_KEY!;
+    await loginWithCookie(context, apiKey);
+  });
+
+  // --- Happy Path ---
+
+  test("RE-1 新增 derives_from 連結（E2E）：搜尋→選擇→選 link_type→Add→chip 出現", async ({ page }) => {
+    test.skip(true, "skeleton：等 F-046 RelationEditor + EntrySearch 元件實作");
+
+    // Mock 搜尋 API
+    await page.route(`${API_BASE}/api/v1/entries/search*`, (route) => {
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify(makeSearchResults()),
+      });
+    });
+
+    // Mock 建立 link API
+    await page.route(`${API_BASE}/api/v1/entries/${CURRENT_ENTRY_ID}/links`, (route) => {
+      if (route.request().method() === "POST") {
+        route.fulfill({
+          status: 201,
+          contentType: "application/json",
+          body: JSON.stringify(makeLinkChip()),
+        });
+      } else if (route.request().method() === "GET") {
+        route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify({
+            outgoing: [makeLinkChip()],
+            incoming: [],
+          }),
+        });
+      } else {
+        route.continue();
+      }
+    });
+
+    await page.goto(`/entries/${CURRENT_ENTRY_ID}`);
+    await page.waitForLoadState("networkidle");
+
+    // 在 EntrySearch combobox 輸入搜尋關鍵字
+    const searchInput = page.getByTestId("entry-search-input");
+    await searchInput.fill("machine");
+    await page.waitForTimeout(300); // debounce
+
+    // 選擇第一個搜尋結果
+    const firstResult = page.getByText("Machine Learning Basics");
+    await firstResult.click();
+
+    // 選擇 link_type = derives_from
+    const linkTypeSelect = page.getByTestId("link-type-select");
+    await linkTypeSelect.selectOption("derives_from");
+
+    // 點擊 Add 按鈕
+    const addButton = page.getByRole("button", { name: /add/i });
+    await addButton.click();
+    await page.waitForLoadState("networkidle");
+
+    // outgoing 區塊出現新 chip，badge = derives_from（blue）
+    const outgoingSection = page.getByTestId("outgoing-links");
+    await expect(outgoingSection).toBeVisible();
+    const chip = outgoingSection.getByTestId("link-chip").first();
+    await expect(chip).toBeVisible();
+    await expect(chip.getByText("derives_from")).toBeVisible();
+  });
+
+  test("RE-2 Combobox autocomplete：輸入 'go lang' 後下拉顯示搜尋結果", async ({ page }) => {
+    test.skip(true, "skeleton：等 F-046 EntrySearch Combobox 實作");
+
+    await page.route(`${API_BASE}/api/v1/entries/search*`, (route) => {
+      const url = new URL(route.request().url());
+      if (url.searchParams.get("q")?.includes("go lang")) {
+        route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify({
+            items: [{ id: "entry-go", title: "Go Language Basics", category: "Programming" }],
+            total: 1,
+          }),
+        });
+      } else {
+        route.continue();
+      }
+    });
+
+    await page.goto(`/entries/${CURRENT_ENTRY_ID}`);
+    await page.waitForLoadState("networkidle");
+
+    const searchInput = page.getByTestId("entry-search-input");
+    await searchInput.fill("go lang");
+    await page.waitForTimeout(300); // 等待 debounce
+
+    // Combobox 下拉顯示結果
+    const dropdown = page.getByTestId("entry-search-dropdown");
+    await expect(dropdown).toBeVisible();
+    await expect(dropdown.getByText("Go Language Basics")).toBeVisible();
+  });
+
+  test("RE-3 self-link 前端阻止：選擇與當前 entry 相同時 Add button disabled", async ({ page }) => {
+    test.skip(true, "skeleton：等 F-046 self-link 前端驗證實作");
+
+    await page.route(`${API_BASE}/api/v1/entries/search*`, (route) => {
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          items: [{ id: CURRENT_ENTRY_ID, title: "Current Entry (self)", category: "Test" }],
+          total: 1,
+        }),
+      });
+    });
+
+    await page.goto(`/entries/${CURRENT_ENTRY_ID}`);
+    await page.waitForLoadState("networkidle");
+
+    const searchInput = page.getByTestId("entry-search-input");
+    await searchInput.fill("Current");
+    await page.waitForTimeout(300);
+
+    // 選擇與當前 entry 相同的結果
+    const selfResult = page.getByText("Current Entry (self)");
+    await selfResult.click();
+
+    // Add button 應為 disabled
+    const addButton = page.getByRole("button", { name: /add/i });
+    await expect(addButton).toBeDisabled();
+  });
+
+  test("RE-4 刪除 manual link：hover chip → Delete → 確認對話框 → 確認後 chip 消失", async ({ page }) => {
+    test.skip(true, "skeleton：等 F-046 link chip delete 確認對話框實作");
+
+    await page.route(`${API_BASE}/api/v1/entries/${CURRENT_ENTRY_ID}/links`, (route) => {
+      if (route.request().method() === "GET") {
+        route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify({
+            outgoing: [makeLinkChip()],
+            incoming: [],
+          }),
+        });
+      } else {
+        route.continue();
+      }
+    });
+
+    await page.route(`${API_BASE}/api/v1/entries/links/link-uuid-1`, (route) => {
+      if (route.request().method() === "DELETE") {
+        route.fulfill({ status: 204 });
+      } else {
+        route.continue();
+      }
+    });
+
+    await page.goto(`/entries/${CURRENT_ENTRY_ID}`);
+    await page.waitForLoadState("networkidle");
+
+    const chip = page.getByTestId("link-chip").first();
+
+    // hover chip 顯示 Delete 按鈕
+    await chip.hover();
+    const deleteButton = chip.getByRole("button", { name: /delete/i });
+    await deleteButton.click();
+
+    // 確認對話框出現
+    const confirmDialog = page.getByRole("alertdialog");
+    await expect(confirmDialog).toBeVisible();
+
+    // 確認刪除
+    await confirmDialog.getByRole("button", { name: /confirm|確認/i }).click();
+    await page.waitForLoadState("networkidle");
+
+    // chip 消失
+    await expect(chip).not.toBeVisible();
+  });
+
+  test("RE-5 編輯 link_type：hover chip → Edit → 選 derives_from → chip badge 更新為 blue", async ({ page }) => {
+    test.skip(true, "skeleton：等 F-046 link chip edit 功能實作");
+
+    await page.route(`${API_BASE}/api/v1/entries/${CURRENT_ENTRY_ID}/links`, (route) => {
+      if (route.request().method() === "GET") {
+        route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify({
+            outgoing: [makeLinkChip({ link_type: "related_to" })],
+            incoming: [],
+          }),
+        });
+      } else {
+        route.continue();
+      }
+    });
+
+    await page.route(`${API_BASE}/api/v1/entries/links/link-uuid-1`, (route) => {
+      if (route.request().method() === "PATCH") {
+        route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify(makeLinkChip({ link_type: "derives_from" })),
+        });
+      } else {
+        route.continue();
+      }
+    });
+
+    await page.goto(`/entries/${CURRENT_ENTRY_ID}`);
+    await page.waitForLoadState("networkidle");
+
+    const chip = page.getByTestId("link-chip").first();
+    await chip.hover();
+
+    // 點擊 Edit
+    const editButton = chip.getByRole("button", { name: /edit/i });
+    await editButton.click();
+
+    // 選擇新的 link_type
+    const linkTypeSelect = page.getByTestId("edit-link-type-select");
+    await linkTypeSelect.selectOption("derives_from");
+    await page.getByRole("button", { name: /save|儲存/i }).click();
+    await page.waitForLoadState("networkidle");
+
+    // chip badge 更新為 derives_from
+    await expect(chip.getByText("derives_from")).toBeVisible();
+  });
+
+  // --- Edge Cases ---
+
+  test("RE-6 incoming links 唯讀：hover incoming chip 無 Edit / Delete 按鈕", async ({ page }) => {
+    test.skip(true, "skeleton：等 F-046 incoming links 唯讀 UI 實作");
+
+    await page.route(`${API_BASE}/api/v1/entries/${CURRENT_ENTRY_ID}/links`, (route) => {
+      if (route.request().method() === "GET") {
+        route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify({
+            outgoing: [],
+            incoming: [makeIncomingChip()],
+          }),
+        });
+      } else {
+        route.continue();
+      }
+    });
+
+    await page.goto(`/entries/${CURRENT_ENTRY_ID}`);
+    await page.waitForLoadState("networkidle");
+
+    const incomingSection = page.getByTestId("incoming-links");
+    const incomingChip = incomingSection.getByTestId("link-chip").first();
+
+    await incomingChip.hover();
+
+    // 無 Edit / Delete 按鈕
+    await expect(incomingChip.getByRole("button", { name: /edit/i })).toHaveCount(0);
+    await expect(incomingChip.getByRole("button", { name: /delete/i })).toHaveCount(0);
+  });
+
+  test("RE-7 樂觀更新 rollback：API 500 → chip 先出現後消失 + toast 顯示失敗訊息", async ({ page }) => {
+    test.skip(true, "skeleton：等 F-046 樂觀更新 + rollback 邏輯實作");
+
+    await page.route(`${API_BASE}/api/v1/entries/search*`, (route) => {
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify(makeSearchResults()),
+      });
+    });
+
+    // API 回傳 500
+    await page.route(`${API_BASE}/api/v1/entries/${CURRENT_ENTRY_ID}/links`, (route) => {
+      if (route.request().method() === "POST") {
+        route.fulfill({
+          status: 500,
+          contentType: "application/json",
+          body: JSON.stringify({ error: "Internal Server Error" }),
+        });
+      } else if (route.request().method() === "GET") {
+        route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify({ outgoing: [], incoming: [] }),
+        });
+      } else {
+        route.continue();
+      }
+    });
+
+    await page.goto(`/entries/${CURRENT_ENTRY_ID}`);
+    await page.waitForLoadState("networkidle");
+
+    const searchInput = page.getByTestId("entry-search-input");
+    await searchInput.fill("machine");
+    await page.waitForTimeout(300);
+    await page.getByText("Machine Learning Basics").click();
+    await page.getByTestId("link-type-select").selectOption("derives_from");
+    await page.getByRole("button", { name: /add/i }).click();
+
+    // 樂觀更新：chip 先出現
+    const chip = page.getByTestId("link-chip").first();
+    await expect(chip).toBeVisible();
+
+    // rollback：chip 消失
+    await expect(chip).not.toBeVisible({ timeout: 5000 });
+
+    // toast 顯示失敗訊息
+    await expect(page.getByText(/Failed to add link/i)).toBeVisible();
+  });
+
+  test("RE-8 confidence < 0.7 的 LLM chip 顯示虛線外框樣式", async ({ page }) => {
+    test.skip(true, "skeleton：等 F-046 LLM link chip 樣式實作");
+
+    const llmLink = makeLinkChip({
+      id: "link-llm-1",
+      source: "llm",
+      confidence: 0.5,
+    });
+
+    await page.route(`${API_BASE}/api/v1/entries/${CURRENT_ENTRY_ID}/links`, (route) => {
+      if (route.request().method() === "GET") {
+        route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify({
+            outgoing: [llmLink],
+            incoming: [],
+          }),
+        });
+      } else {
+        route.continue();
+      }
+    });
+
+    await page.goto(`/entries/${CURRENT_ENTRY_ID}`);
+    await page.waitForLoadState("networkidle");
+
+    const llmChip = page.getByTestId("link-chip-link-llm-1");
+    await expect(llmChip).toBeVisible();
+
+    // 驗證有虛線外框的 CSS class 或 style
+    await expect(llmChip).toHaveClass(/border-dashed/);
+  });
+});


### PR DESCRIPTION
## 摘要

Sprint 15 三個 feature 的 Playwright browser test skeleton。
全部 `test.skip`，等 engineer PR 合併後啟用。

## 測試覆蓋

| Feature | Issue | Scenarios | 測試 ID |
|---------|-------|-----------|---------|
| F-044 Entry Links Backend | #219 | 8 | EL-1~EL-8 |
| F-045 Canvas Graph View | #220 | 5 | CG-1~CG-5 |
| F-046 Relation Editor | #221 | 8 | RE-1~RE-8 |

## Scenarios 詳細

### F-044 Entry Links
- EL-1：建立 derives_from 連結（201 + 完整欄位）
- EL-2：查詢雙向連結（outgoing + incoming）
- EL-3：同 pair 不同 link_type 允許（outgoing 含兩條）
- EL-4：更新 link_type（PATCH 200）
- EL-5：刪除連結（DELETE 204，GET 不含）
- EL-6：self-link 拒絕（422 SELF_LINK）
- EL-7：重複連結拒絕（409 DUPLICATE）
- EL-8：Entry 刪除時 links cascade

### F-045 Canvas Graph
- CG-1：載入全局圖譜（ReactFlow + entryNode）
- CG-2：點選節點展開 NodeDetailSheet
- CG-3：雙擊切換 Ego Network（entry_id + depth=2）
- CG-4：前端過濾 link_type（無 API 重呼叫）
- CG-5：truncated warning banner（meta.truncated=true）

### F-046 Relation Editor
- RE-1：新增 derives_from 連結 E2E
- RE-2：Combobox autocomplete
- RE-3：self-link 前端阻止（Add disabled）
- RE-4：刪除含確認對話框
- RE-5：編輯 link_type（chip badge 更新）
- RE-6：incoming links 唯讀
- RE-7：樂觀更新 rollback（500 → chip 消失 + toast）
- RE-8：confidence < 0.7 LLM chip 虛線外框

## 測試檔案

- `test/browser/specs/f044_entry_links.spec.ts`
- `test/browser/specs/f045_canvas_graph.spec.ts`
- `test/browser/specs/f046_relation_editor.spec.ts`

Closes #223