### PR TITLE
design(sprint-15): D-15 Canvas + Relation Editor 規格

### DIFF
--- a/design/components/ai-suggestion-chip/example.tsx
+++ b/design/components/ai-suggestion-chip/example.tsx
@@ -1,0 +1,413 @@
+// AI 建議連結 Chip 元件範例
+// 技術基礎：shadcn/ui + Tailwind CSS v4 + Lucide icons
+
+import React, { useState, useCallback } from "react";
+import { Sparkles, Check, X } from "lucide-react";
+import { cn } from "@/lib/utils";
+
+// ─── 型別 ─────────────────────────────────────────────────────────────────────
+
+type LinkType =
+  | "derives_from"
+  | "contradicts"
+  | "duplicate_of"
+  | "references"
+  | "supersedes"
+  | "related_to";
+
+type SuggestionStatus = "pending" | "accepted" | "rejected";
+
+interface AISuggestion {
+  id: string;
+  link_type: LinkType;
+  targetId: string;
+  targetTitle: string;
+  relation?: string;
+  confidence: number;
+  status: SuggestionStatus;
+}
+
+// ─── Link Type 色彩對應 ────────────────────────────────────────────────────────
+
+const LINK_TYPE_CONFIG: Record<LinkType, { hex: string; label: string }> = {
+  derives_from:  { hex: "#3B82F6", label: "衍生自" },
+  contradicts:   { hex: "#EF4444", label: "矛盾" },
+  duplicate_of:  { hex: "#F97316", label: "重複" },
+  references:    { hex: "#6B7280", label: "參考" },
+  supersedes:    { hex: "#A855F7", label: "取代" },
+  related_to:    { hex: "#22C55E", label: "相關" },
+};
+
+// ─── confidence badge 工具函式 ────────────────────────────────────────────────
+
+function getConfidenceBadgeStyle(confidence: number): {
+  bg: string;
+  text: string;
+} {
+  if (confidence >= 0.8) return { bg: "bg-green-100", text: "text-green-700" };
+  if (confidence >= 0.5) return { bg: "bg-yellow-100", text: "text-yellow-700" };
+  return { bg: "bg-red-100", text: "text-red-700" };
+}
+
+// ─── AISuggestionChip ────────────────────────────────────────────────────────
+
+interface AISuggestionChipProps {
+  link_type: LinkType;
+  targetTitle: string;
+  targetId: string;
+  relation?: string;
+  confidence: number;
+  status: SuggestionStatus;
+  onAccept?: () => void;
+  onReject?: () => void;
+  onTitleClick?: (id: string) => void;
+}
+
+export function AISuggestionChip({
+  link_type,
+  targetTitle,
+  targetId,
+  relation,
+  confidence,
+  status,
+  onAccept,
+  onReject,
+  onTitleClick,
+}: AISuggestionChipProps) {
+  const linkConfig = LINK_TYPE_CONFIG[link_type];
+  const confidenceStyle = getConfidenceBadgeStyle(confidence);
+  const confidencePercent = Math.round(confidence * 100);
+
+  // 狀態別樣式
+  const containerStyles = {
+    pending:  "bg-blue-50 border-blue-200",
+    accepted: "bg-green-50 border-green-200",
+    rejected: "bg-neutral-50 border-neutral-200",
+  };
+
+  // 狀態別圖示
+  const StatusIcon = {
+    pending:  <Sparkles className="h-3.5 w-3.5 text-blue-500 flex-shrink-0" aria-hidden="true" />,
+    accepted: <Check    className="h-3.5 w-3.5 text-green-600 flex-shrink-0" aria-hidden="true" />,
+    rejected: <X        className="h-3.5 w-3.5 text-neutral-400 flex-shrink-0" aria-hidden="true" />,
+  };
+
+  // a11y label
+  const statusLabel = {
+    pending:  `，信心值 ${confidencePercent}%，待決`,
+    accepted: "，已接受",
+    rejected: "，已拒絕",
+  };
+  const chipAriaLabel = `${linkConfig.label} 建議至 ${targetTitle}${statusLabel[status]}`;
+
+  return (
+    <div
+      role="listitem"
+      aria-label={chipAriaLabel}
+      className={cn(
+        "inline-flex items-center gap-1.5 px-2.5 py-1.5 rounded-full border",
+        "text-sm transition-all duration-150 motion-reduce:transition-none",
+        "animate-in fade-in slide-in-from-top-1",
+        containerStyles[status],
+        status === "rejected" && "opacity-60"
+      )}
+    >
+      {/* 狀態圖示 */}
+      {StatusIcon[status]}
+
+      {/* link_type badge */}
+      <span
+        className="inline-flex items-center px-1.5 py-0.5 rounded-full text-xs font-normal text-white flex-shrink-0"
+        style={{ backgroundColor: linkConfig.hex }}
+      >
+        {linkConfig.label}
+      </span>
+
+      {/* target title */}
+      <button
+        role="link"
+        aria-label={`前往：${targetTitle}`}
+        onClick={() => onTitleClick?.(targetId)}
+        className={cn(
+          "text-sm max-w-[180px] truncate cursor-pointer",
+          "underline-offset-2 hover:underline",
+          "focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:outline-none focus-visible:rounded",
+          status === "rejected" && "line-through text-muted-foreground",
+          status === "pending" && "text-foreground",
+          status === "accepted" && "text-muted-foreground"
+        )}
+      >
+        {targetTitle}
+      </button>
+
+      {/* relation text */}
+      {relation && (
+        <span className="text-xs text-muted-foreground flex-shrink-0">
+          · {relation}
+        </span>
+      )}
+
+      {/* confidence badge */}
+      <span
+        className={cn(
+          "inline-flex items-center px-1.5 py-0.5 rounded text-xs font-normal flex-shrink-0",
+          confidenceStyle.bg,
+          confidenceStyle.text
+        )}
+      >
+        {confidencePercent}%
+      </span>
+
+      {/* Accept / Reject 按鈕（pending 時顯示）*/}
+      {status === "pending" && (
+        <div className="flex items-center gap-0.5 ml-0.5" role="group" aria-label="操作">
+          <button
+            onClick={onAccept}
+            aria-label={`接受建議：${targetTitle}`}
+            className={cn(
+              "p-1.5 rounded-full transition-colors duration-150 motion-reduce:transition-none",
+              "hover:bg-green-100 hover:text-green-600",
+              "min-w-[32px] min-h-[32px] flex items-center justify-center",
+              "focus-visible:ring-2 focus-visible:ring-green-500 focus-visible:outline-none"
+            )}
+          >
+            <Check className="h-3.5 w-3.5" aria-hidden="true" />
+          </button>
+          <button
+            onClick={onReject}
+            aria-label={`拒絕建議：${targetTitle}`}
+            className={cn(
+              "p-1.5 rounded-full transition-colors duration-150 motion-reduce:transition-none",
+              "hover:bg-red-100 hover:text-red-600",
+              "min-w-[32px] min-h-[32px] flex items-center justify-center",
+              "focus-visible:ring-2 focus-visible:ring-red-500 focus-visible:outline-none"
+            )}
+          >
+            <X className="h-3.5 w-3.5" aria-hidden="true" />
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ─── AISuggestionList ─────────────────────────────────────────────────────────
+
+interface AISuggestionListProps {
+  suggestions: AISuggestion[];
+  onAcceptAll: () => void;
+  onRejectAll: () => void;
+  onAccept: (id: string) => void;
+  onReject: (id: string) => void;
+  onTitleClick: (id: string) => void;
+}
+
+export function AISuggestionList({
+  suggestions,
+  onAcceptAll,
+  onRejectAll,
+  onAccept,
+  onReject,
+  onTitleClick,
+}: AISuggestionListProps) {
+  const pendingCount = suggestions.filter((s) => s.status === "pending").length;
+  const hasPending = pendingCount > 0;
+  const allDone = suggestions.length > 0 && pendingCount === 0;
+
+  return (
+    <section aria-label="AI 建議連結">
+      {/* 標題行 */}
+      <div className="flex items-center gap-2 mb-2 flex-wrap">
+        <div className="flex items-center gap-1.5">
+          <Sparkles className="h-4 w-4 text-blue-500" aria-hidden="true" />
+          <h3 className="text-xs font-semibold text-muted-foreground uppercase tracking-wide">
+            AI 建議連結
+          </h3>
+        </div>
+
+        {/* pending 數量 badge */}
+        {hasPending && (
+          <span className="inline-flex items-center px-1.5 py-0.5 rounded text-xs text-blue-600 bg-blue-100">
+            {pendingCount} 待決
+          </span>
+        )}
+
+        {/* 批次操作（有 pending 時顯示）*/}
+        {hasPending && (
+          <div className="ml-auto flex items-center gap-1">
+            <button
+              onClick={onAcceptAll}
+              aria-label="接受所有 AI 建議"
+              className={cn(
+                "text-xs text-green-600 hover:text-green-700 hover:underline",
+                "px-2 py-1 rounded transition-colors",
+                "focus-visible:ring-2 focus-visible:ring-green-500 focus-visible:outline-none",
+                "min-h-[32px]"
+              )}
+            >
+              全部接受
+            </button>
+            <button
+              onClick={onRejectAll}
+              aria-label="拒絕所有 AI 建議"
+              className={cn(
+                "text-xs text-red-600 hover:text-red-700 hover:underline",
+                "px-2 py-1 rounded transition-colors",
+                "focus-visible:ring-2 focus-visible:ring-red-500 focus-visible:outline-none",
+                "min-h-[32px]"
+              )}
+            >
+              全部拒絕
+            </button>
+          </div>
+        )}
+      </div>
+
+      {/* aria-live 通知區 */}
+      <div aria-live="polite" aria-atomic="false" className="sr-only">
+        {allDone && "所有 AI 建議已處理完畢"}
+      </div>
+
+      {/* Chip 列表 / 空白狀態 */}
+      {allDone ? (
+        <p className="text-sm text-muted-foreground">所有建議已處理</p>
+      ) : (
+        <ul role="list" aria-label="AI 建議連結列表" className="flex flex-col gap-2">
+          {suggestions.map((suggestion) => (
+            <li key={suggestion.id} className="contents">
+              <AISuggestionChip
+                link_type={suggestion.link_type}
+                targetId={suggestion.targetId}
+                targetTitle={suggestion.targetTitle}
+                relation={suggestion.relation}
+                confidence={suggestion.confidence}
+                status={suggestion.status}
+                onAccept={() => onAccept(suggestion.id)}
+                onReject={() => onReject(suggestion.id)}
+                onTitleClick={onTitleClick}
+              />
+            </li>
+          ))}
+        </ul>
+      )}
+    </section>
+  );
+}
+
+// ─── 狀態管理 hook（工具）────────────────────────────────────────────────────
+
+export function useAISuggestions(initialSuggestions: AISuggestion[]) {
+  const [suggestions, setSuggestions] = useState<AISuggestion[]>(initialSuggestions);
+
+  const accept = useCallback((id: string) => {
+    setSuggestions((prev) =>
+      prev.map((s) => (s.id === id ? { ...s, status: "accepted" } : s))
+    );
+  }, []);
+
+  const reject = useCallback((id: string) => {
+    setSuggestions((prev) =>
+      prev.map((s) => (s.id === id ? { ...s, status: "rejected" } : s))
+    );
+  }, []);
+
+  const acceptAll = useCallback(() => {
+    setSuggestions((prev) =>
+      prev.map((s) => (s.status === "pending" ? { ...s, status: "accepted" } : s))
+    );
+  }, []);
+
+  const rejectAll = useCallback(() => {
+    setSuggestions((prev) =>
+      prev.map((s) => (s.status === "pending" ? { ...s, status: "rejected" } : s))
+    );
+  }, []);
+
+  return { suggestions, accept, reject, acceptAll, rejectAll };
+}
+
+// ─── 示範：三種狀態 ─────────────────────────────────────────────────────────
+
+export function AISuggestionChipDemo() {
+  const { suggestions, accept, reject, acceptAll, rejectAll } = useAISuggestions([
+    {
+      id: "s1",
+      link_type: "derives_from",
+      targetId: "e1",
+      targetTitle: "機器學習基礎",
+      relation: "概念衍生",
+      confidence: 0.92,
+      status: "pending",
+    },
+    {
+      id: "s2",
+      link_type: "references",
+      targetId: "e2",
+      targetTitle: "深度學習論文 2024",
+      confidence: 0.65,
+      status: "pending",
+    },
+    {
+      id: "s3",
+      link_type: "contradicts",
+      targetId: "e3",
+      targetTitle: "傳統統計方法",
+      confidence: 0.41,
+      status: "pending",
+    },
+  ]);
+
+  return (
+    <div className="max-w-md p-4 space-y-2">
+      <AISuggestionList
+        suggestions={suggestions}
+        onAccept={accept}
+        onReject={reject}
+        onAcceptAll={acceptAll}
+        onRejectAll={rejectAll}
+        onTitleClick={(id) => console.log("navigate to", id)}
+      />
+    </div>
+  );
+}
+
+// ─── 個別狀態範例 ─────────────────────────────────────────────────────────────
+
+// pending 狀態
+export const PendingExample = (
+  <AISuggestionChip
+    link_type="derives_from"
+    targetId="e1"
+    targetTitle="機器學習基礎"
+    relation="概念衍生"
+    confidence={0.92}
+    status="pending"
+    onAccept={() => {}}
+    onReject={() => {}}
+    onTitleClick={() => {}}
+  />
+);
+
+// accepted 狀態
+export const AcceptedExample = (
+  <AISuggestionChip
+    link_type="references"
+    targetId="e2"
+    targetTitle="深度學習論文"
+    confidence={0.78}
+    status="accepted"
+    onTitleClick={() => {}}
+  />
+);
+
+// rejected 狀態
+export const RejectedExample = (
+  <AISuggestionChip
+    link_type="contradicts"
+    targetId="e3"
+    targetTitle="傳統統計方法"
+    confidence={0.41}
+    status="rejected"
+    onTitleClick={() => {}}
+  />
+);

--- a/design/components/ai-suggestion-chip/spec.md
+++ b/design/components/ai-suggestion-chip/spec.md
@@ -1,0 +1,165 @@
+# AI 建議連結 Chip（AISuggestionChip）
+
+## 對應 Feature
+#221 F-046: Relation Editor（AI 建議連結子功能）
+
+## 技術基礎
+- shadcn/ui primitives：Badge、Button
+- Tailwind CSS v4 + Lucide icons（`Sparkles`、`Check`、`X`、`Clock`）
+- 狀態：pending / accepted / rejected
+
+---
+
+## 元件說明
+
+AISuggestionChip 顯示 LLM 自動建議的連結，提供使用者三種操作：接受、拒絕、或保留待決。
+
+---
+
+## Props
+
+| Prop | Type | Default | 說明 |
+|------|------|---------|------|
+| link_type | LinkType | — | 建議的連結類型 |
+| targetTitle | string | — | 目標條目標題 |
+| targetId | string | — | 目標條目 ID |
+| relation | string \| undefined | — | 建議的關係說明（灰色小字） |
+| confidence | number | — | AI 信心值（0.0–1.0），必填 |
+| status | 'pending' \| 'accepted' \| 'rejected' | 'pending' | 當前狀態 |
+| onAccept | () => void | — | 接受回呼 |
+| onReject | () => void | — | 拒絕回呼 |
+| onTitleClick | (id: string) => void | — | 標題點擊跳轉 |
+
+---
+
+## 狀態規格
+
+### pending（待決）
+
+**外觀：**
+- 背景：primary-50（`bg-blue-50`）
+- 邊框：primary-200（`border-blue-200`）
+- 左側 AI 圖示：`Sparkles` icon（primary-500）
+- chip 外框：實線
+
+**排列（左→右）：**
+```
+[Sparkles icon] [link_type badge] [target title] [relation?] [confidence badge] | [Accept] [Reject]
+```
+
+**Accept 按鈕：**
+- icon：`Check`（Lucide）
+- 尺寸：觸控區 >= 44×44pt（padding 補足）
+- hover：green-50 背景，green-600 顏色
+- aria-label：「接受建議：{targetTitle}」
+
+**Reject 按鈕：**
+- icon：`X`（Lucide）
+- hover：red-50 背景，red-600 顏色
+- aria-label：「拒絕建議：{targetTitle}」
+
+### accepted（已接受）
+
+**外觀：**
+- 背景：green-50（`bg-green-50`）
+- 邊框：green-200（`border-green-200`）
+- 左側圖示：`Check` icon（green-600）
+- 無操作按鈕
+- 文字色：foreground-muted（已操作，低重要性）
+
+**排列：**
+```
+[Check icon] [link_type badge] [target title] [relation?] [confidence badge]
+```
+
+### rejected（已拒絕）
+
+**外觀：**
+- 背景：neutral-50（`bg-neutral-50`）
+- 邊框：neutral-200（`border-neutral-200`）
+- 所有文字：foreground-subtle（`opacity-50` 效果）
+- 左側圖示：`X` icon（neutral-400）
+- 刪除線樣式：target title 加 `line-through`
+- 無操作按鈕
+
+**排列：**
+```
+[X icon] [link_type badge] [target title 刪除線] [relation?] [confidence badge]
+```
+
+---
+
+## confidence badge 規格
+
+| confidence 範圍 | 顯示格式 | 背景色 | 文字色 |
+|----------------|---------|--------|--------|
+| >= 0.8 | `{n}%` | green-100 | green-700 |
+| 0.5 – 0.79 | `{n}%` | yellow-100 | yellow-700 |
+| < 0.5 | `{n}%` | red-100 | red-700 |
+
+---
+
+## link_type badge 規格
+
+沿用 RelationChip 規格：
+- 圓角 pill，對應色彩背景，白色文字，font-size xs
+
+---
+
+## 動畫規格
+
+| 動作 | 動畫 |
+|------|------|
+| pending → accepted | `scale-95` → `scale-100`，150ms ease-out |
+| pending → rejected | fade-out opacity 0，150ms ease-out（可選：slide-out） |
+| 初次出現 | `animate-in fade-in slide-in-from-top-1`，200ms |
+
+尊重 `prefers-reduced-motion`：motion 設定 reduced 時跳過動畫。
+
+---
+
+## AISuggestionList（容器）
+
+一組 AISuggestionChip 的容器，含標題區和批次操作。
+
+### Props
+
+| Prop | Type | 說明 |
+|------|------|------|
+| suggestions | AISuggestion[] | 建議列表 |
+| onAcceptAll | () => void | 接受所有 pending |
+| onRejectAll | () => void | 拒絕所有 pending |
+| onAccept | (id: string) => void | 接受單一 |
+| onReject | (id: string) => void | 拒絕單一 |
+| onTitleClick | (id: string) => void | 標題點擊 |
+
+### 外觀
+- 標題：「AI 建議連結」+ `Sparkles` icon（primary-500）
+- 標題右側：pending 數量 badge（primary-100 背景）
+- 批次操作：「全部接受」（ghost，green）/ 「全部拒絕」（ghost，red）
+  - 顯示條件：有至少 1 個 pending
+- chip 列表：`flex flex-col gap-2 mt-2`
+- 空白狀態（全部處理完）：「所有建議已處理」（foreground-subtle，font-sm）
+
+---
+
+## Accessibility
+
+- `role="list"`（AISuggestionList）
+- `role="listitem"`（每個 chip）
+- Accept/Reject 按鈕：明確 aria-label 含目標標題
+- pending status chip：`aria-label="{link_type} 建議至 {targetTitle}，信心值 {confidence}%，待決"`
+- accepted status chip：`aria-label="{link_type} 建議至 {targetTitle}，已接受"`
+- rejected status chip：`aria-label="{link_type} 建議至 {targetTitle}，已拒絕"`
+- 狀態變化時用 `aria-live="polite"` 通知
+
+## States 總覽
+
+| Status | 外觀 | 操作按鈕 |
+|--------|------|---------|
+| pending | primary-50 底，Sparkles icon | Accept + Reject |
+| accepted | green-50 底，Check icon | 無 |
+| rejected | neutral-50 底，刪除線 | 無 |
+
+## 使用範例
+見 `example.tsx`

--- a/design/components/canvas-graph-node/example.tsx
+++ b/design/components/canvas-graph-node/example.tsx
@@ -1,0 +1,671 @@
+// Canvas Graph Node 元件範例
+// 技術基礎：@xyflow/react v12 + shadcn/ui + Tailwind CSS v4 + Lucide icons
+//
+// 安裝依賴：
+//   npm install @xyflow/react elkjs
+//   import '@xyflow/react/dist/style.css'
+
+import React, { memo, useCallback } from "react";
+import {
+  Handle,
+  Position,
+  NodeProps,
+  EdgeProps,
+  EdgeLabelRenderer,
+  getBezierPath,
+  useReactFlow,
+} from "@xyflow/react";
+import {
+  GitBranch,
+  Atom,
+  CircleDot,
+  Search,
+  ZoomIn,
+  ZoomOut,
+  Maximize2,
+  X,
+  AlertTriangle,
+} from "lucide-react";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Sheet, SheetContent, SheetHeader, SheetTitle } from "@/components/ui/sheet";
+import { Slider } from "@/components/ui/slider";
+import { Switch } from "@/components/ui/switch";
+import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group";
+import { cn } from "@/lib/utils";
+
+// ─── 型別 ─────────────────────────────────────────────────────────────────────
+
+type NodeMode = "full" | "compact" | "dot";
+
+type LinkType =
+  | "derives_from"
+  | "contradicts"
+  | "duplicate_of"
+  | "references"
+  | "supersedes"
+  | "related_to";
+
+interface EntryNodeData {
+  title: string;
+  category: string;
+  categoryColor?: string;
+  confidence?: number;
+  mode?: NodeMode;
+}
+
+interface LinkEdgeData {
+  link_type: LinkType;
+  confidence?: number;
+  relation?: string;
+}
+
+interface LinkPreview {
+  id: string;
+  link_type: LinkType;
+  title: string;
+  confidence?: number;
+}
+
+// ─── Link Type 色彩對應 ────────────────────────────────────────────────────────
+
+const LINK_TYPE_COLORS: Record<LinkType, { hex: string; label: string; tw: string }> = {
+  derives_from:  { hex: "#3B82F6", label: "衍生自", tw: "bg-blue-500" },
+  contradicts:   { hex: "#EF4444", label: "矛盾",   tw: "bg-red-500" },
+  duplicate_of:  { hex: "#F97316", label: "重複",   tw: "bg-orange-500" },
+  references:    { hex: "#6B7280", label: "參考",   tw: "bg-gray-500" },
+  supersedes:    { hex: "#A855F7", label: "取代",   tw: "bg-purple-500" },
+  related_to:    { hex: "#22C55E", label: "相關",   tw: "bg-green-500" },
+};
+
+// ─── 1. EntryNode ─────────────────────────────────────────────────────────────
+
+/**
+ * React Flow 自定義節點
+ * 必須用 React.memo 包裹（React Flow v12 效能要求）
+ */
+export const EntryNode = memo(function EntryNode({
+  data,
+  selected,
+}: NodeProps<EntryNodeData>) {
+  const mode = data.mode ?? "full";
+
+  // dot-only 模式：僅圓點
+  if (mode === "dot") {
+    return (
+      <>
+        <Handle type="target" position={Position.Top} className="opacity-0" />
+        <div
+          role="button"
+          tabIndex={0}
+          title={data.title}
+          aria-label={`${data.title}，分類：${data.category}`}
+          className={cn(
+            "w-4 h-4 rounded-full transition-transform hover:scale-125",
+            selected && "ring-2 ring-primary",
+            data.categoryColor ? "" : "bg-primary"
+          )}
+          style={data.categoryColor ? { backgroundColor: data.categoryColor } : undefined}
+        />
+        <Handle type="source" position={Position.Bottom} className="opacity-0" />
+      </>
+    );
+  }
+
+  // compact 模式：僅 title
+  if (mode === "compact") {
+    return (
+      <>
+        <Handle type="target" position={Position.Top} />
+        <div
+          role="button"
+          tabIndex={0}
+          aria-label={`${data.title}，分類：${data.category}`}
+          className={cn(
+            "w-[140px] min-h-[40px] px-2 py-1.5 bg-background border border-border",
+            "rounded-lg shadow-sm cursor-pointer select-none",
+            "hover:shadow-md transition-shadow",
+            selected && "ring-2 ring-primary"
+          )}
+        >
+          <p className="text-sm font-medium leading-tight line-clamp-2 text-foreground">
+            {data.title}
+          </p>
+        </div>
+        <Handle type="source" position={Position.Bottom} />
+      </>
+    );
+  }
+
+  // 完整模式
+  return (
+    <>
+      <Handle type="target" position={Position.Top} />
+      <div
+        role="button"
+        tabIndex={0}
+        aria-label={`${data.title}，分類：${data.category}`}
+        className={cn(
+          "w-[180px] min-h-[64px] p-3 bg-background border border-border",
+          "rounded-lg shadow-sm cursor-pointer select-none",
+          "hover:shadow-md transition-shadow",
+          selected && "ring-2 ring-primary"
+        )}
+      >
+        {/* Title */}
+        <p className="text-sm font-medium leading-tight line-clamp-2 text-foreground mb-2">
+          {data.title}
+        </p>
+
+        {/* Badges 行 */}
+        <div className="flex items-center gap-1 flex-wrap">
+          {/* Category badge */}
+          <span
+            className="inline-flex items-center px-1.5 py-0.5 rounded text-xs font-normal text-white"
+            style={data.categoryColor ? { backgroundColor: data.categoryColor } : undefined}
+          >
+            {data.category}
+          </span>
+
+          {/* Confidence badge（< 1.0 才顯示） */}
+          {data.confidence !== undefined && data.confidence < 1.0 && (
+            <span className="inline-flex items-center px-1.5 py-0.5 rounded text-xs text-muted-foreground bg-neutral-100">
+              {(data.confidence * 100).toFixed(0)}%
+            </span>
+          )}
+        </div>
+      </div>
+      <Handle type="source" position={Position.Bottom} />
+    </>
+  );
+});
+
+// ─── 2. LinkEdge ─────────────────────────────────────────────────────────────
+
+/**
+ * React Flow 自定義邊
+ * Label 使用 EdgeLabelRenderer portal（非 SVG foreignObject）
+ */
+export const LinkEdge = memo(function LinkEdge({
+  id,
+  sourceX,
+  sourceY,
+  targetX,
+  targetY,
+  sourcePosition,
+  targetPosition,
+  data,
+  selected,
+  markerEnd,
+}: EdgeProps<LinkEdgeData>) {
+  const linkType = (data?.link_type ?? "related_to") as LinkType;
+  const confidence = data?.confidence ?? 1.0;
+  const color = LINK_TYPE_COLORS[linkType];
+
+  const [edgePath, labelX, labelY] = getBezierPath({
+    sourceX,
+    sourceY,
+    sourcePosition,
+    targetX,
+    targetY,
+    targetPosition,
+  });
+
+  const strokeWidth = selected ? 2.5 : 1.5;
+  const strokeDasharray = confidence < 0.5 ? "6 3" : undefined;
+
+  return (
+    <>
+      {/* Edge 主體 */}
+      <path
+        id={id}
+        className="react-flow__edge-path"
+        d={edgePath}
+        strokeWidth={strokeWidth}
+        stroke={color.hex}
+        strokeDasharray={strokeDasharray}
+        fill="none"
+        markerEnd={markerEnd}
+      />
+
+      {/* 不可見寬互動區 */}
+      <path
+        d={edgePath}
+        fill="none"
+        strokeWidth={20}
+        stroke="transparent"
+        strokeOpacity={0}
+        className="react-flow__edge-interaction"
+      />
+
+      {/* EdgeLabel（使用 EdgeLabelRenderer portal） */}
+      <EdgeLabelRenderer>
+        <div
+          style={{
+            position: "absolute",
+            transform: `translate(-50%, -50%) translate(${labelX}px,${labelY}px)`,
+            pointerEvents: "all",
+          }}
+          className="nodrag nopan"
+        >
+          <span
+            title={`${linkType}（信心值：${confidence}）`}
+            className={cn(
+              "inline-flex items-center px-1.5 py-0.5 rounded-full text-xs font-normal",
+              "bg-background border shadow-sm whitespace-nowrap",
+              "opacity-0 group-hover:opacity-100 transition-opacity"
+            )}
+            style={{ borderColor: color.hex, color: color.hex }}
+          >
+            {color.label}
+          </span>
+        </div>
+      </EdgeLabelRenderer>
+    </>
+  );
+});
+
+// ─── 3. CanvasToolbar ────────────────────────────────────────────────────────
+
+type LayoutMode = "hierarchical" | "force" | "radial";
+
+interface CanvasToolbarProps {
+  layout: LayoutMode;
+  onLayoutChange: (layout: LayoutMode) => void;
+  selectedLinkTypes: LinkType[];
+  onLinkTypesChange: (types: LinkType[]) => void;
+  minConfidence: number;
+  onMinConfidenceChange: (v: number) => void;
+  showIsolated: boolean;
+  onShowIsolatedChange: (v: boolean) => void;
+  searchQuery: string;
+  onSearchChange: (q: string) => void;
+}
+
+export function CanvasToolbar({
+  layout,
+  onLayoutChange,
+  selectedLinkTypes,
+  onLinkTypesChange,
+  minConfidence,
+  onMinConfidenceChange,
+  showIsolated,
+  onShowIsolatedChange,
+  searchQuery,
+  onSearchChange,
+}: CanvasToolbarProps) {
+  const { fitView, zoomIn, zoomOut } = useReactFlow();
+
+  const ALL_LINK_TYPES = Object.keys(LINK_TYPE_COLORS) as LinkType[];
+
+  const toggleLinkType = useCallback(
+    (type: LinkType) => {
+      onLinkTypesChange(
+        selectedLinkTypes.includes(type)
+          ? selectedLinkTypes.filter((t) => t !== type)
+          : [...selectedLinkTypes, type]
+      );
+    },
+    [selectedLinkTypes, onLinkTypesChange]
+  );
+
+  return (
+    <div
+      role="toolbar"
+      aria-label="Canvas 工具列"
+      className="flex items-center gap-3 h-14 px-4 bg-background border-b border-border z-10 flex-wrap"
+    >
+      {/* LayoutToggle */}
+      <ToggleGroup
+        type="single"
+        value={layout}
+        onValueChange={(v) => v && onLayoutChange(v as LayoutMode)}
+        aria-label="佈局模式"
+      >
+        <ToggleGroupItem value="hierarchical" aria-label="層次佈局">
+          <GitBranch className="h-4 w-4" />
+        </ToggleGroupItem>
+        <ToggleGroupItem value="force" aria-label="力導向佈局">
+          <Atom className="h-4 w-4" />
+        </ToggleGroupItem>
+        <ToggleGroupItem value="radial" aria-label="放射佈局">
+          <CircleDot className="h-4 w-4" />
+        </ToggleGroupItem>
+      </ToggleGroup>
+
+      {/* 分隔 */}
+      <div className="w-px h-6 bg-border" aria-hidden="true" />
+
+      {/* FilterBar — link_type 多選 */}
+      <div className="flex items-center gap-1" role="group" aria-label="連結類型篩選">
+        {ALL_LINK_TYPES.map((type) => {
+          const isSelected = selectedLinkTypes.includes(type);
+          const color = LINK_TYPE_COLORS[type];
+          return (
+            <button
+              key={type}
+              onClick={() => toggleLinkType(type)}
+              aria-pressed={isSelected}
+              aria-label={`篩選：${color.label}`}
+              className={cn(
+                "h-6 px-2 rounded-full text-xs font-normal border transition-all",
+                "min-w-[44px] min-h-[44px] flex items-center gap-1",
+                isSelected ? "text-white" : "bg-background text-muted-foreground"
+              )}
+              style={
+                isSelected
+                  ? { backgroundColor: color.hex, borderColor: color.hex }
+                  : { borderColor: color.hex }
+              }
+            >
+              <span
+                className="w-2 h-2 rounded-full flex-shrink-0"
+                style={{ backgroundColor: color.hex }}
+                aria-hidden="true"
+              />
+              {color.label}
+            </button>
+          );
+        })}
+      </div>
+
+      {/* 分隔 */}
+      <div className="w-px h-6 bg-border" aria-hidden="true" />
+
+      {/* min_confidence slider */}
+      <div className="flex items-center gap-2 min-w-[120px]">
+        <label htmlFor="confidence-slider" className="text-xs text-muted-foreground whitespace-nowrap">
+          信心值 ≥ {minConfidence.toFixed(1)}
+        </label>
+        <Slider
+          id="confidence-slider"
+          min={0}
+          max={1}
+          step={0.1}
+          value={[minConfidence]}
+          onValueChange={([v]) => onMinConfidenceChange(v)}
+          className="w-20"
+          aria-label="最低信心值"
+        />
+      </div>
+
+      {/* show isolated toggle */}
+      <div className="flex items-center gap-1.5">
+        <Switch
+          id="show-isolated"
+          checked={showIsolated}
+          onCheckedChange={onShowIsolatedChange}
+          aria-label="顯示孤立節點"
+        />
+        <label htmlFor="show-isolated" className="text-xs text-muted-foreground cursor-pointer">
+          顯示孤立
+        </label>
+      </div>
+
+      {/* 分隔 */}
+      <div className="w-px h-6 bg-border" aria-hidden="true" />
+
+      {/* SearchHighlight */}
+      <div className="relative flex items-center">
+        <Search className="absolute left-2 h-3.5 w-3.5 text-muted-foreground pointer-events-none" aria-hidden="true" />
+        <Input
+          value={searchQuery}
+          onChange={(e) => onSearchChange(e.target.value)}
+          placeholder="搜尋節點..."
+          className="h-8 pl-7 pr-7 w-36 text-sm"
+          aria-label="搜尋節點"
+        />
+        {searchQuery && (
+          <button
+            onClick={() => onSearchChange("")}
+            aria-label="清除搜尋"
+            className="absolute right-2 p-0.5 rounded hover:bg-neutral-100 transition-colors"
+          >
+            <X className="h-3 w-3 text-muted-foreground" />
+          </button>
+        )}
+      </div>
+
+      {/* 彈性空間 */}
+      <div className="flex-1" />
+
+      {/* ZoomControls */}
+      <div className="flex items-center gap-1" role="group" aria-label="縮放控制">
+        <button
+          onClick={() => fitView({ padding: 0.2 })}
+          aria-label="適合視窗"
+          className="w-8 h-8 flex items-center justify-center rounded hover:bg-neutral-100 transition-colors p-1.5"
+        >
+          <Maximize2 className="h-4 w-4" />
+        </button>
+        <button
+          onClick={() => zoomIn()}
+          aria-label="放大"
+          className="w-8 h-8 flex items-center justify-center rounded hover:bg-neutral-100 transition-colors p-1.5"
+        >
+          <ZoomIn className="h-4 w-4" />
+        </button>
+        <button
+          onClick={() => zoomOut()}
+          aria-label="縮小"
+          className="w-8 h-8 flex items-center justify-center rounded hover:bg-neutral-100 transition-colors p-1.5"
+        >
+          <ZoomOut className="h-4 w-4" />
+        </button>
+      </div>
+    </div>
+  );
+}
+
+// ─── 4. NodeDetailSheet ───────────────────────────────────────────────────────
+
+interface NodeDetailSheetProps {
+  open: boolean;
+  onClose: () => void;
+  entry: {
+    title: string;
+    summary: string;
+    tags: string[];
+    category: string;
+    outgoing_links: LinkPreview[];
+    incoming_links: LinkPreview[];
+  } | null;
+  onOpenLibrary: () => void;
+}
+
+export function NodeDetailSheet({ open, onClose, entry, onOpenLibrary }: NodeDetailSheetProps) {
+  return (
+    <Sheet open={open} onOpenChange={(v) => !v && onClose()}>
+      {/* md+ 右側；< md 底部 sheet（side 由 CSS 控制） */}
+      <SheetContent
+        side="right"
+        className="w-full sm:w-[360px] md:w-[360px] p-0 flex flex-col"
+        aria-label={entry ? `節點詳情：${entry.title}` : "節點詳情"}
+      >
+        {entry ? (
+          <>
+            <SheetHeader className="px-5 py-4 border-b border-border">
+              <SheetTitle className="text-xl font-semibold leading-tight pr-8">
+                {entry.title}
+              </SheetTitle>
+              {/* Meta */}
+              <div className="flex items-center gap-1.5 flex-wrap mt-2">
+                <Badge variant="secondary">{entry.category}</Badge>
+                {entry.tags.map((tag) => (
+                  <Badge key={tag} variant="outline" className="text-xs font-normal">
+                    {tag}
+                  </Badge>
+                ))}
+              </div>
+            </SheetHeader>
+
+            <div className="flex-1 overflow-y-auto px-5 py-4 space-y-5">
+              {/* Summary */}
+              {entry.summary && (
+                <section>
+                  <p className="text-sm text-muted-foreground leading-relaxed line-clamp-3">
+                    {entry.summary}
+                  </p>
+                </section>
+              )}
+
+              {/* Outgoing Links */}
+              <section>
+                <h3 className="text-xs font-semibold text-muted-foreground uppercase tracking-wide mb-2">
+                  連出（{entry.outgoing_links.length}）
+                </h3>
+                <div className="space-y-1.5">
+                  {entry.outgoing_links.slice(0, 3).map((link) => (
+                    <LinkPreviewChip key={link.id} link={link} direction="out" />
+                  ))}
+                </div>
+              </section>
+
+              {/* Incoming Links */}
+              <section>
+                <h3 className="text-xs font-semibold text-muted-foreground uppercase tracking-wide mb-2">
+                  連入（{entry.incoming_links.length}）
+                </h3>
+                <div className="space-y-1.5">
+                  {entry.incoming_links.slice(0, 3).map((link) => (
+                    <LinkPreviewChip key={link.id} link={link} direction="in" />
+                  ))}
+                </div>
+              </section>
+            </div>
+
+            {/* Footer */}
+            <div className="px-5 py-4 border-t border-border">
+              <Button variant="outline" className="w-full" onClick={onOpenLibrary}>
+                在 Library 開啟
+              </Button>
+            </div>
+          </>
+        ) : (
+          <div className="flex-1 flex items-center justify-center p-5">
+            <p className="text-sm text-muted-foreground">載入中...</p>
+          </div>
+        )}
+      </SheetContent>
+    </Sheet>
+  );
+}
+
+// 小型 Link Preview chip（NodeDetailSheet 內使用）
+function LinkPreviewChip({
+  link,
+  direction,
+}: {
+  link: LinkPreview;
+  direction: "in" | "out";
+}) {
+  const color = LINK_TYPE_COLORS[link.link_type];
+  return (
+    <div className="flex items-center gap-1.5 text-sm">
+      {direction === "in" && (
+        <span className="text-xs text-muted-foreground">from</span>
+      )}
+      <span
+        className="inline-flex items-center px-1.5 py-0.5 rounded-full text-xs font-normal text-white flex-shrink-0"
+        style={{ backgroundColor: color.hex }}
+      >
+        {color.label}
+      </span>
+      <span className="text-sm text-foreground truncate">{link.title}</span>
+      {link.confidence !== undefined && link.confidence < 1.0 && (
+        <span className="text-xs text-muted-foreground flex-shrink-0">
+          {(link.confidence * 100).toFixed(0)}%
+        </span>
+      )}
+    </div>
+  );
+}
+
+// ─── 5. TruncatedWarningBanner ────────────────────────────────────────────────
+
+export function TruncatedWarningBanner({
+  onClose,
+}: {
+  onClose: () => void;
+}) {
+  return (
+    <div
+      role="alert"
+      className="flex items-center gap-2 h-10 px-4 bg-yellow-50 border-b border-yellow-200 z-20"
+    >
+      <AlertTriangle className="h-4 w-4 text-yellow-700 flex-shrink-0" aria-hidden="true" />
+      <p className="text-sm text-yellow-800 flex-1">
+        圖譜資料已截斷（&gt; 200 節點），建議篩選後查看
+      </p>
+      <button
+        onClick={onClose}
+        aria-label="關閉截斷警告"
+        className="p-1 rounded hover:bg-yellow-100 transition-colors"
+      >
+        <X className="h-3.5 w-3.5 text-yellow-700" />
+      </button>
+    </div>
+  );
+}
+
+// ─── 6. Canvas Empty State ────────────────────────────────────────────────────
+
+export function CanvasEmptyState({ onGoToLibrary }: { onGoToLibrary: () => void }) {
+  return (
+    <div className="flex flex-col items-center justify-center h-full gap-4 p-8 text-center">
+      {/* 插圖 placeholder */}
+      <div
+        className="w-32 h-32 rounded-full bg-neutral-100 flex items-center justify-center"
+        aria-hidden="true"
+      >
+        <svg viewBox="0 0 80 80" className="w-20 h-20 text-neutral-300" fill="none" stroke="currentColor" strokeWidth={1.5}>
+          <circle cx="20" cy="40" r="8" />
+          <circle cx="60" cy="20" r="8" />
+          <circle cx="60" cy="60" r="8" />
+          <line x1="28" y1="37" x2="52" y2="23" />
+          <line x1="28" y1="43" x2="52" y2="57" />
+        </svg>
+      </div>
+      <div className="space-y-1.5">
+        <h2 className="text-xl font-semibold text-foreground">尚無連結關係</h2>
+        <p className="text-sm text-muted-foreground max-w-xs">
+          在 Library 頁面新增條目並設定連結後，此處將顯示知識圖譜
+        </p>
+      </div>
+      <Button onClick={onGoToLibrary}>前往 Library</Button>
+    </div>
+  );
+}
+
+// ─── 組合使用示範 ──────────────────────────────────────────────────────────────
+
+/*
+// 在 CanvasPage 中使用：
+// （完整實作見 design/pages/f045-canvas.md）
+
+const nodeTypes = { entry: EntryNode };
+const edgeTypes = { link: LinkEdge };
+
+<ReactFlowProvider>
+  <div className="flex flex-col h-screen">
+    {truncated && <TruncatedWarningBanner onClose={() => setTruncated(false)} />}
+    <CanvasToolbar ... />
+    <div className="flex-1 relative">
+      <ReactFlow
+        nodes={nodes}
+        edges={edges}
+        nodeTypes={nodeTypes}
+        edgeTypes={edgeTypes}
+        fitView
+      />
+      <NodeDetailSheet
+        open={!!selectedNode}
+        onClose={() => setSelectedNode(null)}
+        entry={selectedEntry}
+        onOpenLibrary={handleOpenLibrary}
+      />
+    </div>
+  </div>
+</ReactFlowProvider>
+*/

--- a/design/components/canvas-graph-node/spec.md
+++ b/design/components/canvas-graph-node/spec.md
@@ -1,0 +1,233 @@
+# Canvas Graph Node（EntryNode + LinkEdge + CanvasToolbar + NodeDetailSheet）
+
+## 對應 Feature
+#220 F-045: Canvas Graph View
+
+## 技術基礎
+- `@xyflow/react` v12（`@xyflow/react` package）
+- 所有自定義節點 Component 必須用 `React.memo` 包裹
+- `LinkEdge` 標籤使用 `EdgeLabelRenderer` portal（非 SVG foreignObject）
+- 佈局引擎：ELK.js（`elkjs` ^0.9），dynamic import 延遲載入
+
+---
+
+## 元件一覽
+
+### 1. EntryNode
+
+#### 用途
+React Flow 自定義節點，顯示知識庫條目卡片。
+
+#### 節點模式（依節點總數分級）
+
+| 節點總數 | 模式 | 顯示內容 |
+|---------|------|---------|
+| ≤ 50 | 完整模式 | title、category badge、confidence badge、完整樣式 |
+| 51–200 | 精簡模式 | title only，移除 badge、confidence，簡化樣式 |
+| > 200 | dot-only 模式 | 僅圓點（16×16px），hover 顯示 tooltip |
+
+#### 完整模式 Props
+
+| Prop | Type | Default | 說明 |
+|------|------|---------|------|
+| data.title | string | — | 條目標題，最多 2 行 ellipsis |
+| data.category | string | — | 分類名稱，對應 badge 顏色 |
+| data.categoryColor | string | — | 分類色彩 token（primary / neutral / etc.） |
+| data.confidence | number | 1.0 | 信心值，< 1.0 時顯示灰色小字 badge |
+| data.mode | 'full' \| 'compact' \| 'dot' | 'full' | 渲染模式 |
+| selected | boolean | false | React Flow 注入，選中狀態 |
+
+#### 尺寸規格
+
+| 模式 | 寬度 | 最小高度 | Padding |
+|------|------|---------|---------|
+| 完整 | 180px | 64px | spacing-3 |
+| 精簡 | 140px | 40px | spacing-2 |
+| dot-only | 16px | 16px | 0 |
+
+#### 外觀規格
+
+| 狀態 | 外觀 |
+|------|------|
+| default | 白底、border-default、radius-lg、shadow-sm |
+| selected | ring 2px primary-500（`ring-2 ring-primary-500`）|
+| hover | shadow-md、cursor-pointer |
+| dot-only | 圓形（radius-full），顏色對應 category |
+
+#### 字型規格
+- title：font-size sm（0.875rem）、font-weight medium、行高 tight（1.25）、最多 2 行、overflow ellipsis
+- category badge：font-size xs（0.75rem）、font-weight normal
+- confidence badge：font-size xs（0.75rem）、color foreground-subtle、背景 neutral-100
+
+#### Accessibility
+- `aria-label`：`{title}，分類：{category}` 
+- `role="button"`（可點擊進入 ego network）
+- `tabIndex={0}`，支援 Enter 觸發 double-click 行為
+- dot-only 模式：`title` attribute 顯示 tooltip（原生 HTML tooltip）
+
+---
+
+### 2. LinkEdge
+
+#### 用途
+React Flow 自定義邊，顯示知識連結。
+
+#### Props
+
+| Prop | Type | 說明 |
+|------|------|------|
+| data.link_type | LinkType | 連結類型 |
+| data.confidence | number | 信心值 |
+| data.relation | string | 關係說明文字（optional） |
+
+#### Link Type 色彩規格
+
+| link_type | 顏色 token | Hex | Badge 文字 |
+|-----------|-----------|-----|-----------|
+| derives_from | blue-500 | #3B82F6 | 衍生自 |
+| contradicts | red-500 | #EF4444 | 矛盾 |
+| duplicate_of | orange-500 | #F97316 | 重複 |
+| references | gray-500 | #6B7280 | 參考 |
+| supersedes | purple-500 | #A855F7 | 取代 |
+| related_to | green-500 | #22C55E | 相關 |
+
+#### 視覺規格
+
+| 條件 | 樣式 |
+|------|------|
+| 預設 | BezierEdge 基底，實線，strokeWidth 1.5 |
+| confidence < 0.5 | 虛線（strokeDasharray: "6 3"）|
+| 選中 | strokeWidth 2.5 |
+| hover | strokeWidth 2，顯示 EdgeLabel |
+
+#### EdgeLabel（EdgeLabelRenderer portal）
+- 位置：邊中點
+- 外觀：白底 pill，font-size xs，對應 link_type 顏色邊框
+- 顯示時機：hover 或圖中 ≤ 50 節點時
+- `title` attribute：顯示 `{link_type}（信心值：{confidence}）`（a11y tooltip）
+
+---
+
+### 3. CanvasToolbar
+
+#### 用途
+Canvas 頁面頂部工具列，含佈局切換、過濾、搜尋、縮放控制。
+
+#### 子元件
+
+##### LayoutToggle（按鈕組）
+
+| 選項 | 圖示 | ELK algorithm |
+|------|------|--------------|
+| hierarchical | `GitBranch`（Lucide） | layered |
+| force | `Atom`（Lucide） | force |
+| radial | `CircleDot`（Lucide） | radial |
+
+外觀：`ToggleGroup`（shadcn），選中項目 primary-600 底色，白色文字。
+
+##### FilterBar
+
+| 控制 | 類型 | 說明 |
+|------|------|------|
+| link_type 多選 | Checkbox group（6 種類型） | 各選項帶對應顏色 dot |
+| min_confidence | Slider（shadcn） | 0.0～1.0，步距 0.1，預設 0 |
+| show isolated | Switch（shadcn） | 顯示無連結節點，預設 off |
+
+##### SearchHighlight
+- Input（shadcn），前置 `Search` icon（Lucide）
+- 輸入時高亮匹配節點（ring highlight），其餘節點半透明（opacity 0.3）
+- placeholder：「搜尋節點...」
+- 清除按鈕（X icon），出現時機：有值時
+
+##### ZoomControls
+- 按鈕組：Fit（`Maximize2`）、放大（`ZoomIn`）、縮小（`ZoomOut`）
+- 尺寸：32×32px（觸控最小 44×44pt — 使用 padding 補足）
+- aria-label：「適合視窗」、「放大」、「縮小」
+
+#### Toolbar 尺寸
+- height：56px
+- padding：spacing-3 spacing-4
+- 背景：background-default，下邊框 border-default
+- z-index：10（覆蓋 Flow 畫布）
+
+---
+
+### 4. NodeDetailSheet
+
+#### 用途
+點擊節點後從右側滑入的詳情側板（shadcn `Sheet`）。
+
+#### Props
+
+| Prop | Type | 說明 |
+|------|------|------|
+| entry.title | string | 條目標題 |
+| entry.summary | string | 摘要（最多 3 行 clamp）|
+| entry.tags | string[] | 標籤列表 |
+| entry.category | string | 分類 |
+| entry.outgoing_links | LinkPreview[] | 外送連結（最多 3 條 preview）|
+| entry.incoming_links | LinkPreview[] | 傳入連結（最多 3 條 preview）|
+| onOpenLibrary | () => void | 跳轉 Library 頁面 |
+| open | boolean | 控制開關 |
+| onClose | () => void | 關閉回呼 |
+
+#### 尺寸與版面
+
+| 斷點 | 樣式 |
+|------|------|
+| >= 768px | 右側滑入，width 360px |
+| < 768px | 底部 bottom sheet，height 60vh |
+
+#### 區段
+1. Header：entry title（font-xl、semibold）+ 關閉按鈕（X icon）
+2. Meta：category badge + tags（Badge component）
+3. Summary：font-sm、foreground-muted、行高 relaxed，最多 3 行（line-clamp-3）
+4. Outgoing Links：小標題「連出」+ 最多 3 條 RelationChip（精簡版，無 edit/delete）
+5. Incoming Links：小標題「連入」+ 最多 3 條 RelationChip（精簡版）
+6. Footer：「在 Library 開啟」Button（variant=secondary，fullWidth）
+
+#### Accessibility
+- `role="dialog"`，`aria-label="節點詳情：{title}"`
+- Escape 鍵關閉
+- 開啟時 focus trap
+
+---
+
+### 5. Truncated Warning Banner
+
+#### 用途
+`meta.truncated = true` 時在 Canvas 頂部顯示警告。
+
+#### 外觀
+- 背景 warning-500 / 10% opacity（`bg-yellow-50`）
+- 左側 `AlertTriangle` icon（warning-700）
+- 文字：「圖譜資料已截斷（> 200 節點），建議篩選後查看」
+- 右側 X 關閉按鈕
+- height：40px，font-size sm
+
+---
+
+### 6. Canvas Empty State
+
+#### 用途
+無 links 時顯示。
+
+#### 外觀
+- 置中插圖（SVG，無文字裝飾圖）
+- 標題：「尚無連結關係」（font-xl、semibold）
+- 說明：「在 Library 頁面新增條目並設定連結後，此處將顯示知識圖譜」（font-sm、foreground-muted）
+- CTA：「前往 Library」Button（variant=primary）
+
+---
+
+## States 總覽
+
+| 元件 | 支援狀態 |
+|------|---------|
+| EntryNode | default / hover / selected / dot-only / compact |
+| LinkEdge | default / hover / selected / dashed（低信心）|
+| CanvasToolbar | — |
+| NodeDetailSheet | open / loading / closed |
+
+## 使用範例
+見 `example.tsx`

--- a/design/components/relation-editor/example.tsx
+++ b/design/components/relation-editor/example.tsx
@@ -1,0 +1,653 @@
+// Relation Editor 元件範例
+// 技術基礎：shadcn/ui + Tailwind CSS v4 + Lucide icons + react-hook-form v7 + zod v3
+
+import React, { useState, useCallback } from "react";
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { z } from "zod";
+import { Pencil, Trash2, PlusCircle, X, Check, ChevronsUpDown } from "lucide-react";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import {
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+} from "@/components/ui/command";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/ui/form";
+import { toast } from "sonner";
+import { cn } from "@/lib/utils";
+
+// ─── 型別 ─────────────────────────────────────────────────────────────────────
+
+type LinkType =
+  | "derives_from"
+  | "contradicts"
+  | "duplicate_of"
+  | "references"
+  | "supersedes"
+  | "related_to";
+
+interface RelationLink {
+  id: string;
+  link_type: LinkType;
+  targetId: string;
+  targetTitle: string;
+  relation?: string;
+  confidence?: number;
+  isLlmGenerated?: boolean;
+}
+
+interface NewRelation {
+  target_entry_id: string;
+  link_type: LinkType;
+  relation?: string;
+}
+
+// ─── Link Type 色彩對應 ────────────────────────────────────────────────────────
+
+const LINK_TYPE_CONFIG: Record<LinkType, { hex: string; label: string }> = {
+  derives_from:  { hex: "#3B82F6", label: "衍生自" },
+  contradicts:   { hex: "#EF4444", label: "矛盾" },
+  duplicate_of:  { hex: "#F97316", label: "重複" },
+  references:    { hex: "#6B7280", label: "參考" },
+  supersedes:    { hex: "#A855F7", label: "取代" },
+  related_to:    { hex: "#22C55E", label: "相關" },
+};
+
+// ─── 1. RelationChip ──────────────────────────────────────────────────────────
+
+interface RelationChipProps {
+  link_type: LinkType;
+  targetTitle: string;
+  targetId: string;
+  relation?: string;
+  confidence?: number;
+  isLlmGenerated?: boolean;
+  direction?: "out" | "in";
+  onEdit?: () => void;
+  onDelete?: () => void;
+  onTitleClick?: (id: string) => void;
+}
+
+export function RelationChip({
+  link_type,
+  targetTitle,
+  targetId,
+  relation,
+  confidence = 1.0,
+  isLlmGenerated = false,
+  direction = "out",
+  onEdit,
+  onDelete,
+  onTitleClick,
+}: RelationChipProps) {
+  const config = LINK_TYPE_CONFIG[link_type];
+  const isLowConfidence = isLlmGenerated && confidence < 0.7;
+  const isOutgoing = direction === "out";
+
+  return (
+    <div
+      role="listitem"
+      className={cn(
+        "group inline-flex items-center gap-1.5 px-2 py-1 rounded-full border bg-background",
+        "text-sm transition-all",
+        isLowConfidence ? "border-dashed" : "border-border"
+      )}
+    >
+      {/* incoming "from" 前綴 */}
+      {!isOutgoing && (
+        <span className="text-xs text-muted-foreground">from</span>
+      )}
+
+      {/* link_type badge */}
+      <span
+        className="inline-flex items-center px-1.5 py-0.5 rounded-full text-xs font-normal text-white flex-shrink-0"
+        style={{ backgroundColor: config.hex }}
+      >
+        {config.label}
+      </span>
+
+      {/* target title */}
+      <button
+        role="link"
+        aria-label={`前往：${targetTitle}`}
+        onClick={() => onTitleClick?.(targetId)}
+        className={cn(
+          "text-sm text-foreground max-w-[200px] truncate",
+          "cursor-pointer underline-offset-2 hover:underline focus:outline-none",
+          "focus-visible:ring-2 focus-visible:ring-primary focus-visible:rounded"
+        )}
+      >
+        {targetTitle}
+      </button>
+
+      {/* relation text */}
+      {relation && (
+        <span className="text-xs text-muted-foreground flex-shrink-0">
+          · {relation}
+        </span>
+      )}
+
+      {/* confidence badge */}
+      {confidence < 1.0 && (
+        <span className="text-xs text-muted-foreground bg-neutral-100 px-1 py-0.5 rounded flex-shrink-0">
+          {(confidence * 100).toFixed(0)}%
+        </span>
+      )}
+
+      {/* Edit / Delete（outgoing only，hover 顯示）*/}
+      {isOutgoing && (onEdit || onDelete) && (
+        <div className="hidden group-hover:flex items-center gap-0.5 ml-0.5">
+          {onEdit && (
+            <button
+              aria-label="編輯連結"
+              onClick={onEdit}
+              className={cn(
+                "p-1.5 rounded-full transition-colors",
+                "hover:bg-primary-50 hover:text-primary",
+                // 視覺 20px，觸控區 padding 補足 44pt
+                "min-w-[32px] min-h-[32px] flex items-center justify-center",
+                "focus-visible:ring-2 focus-visible:ring-primary focus-visible:outline-none"
+              )}
+            >
+              <Pencil className="h-3.5 w-3.5" />
+            </button>
+          )}
+          {onDelete && (
+            <button
+              aria-label={`刪除連結至 ${targetTitle}`}
+              onClick={onDelete}
+              className={cn(
+                "p-1.5 rounded-full transition-colors",
+                "hover:bg-red-50 hover:text-red-600",
+                "min-w-[32px] min-h-[32px] flex items-center justify-center",
+                "focus-visible:ring-2 focus-visible:ring-red-500 focus-visible:outline-none"
+              )}
+            >
+              <Trash2 className="h-3.5 w-3.5" />
+            </button>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ─── 2. RelationsSection ──────────────────────────────────────────────────────
+
+interface RelationsSectionProps {
+  title: string;
+  links: RelationLink[];
+  direction: "out" | "in";
+  onEdit?: (id: string) => void;
+  onDelete?: (id: string) => void;
+  onTitleClick?: (id: string) => void;
+}
+
+export function RelationsSection({
+  title,
+  links,
+  direction,
+  onEdit,
+  onDelete,
+  onTitleClick,
+}: RelationsSectionProps) {
+  return (
+    <section>
+      {/* 標題行 */}
+      <div className="flex items-center gap-2 mb-2">
+        <h3 className="text-xs font-semibold text-muted-foreground uppercase tracking-wide">
+          {title}
+        </h3>
+        <span className="inline-flex items-center px-1.5 py-0.5 rounded text-xs text-muted-foreground bg-neutral-100">
+          {links.length}
+        </span>
+      </div>
+
+      {/* Chip 列表 */}
+      {links.length > 0 ? (
+        <ul
+          role="list"
+          aria-label={`${title}連結列表`}
+          className="flex flex-wrap gap-2"
+        >
+          {links.map((link) => (
+            <li key={link.id} className="contents">
+              <RelationChip
+                link_type={link.link_type}
+                targetId={link.targetId}
+                targetTitle={link.targetTitle}
+                relation={link.relation}
+                confidence={link.confidence}
+                isLlmGenerated={link.isLlmGenerated}
+                direction={direction}
+                onEdit={direction === "out" && onEdit ? () => onEdit(link.id) : undefined}
+                onDelete={direction === "out" && onDelete ? () => onDelete(link.id) : undefined}
+                onTitleClick={onTitleClick}
+              />
+            </li>
+          ))}
+        </ul>
+      ) : (
+        <p className="text-sm text-muted-foreground">尚無連結</p>
+      )}
+    </section>
+  );
+}
+
+// ─── 3. AddRelationForm ────────────────────────────────────────────────────────
+
+const addRelationSchema = z.object({
+  target_entry_id: z.string().min(1, "請選擇目標條目"),
+  link_type: z.enum([
+    "derives_from",
+    "contradicts",
+    "duplicate_of",
+    "references",
+    "supersedes",
+    "related_to",
+  ] as const, { required_error: "請選擇連結類型" }),
+  relation: z.string().optional(),
+});
+
+type AddRelationFormValues = z.infer<typeof addRelationSchema>;
+
+interface EntryOption {
+  id: string;
+  title: string;
+  category: string;
+}
+
+interface AddRelationFormProps {
+  onSubmit: (data: NewRelation) => Promise<void>;
+  isLoading?: boolean;
+  /** 搜尋條目的非同步函式 */
+  searchEntries: (query: string) => Promise<EntryOption[]>;
+}
+
+export function AddRelationForm({
+  onSubmit,
+  isLoading = false,
+  searchEntries,
+}: AddRelationFormProps) {
+  const [expanded, setExpanded] = useState(false);
+  const [comboboxOpen, setComboboxOpen] = useState(false);
+  const [entryOptions, setEntryOptions] = useState<EntryOption[]>([]);
+  const [selectedEntry, setSelectedEntry] = useState<EntryOption | null>(null);
+  const [searching, setSearching] = useState(false);
+
+  const form = useForm<AddRelationFormValues>({
+    resolver: zodResolver(addRelationSchema),
+    defaultValues: { target_entry_id: "", link_type: undefined, relation: "" },
+  });
+
+  const handleSearch = useCallback(
+    async (query: string) => {
+      if (!query.trim()) {
+        setEntryOptions([]);
+        return;
+      }
+      setSearching(true);
+      try {
+        const results = await searchEntries(query);
+        setEntryOptions(results);
+      } finally {
+        setSearching(false);
+      }
+    },
+    [searchEntries]
+  );
+
+  const handleSubmit = async (values: AddRelationFormValues) => {
+    try {
+      await onSubmit({
+        target_entry_id: values.target_entry_id,
+        link_type: values.link_type,
+        relation: values.relation || undefined,
+      });
+      toast.success("連結已新增");
+      form.reset();
+      setSelectedEntry(null);
+      setExpanded(false);
+    } catch {
+      toast.error("新增失敗，請重試");
+    }
+  };
+
+  if (!expanded) {
+    return (
+      <Button
+        variant="ghost"
+        size="sm"
+        onClick={() => setExpanded(true)}
+        className="gap-1.5 text-muted-foreground hover:text-foreground mt-2"
+      >
+        <PlusCircle className="h-4 w-4" aria-hidden="true" />
+        新增連結
+      </Button>
+    );
+  }
+
+  return (
+    <Form {...form}>
+      <form
+        onSubmit={form.handleSubmit(handleSubmit)}
+        className="mt-3 space-y-3 p-3 border border-border rounded-lg bg-background transition-all"
+        aria-label="新增連結表單"
+      >
+        {/* 目標條目 Combobox */}
+        <FormField
+          control={form.control}
+          name="target_entry_id"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel className="text-xs font-medium">目標條目</FormLabel>
+              <FormControl>
+                <Popover open={comboboxOpen} onOpenChange={setComboboxOpen}>
+                  <PopoverTrigger asChild>
+                    <button
+                      role="combobox"
+                      aria-expanded={comboboxOpen}
+                      aria-label="選擇目標條目"
+                      className={cn(
+                        "w-full flex items-center justify-between",
+                        "h-9 px-3 py-2 text-sm border border-input rounded-md bg-background",
+                        "hover:bg-accent focus-visible:ring-2 focus-visible:ring-ring focus-visible:outline-none",
+                        !selectedEntry && "text-muted-foreground"
+                      )}
+                    >
+                      {selectedEntry ? (
+                        <span className="flex items-center gap-1.5 truncate">
+                          <span>{selectedEntry.title}</span>
+                          <Badge variant="secondary" className="text-xs font-normal">
+                            {selectedEntry.category}
+                          </Badge>
+                        </span>
+                      ) : (
+                        "搜尋條目..."
+                      )}
+                      <ChevronsUpDown className="ml-2 h-4 w-4 shrink-0 opacity-50" aria-hidden="true" />
+                    </button>
+                  </PopoverTrigger>
+                  <PopoverContent className="w-[300px] p-0" align="start">
+                    <Command shouldFilter={false}>
+                      <CommandInput
+                        placeholder="輸入關鍵字搜尋..."
+                        onValueChange={handleSearch}
+                        aria-label="搜尋條目"
+                      />
+                      <CommandList>
+                        {searching ? (
+                          <div className="py-6 text-center text-sm text-muted-foreground">搜尋中...</div>
+                        ) : (
+                          <>
+                            <CommandEmpty>找不到符合的條目</CommandEmpty>
+                            <CommandGroup>
+                              {entryOptions.map((entry) => (
+                                <CommandItem
+                                  key={entry.id}
+                                  value={entry.id}
+                                  onSelect={() => {
+                                    setSelectedEntry(entry);
+                                    field.onChange(entry.id);
+                                    setComboboxOpen(false);
+                                  }}
+                                >
+                                  <Check
+                                    className={cn(
+                                      "mr-2 h-4 w-4",
+                                      field.value === entry.id ? "opacity-100" : "opacity-0"
+                                    )}
+                                    aria-hidden="true"
+                                  />
+                                  <span className="flex-1 truncate">{entry.title}</span>
+                                  <Badge variant="secondary" className="text-xs font-normal ml-2">
+                                    {entry.category}
+                                  </Badge>
+                                </CommandItem>
+                              ))}
+                            </CommandGroup>
+                          </>
+                        )}
+                      </CommandList>
+                    </Command>
+                  </PopoverContent>
+                </Popover>
+              </FormControl>
+              <FormMessage className="text-xs" />
+            </FormItem>
+          )}
+        />
+
+        {/* 連結類型 Select */}
+        <FormField
+          control={form.control}
+          name="link_type"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel className="text-xs font-medium">連結類型</FormLabel>
+              <Select onValueChange={field.onChange} defaultValue={field.value}>
+                <FormControl>
+                  <SelectTrigger aria-label="選擇連結類型" className="h-9 text-sm">
+                    <SelectValue placeholder="選擇連結類型" />
+                  </SelectTrigger>
+                </FormControl>
+                <SelectContent>
+                  {(Object.keys(LINK_TYPE_CONFIG) as LinkType[]).map((type) => {
+                    const config = LINK_TYPE_CONFIG[type];
+                    return (
+                      <SelectItem key={type} value={type}>
+                        <span className="flex items-center gap-2">
+                          <span
+                            className="w-2 h-2 rounded-full flex-shrink-0"
+                            style={{ backgroundColor: config.hex }}
+                            aria-hidden="true"
+                          />
+                          {config.label}
+                        </span>
+                      </SelectItem>
+                    );
+                  })}
+                </SelectContent>
+              </Select>
+              <FormMessage className="text-xs" />
+            </FormItem>
+          )}
+        />
+
+        {/* 關係說明 Input */}
+        <FormField
+          control={form.control}
+          name="relation"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel className="text-xs font-medium">
+                關係說明
+                <span className="text-muted-foreground font-normal ml-1">（選填）</span>
+              </FormLabel>
+              <FormControl>
+                <Input
+                  {...field}
+                  placeholder="關係描述（選填）"
+                  className="h-9 text-sm"
+                  aria-label="關係說明（選填）"
+                />
+              </FormControl>
+              <FormMessage className="text-xs" />
+            </FormItem>
+          )}
+        />
+
+        {/* 操作按鈕 */}
+        <div className="flex items-center gap-2 pt-1">
+          <Button
+            type="submit"
+            size="sm"
+            disabled={isLoading || form.formState.isSubmitting}
+            aria-busy={isLoading || form.formState.isSubmitting}
+            className="flex-1"
+          >
+            {(isLoading || form.formState.isSubmitting) ? (
+              <>
+                <span
+                  className="mr-1.5 h-3.5 w-3.5 animate-spin rounded-full border-2 border-current border-t-transparent"
+                  aria-hidden="true"
+                />
+                新增中...
+              </>
+            ) : (
+              "新增連結"
+            )}
+          </Button>
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            onClick={() => {
+              setExpanded(false);
+              form.reset();
+              setSelectedEntry(null);
+            }}
+          >
+            取消
+          </Button>
+        </div>
+      </form>
+    </Form>
+  );
+}
+
+// ─── 組合使用示範 ──────────────────────────────────────────────────────────────
+
+/*
+// 在 Entry Detail Panel 中使用：
+
+const outgoingLinks: RelationLink[] = [
+  {
+    id: "link-1",
+    link_type: "derives_from",
+    targetId: "entry-abc",
+    targetTitle: "機器學習基礎",
+    confidence: 0.9,
+    isLlmGenerated: true,
+  },
+  {
+    id: "link-2",
+    link_type: "references",
+    targetId: "entry-def",
+    targetTitle: "深度學習論文",
+    relation: "核心參考",
+    confidence: 1.0,
+    isLlmGenerated: false,
+  },
+];
+
+const incomingLinks: RelationLink[] = [
+  {
+    id: "link-3",
+    link_type: "supersedes",
+    targetId: "entry-ghi",
+    targetTitle: "舊版神經網路筆記",
+    confidence: 0.85,
+    isLlmGenerated: true,
+  },
+];
+
+function EntryRelationsPanel() {
+  return (
+    <div className="space-y-5">
+      <RelationsSection
+        title="連出"
+        links={outgoingLinks}
+        direction="out"
+        onEdit={(id) => console.log("edit", id)}
+        onDelete={(id) => console.log("delete", id)}
+        onTitleClick={(id) => router.push(`/library/${id}`)}
+      />
+
+      <AddRelationForm
+        onSubmit={async (data) => {
+          await createLink(data);
+        }}
+        searchEntries={async (q) => fetchEntries(q)}
+      />
+
+      <RelationsSection
+        title="連入"
+        links={incomingLinks}
+        direction="in"
+        onTitleClick={(id) => router.push(`/library/${id}`)}
+      />
+    </div>
+  );
+}
+*/
+
+// ─── 獨立示範 ─────────────────────────────────────────────────────────────────
+
+// outgoing chip（完整模式）
+export const OutgoingChipExample = (
+  <RelationChip
+    link_type="derives_from"
+    targetId="entry-1"
+    targetTitle="機器學習基礎"
+    relation="核心概念"
+    confidence={0.9}
+    isLlmGenerated={true}
+    direction="out"
+    onEdit={() => {}}
+    onDelete={() => {}}
+    onTitleClick={(id) => console.log("navigate to", id)}
+  />
+);
+
+// incoming chip（唯讀，無 Edit/Delete）
+export const IncomingChipExample = (
+  <RelationChip
+    link_type="supersedes"
+    targetId="entry-2"
+    targetTitle="舊版筆記"
+    confidence={0.85}
+    isLlmGenerated={true}
+    direction="in"
+    onTitleClick={(id) => console.log("navigate to", id)}
+  />
+);
+
+// LLM 低信心虛線 chip（confidence < 0.7）
+export const LowConfidenceChipExample = (
+  <RelationChip
+    link_type="contradicts"
+    targetId="entry-3"
+    targetTitle="相矛盾的觀點"
+    confidence={0.5}
+    isLlmGenerated={true}
+    direction="out"
+    onEdit={() => {}}
+    onDelete={() => {}}
+    onTitleClick={(id) => console.log("navigate to", id)}
+  />
+);

--- a/design/components/relation-editor/spec.md
+++ b/design/components/relation-editor/spec.md
@@ -1,0 +1,180 @@
+# Relation Editor（RelationChip + RelationsSection + AddRelationForm）
+
+## 對應 Feature
+#221 F-046: Relation Editor
+
+## 技術基礎
+- shadcn/ui primitives：Badge、Sheet、Select、Button、Input
+- Combobox：沿用既有 Combobox primitive（Entry 搜尋用）
+- Tailwind CSS v4 + Lucide icons
+
+---
+
+## 元件一覽
+
+### 1. RelationChip
+
+#### 用途
+顯示單一連結關係的 chip。區分 outgoing（可編輯）與 incoming（唯讀）兩種模式。
+
+#### Props
+
+| Prop | Type | Default | 說明 |
+|------|------|---------|------|
+| link_type | LinkType | — | 連結類型，對應色彩規格 |
+| targetTitle | string | — | 目標條目標題（可點擊） |
+| targetId | string | — | 目標條目 ID |
+| relation | string \| undefined | — | 關係說明文字（灰色小字） |
+| confidence | number | 1.0 | 信心值，< 1.0 顯示 badge |
+| isLlmGenerated | boolean | false | LLM 生成標記 |
+| direction | 'out' \| 'in' | 'out' | outgoing 或 incoming |
+| onEdit | () => void \| undefined | — | 編輯回呼（outgoing only） |
+| onDelete | () => void \| undefined | — | 刪除回呼（outgoing only） |
+| onTitleClick | (id: string) => void | — | 標題點擊回呼 |
+
+#### 外觀規格
+
+| 條件 | 樣式 |
+|------|------|
+| 預設 | 白底 pill，border border-border，radius-full，padding spacing-1 spacing-2 |
+| LLM + confidence < 0.7 | 虛線外框（`border-dashed`）|
+| incoming | 前置「from」灰色小字標籤 |
+| hover（outgoing only） | 顯示 Edit + Delete icon buttons |
+
+#### Chip 內容排列（左→右）
+
+**outgoing chip：**
+```
+[link_type badge] [target title] [relation text?] [confidence?] | [Edit icon] [Delete icon]
+```
+
+**incoming chip：**
+```
+[from 標籤] [link_type badge] [source title] [relation text?] [confidence?]
+```
+
+#### link_type badge 規格
+- 圓角 pill，對應色彩背景，白色文字
+- font-size xs（0.75rem）
+- padding：spacing-1 spacing-1.5
+
+#### target title 規格
+- font-size sm（0.875rem）
+- 可點擊：`cursor-pointer underline-offset-2 hover:underline`
+- 最大寬度 200px，overflow ellipsis
+
+#### relation text 規格
+- font-size xs（0.75rem）
+- 顏色：foreground-subtle
+- 以「·」分隔顯示
+
+#### confidence badge 規格
+- 顯示條件：confidence < 1.0
+- 外觀：foreground-subtle 顏色，neutral-100 背景，font-size xs
+- 格式：`{confidence*100}%`
+
+#### Edit / Delete icon buttons 規格
+- 圖示：`Pencil`（Edit）、`Trash2`（Delete）— Lucide
+- 尺寸：20×20px，padding 補足至 44×44pt 觸控區
+- hover 狀態：Edit 用 primary-50 背景，Delete 用 red-50 背景
+- aria-label：「編輯連結」、「刪除連結」
+- 顯示時機：chip hover 時（`group-hover:flex`，預設 `hidden`）
+
+#### Accessibility
+- `role="listitem"`
+- 可點擊 title：`role="link"`，`aria-label="前往：{targetTitle}"`
+- Delete 按鈕：`aria-label="刪除連結至 {targetTitle}"`
+
+---
+
+### 2. RelationsSection
+
+#### 用途
+Outgoing / Incoming 分區標題 + RelationChip 列表容器。
+
+#### Props
+
+| Prop | Type | 說明 |
+|------|------|------|
+| title | string | 區段標題（「連出」/ 「連入」）|
+| links | RelationLink[] | 連結資料陣列 |
+| direction | 'out' \| 'in' | 控制 RelationChip 模式 |
+| onEdit | (id: string) => void | 編輯回呼（direction=out）|
+| onDelete | (id: string) => void | 刪除回呼（direction=out）|
+| onTitleClick | (id: string) => void | 標題點擊跳轉 |
+
+#### 外觀規格
+
+- 區段標題：font-size xs、font-weight semibold、foreground-muted、uppercase、tracking-wide
+- 標題右側：chip 數量 badge（neutral-100 背景，foreground-subtle 文字）
+- chip 列表：`flex flex-wrap gap-2 mt-2`
+- 空白狀態（無連結）：「尚無連結」文字，foreground-subtle，font-size sm
+
+---
+
+### 3. AddRelationForm
+
+#### 用途
+新增連結的表單（顯示於 outgoing 區塊下方，可展開/收合）。
+
+#### Props
+
+| Prop | Type | Default | 說明 |
+|------|------|---------|------|
+| onSubmit | (data: NewRelation) => Promise\<void\> | — | 提交回呼 |
+| isLoading | boolean | false | 提交中 |
+
+#### NewRelation 型別
+```ts
+interface NewRelation {
+  target_entry_id: string;
+  link_type: LinkType;
+  relation?: string;
+}
+```
+
+#### 表單欄位規格
+
+| 欄位 | 元件 | 說明 |
+|------|------|------|
+| 目標條目 | EntrySearch Combobox | 搜尋現有條目，顯示名稱 + 分類 |
+| 連結類型 | Select（shadcn） | 6 種 link_type，各帶顏色 dot |
+| 關係說明 | Input（shadcn） | optional，placeholder「關係描述（選填）」|
+| 送出 | Button primary | 「新增連結」，loading 時顯示 spinner |
+
+#### EntrySearch Combobox 規格
+- 使用既有 Combobox primitive
+- 搜尋時呼叫 API：`GET /api/v1/entries?q={query}&limit=10`
+- 每個選項：條目 title（font-sm）+ 分類 badge（font-xs）
+- 空白狀態：「找不到符合的條目」（foreground-subtle，font-sm）
+- 選中後：顯示條目 title + 分類，X 清除按鈕
+
+#### Link Type Select 規格
+- 每個選項帶顏色 dot（`link_type` 對應色彩）
+- placeholder：「選擇連結類型」
+
+#### 表單驗證
+- 目標條目：必填（顯示錯誤：「請選擇目標條目」）
+- 連結類型：必填（顯示錯誤：「請選擇連結類型」）
+- 錯誤訊息顯示於欄位正下方，error-500 顏色，font-size xs
+
+#### 送出行為
+1. 驗證通過 → Button 進入 loading 狀態（spinner + 文字「新增中...」）
+2. 成功 → Toast「連結已新增」（成功色）+ 表單重置
+3. 失敗 → Toast「新增失敗，請重試」（錯誤色）+ Button 恢復
+
+#### 展開/收合控制
+- 預設：收合，顯示「+ 新增連結」按鈕（ghost variant，PlusCircle icon）
+- 展開後：顯示表單，按鈕改為「取消」
+- 動畫：150ms ease-out（`transition-all`）
+
+## States 總覽
+
+| 元件 | 支援狀態 |
+|------|---------|
+| RelationChip | default / hover（outgoing）/ dashed（LLM 低信心）/ incoming（唯讀）|
+| RelationsSection | default / empty |
+| AddRelationForm | collapsed / expanded / loading / success / error |
+
+## 使用範例
+見 `example.tsx`

--- a/design/pages/f045-canvas.md
+++ b/design/pages/f045-canvas.md
@@ -1,0 +1,171 @@
+# Canvas Page（/canvas）
+
+## 對應 Feature
+#220 F-045: Canvas Graph View
+
+## 技術基礎
+- `@xyflow/react` v12（ReactFlowProvider + ReactFlow）
+- ELK.js 佈局（dynamic import）
+- shadcn/ui Sheet（NodeDetailSheet）
+- Next.js App Router
+
+---
+
+## 整體版面
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│  App Shell Navbar（height: 64px）                               │
+├─────────────────────────────────────────────────────────────────┤
+│  [TruncatedWarningBanner: 40px — meta.truncated=true 時顯示]    │
+├─────────────────────────────────────────────────────────────────┤
+│  CanvasToolbar（height: 56px）                                  │
+│  ┌──LayoutToggle──┐ ┌──FilterBar──┐ ┌──SearchHighlight──┐      │
+│  │ 層次 力 放射   │ │ 6 type chip │ │ 搜尋框            │      │
+│  └───────────────┘ └─────────────┘ └──────────────────-─┘      │
+│                                     [ZoomControls: Fit/+/-]     │
+├─────────────────────────────────────────────────────────────────┤
+│                                                                  │
+│  React Flow 畫布（flex-1，100% 剩餘高度）                       │
+│                                                                  │
+│  ┌─────────────────────────────────┐   ┌───────────────────┐   │
+│  │  EntryNode（卡片）              │   │  NodeDetailSheet  │   │
+│  │  ╔═══════════════╗             │   │  （右側，360px）  │   │
+│  │  ║ Title         ║             │   │                   │   │
+│  │  ║ [cat badge]   ║             │   │  [entry title]    │   │
+│  │  ╚═══════════════╝             │   │  [meta badges]    │   │
+│  │          ↓ LinkEdge            │   │  [summary]        │   │
+│  │  ╔═══════════════╗             │   │  [連出 chips]     │   │
+│  │  ║ Target Entry  ║             │   │  [連入 chips]     │   │
+│  │  ╚═══════════════╝             │   │                   │   │
+│  └─────────────────────────────────┘   │  [在Library開啟]  │   │
+│                                         └───────────────────┘   │
+│  [React Flow MiniMap — 右下角]                                   │
+│  [React Flow Attribution — 左下角]                              │
+│                                                                  │
+│  ┌ Empty State（無連結時，整個畫布區置中）─────────────────┐    │
+│  │  [圖示] 尚無連結關係  [前往 Library 按鈕]               │    │
+│  └──────────────────────────────────────────────────────────┘   │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+---
+
+## 響應式行為
+
+| 斷點 | 變化 |
+|------|------|
+| >= 768px（md） | NodeDetailSheet 右側滑入（width: 360px）；CanvasToolbar 單行 |
+| < 768px（sm） | NodeDetailSheet 改為底部 bottom sheet（height: 60vh）；FilterBar 折疊為下拉按鈕 |
+| < 640px | LayoutToggle 僅顯示 icon（不顯示文字標籤）；ZoomControls 縮小 |
+
+---
+
+## 使用的元件
+
+| 元件 | 來源 | 用途 |
+|------|------|------|
+| CanvasToolbar | `design/components/canvas-graph-node` | 工具列 |
+| EntryNode | `design/components/canvas-graph-node` | 節點卡片 |
+| LinkEdge | `design/components/canvas-graph-node` | 連結邊 |
+| NodeDetailSheet | `design/components/canvas-graph-node` | 節點詳情側板 |
+| TruncatedWarningBanner | `design/components/canvas-graph-node` | 截斷警告 |
+| CanvasEmptyState | `design/components/canvas-graph-node` | 空白狀態 |
+| ReactFlow（@xyflow/react） | 第三方 | 圖譜渲染引擎 |
+| MiniMap（@xyflow/react） | 第三方 | 縮略圖導覽 |
+
+---
+
+## 頁面狀態機
+
+```
+初始載入
+  │
+  ▼
+Loading（skeleton：Toolbar 骨架 + 畫布 spinner）
+  │
+  ├─ 成功且有資料 ──→ 渲染 ReactFlow 圖譜
+  │                        │
+  │               ┌─ meta.truncated=true ──→ 顯示 TruncatedWarningBanner
+  │               └─ 點擊節點 ──→ NodeDetailSheet open=true
+  │
+  ├─ 成功但無連結 ──→ CanvasEmptyState
+  │
+  └─ 失敗 ──→ Error state（Toast + 重試按鈕）
+```
+
+---
+
+## Canvas 載入 Skeleton
+
+- Toolbar 區域：3 個灰色圓角方塊（`animate-pulse`）
+- 畫布區域：居中顯示 spinner（`LoaderCircle` icon，Lucide，animate-spin）
+
+---
+
+## 佈局計算流程
+
+1. 頁面載入：`GET /api/v1/graph?entry_id={id}&depth=2`（預設 ego network）
+2. 收到資料後，dynamic import ELK（`import('elkjs/lib/elk.bundled.js')`）
+3. ELK Web Worker 執行 `layered` 佈局算法
+4. 佈局完成後，更新 nodes 位置，呼叫 `fitView()`
+5. 切換佈局（LayoutToggle）：重新執行步驟 3-4，300ms 動畫過渡
+
+---
+
+## 節點模式觸發
+
+| 條件 | 行為 |
+|------|------|
+| 節點總數 ≤ 50 | 所有 EntryNode 用 `mode="full"` |
+| 節點總數 51–200 | 所有 EntryNode 用 `mode="compact"` |
+| 節點總數 > 200 | 所有 EntryNode 用 `mode="dot"`；顯示 TruncatedWarningBanner |
+
+---
+
+## 鍵盤互動
+
+| 快捷鍵 | 行為 |
+|--------|------|
+| `Escape` | 關閉 NodeDetailSheet |
+| `Cmd/Ctrl + F` | 聚焦 SearchHighlight |
+| `+` / `-` | Zoom In / Out |
+| `0` | Fit View |
+| `Tab` | 在 Toolbar 控制項間導覽 |
+
+---
+
+## 數據來源
+
+| API | 用途 |
+|-----|------|
+| `GET /api/v1/graph?entry_id={id}&depth={n}` | 取得圖譜資料（nodes + edges + meta）|
+| `GET /api/v1/entries/{id}` | 取得節點詳情（NodeDetailSheet 用）|
+
+---
+
+## z-index 層級
+
+| 元件 | z-index |
+|------|---------|
+| TruncatedWarningBanner | 20 |
+| CanvasToolbar | 10 |
+| NodeDetailSheet | 50（shadcn Sheet 預設）|
+| ReactFlow MiniMap | 5 |
+
+---
+
+## 效能注意事項
+
+- `nodeTypes` 和 `edgeTypes` 物件必須在元件外（或 `useMemo`）定義，避免每次 render 建立新參考
+- `EntryNode` / `LinkEdge` 均以 `React.memo` 包裹
+- `onNodesChange` / `onEdgesChange` handlers 使用 `useCallback`
+- ELK 使用 dynamic import + Web Worker，避免阻塞 UI
+
+---
+
+## 空白狀態規格
+
+顯示條件：API 回傳 nodes 陣列為空（無任何帶 links 的條目）。
+
+詳見 `design/components/canvas-graph-node/spec.md` — Canvas Empty State 段落。


### PR DESCRIPTION
## 摘要

Sprint 15 UI component dataset，供前端 engineer 開發 F-045 / F-046 使用。

## 新增元件

| 元件 | Spec | Example | 說明 |
|------|------|---------|------|
| canvas-graph-node | `design/components/canvas-graph-node/spec.md` | ✅ | EntryNode、LinkEdge、CanvasToolbar、NodeDetailSheet、TruncatedWarningBanner、Empty State |
| relation-editor | `design/components/relation-editor/spec.md` | ✅ | RelationChip（outgoing/incoming）、RelationsSection、AddRelationForm |
| ai-suggestion-chip | `design/components/ai-suggestion-chip/spec.md` | ✅ | pending/accepted/rejected 三種狀態 |

## 新增頁面

| 頁面 | Layout |
|------|--------|
| Canvas（/canvas） | `design/pages/f045-canvas.md` |

## 設計決策

- EntryNode 三段模式（full/compact/dot-only）對應節點數分級（≤50 / 51–200 / >200）
- LinkEdge 6 種 link_type 色彩規格，confidence < 0.5 自動切換虛線
- AISuggestionChip confidence badge 三色系（green/yellow/red）直觀呈現信心水準
- NodeDetailSheet 在 < 768px 切換為 bottom sheet，符合行動端 UX

## Pre-Delivery Checklist

- [x] 無 emoji icon，全數使用 Lucide icon set
- [x] 觸控目標 >= 44pt（padding 補足）
- [x] 所有互動元素有 focus-visible ring
- [x] 完整 aria-label / aria-expanded / aria-live 規格
- [x] prefers-reduced-motion 支援（motion-reduce: 前綴）
- [x] Mobile-first，< 768px 響應式行為已定義
- [x] semantic color tokens（不寫死色碼，除 link_type hex 需精確對應規格）

Closes #222