### PR TITLE
[Feature] F-044: Entry Links Backend

### DIFF
--- a/dev/__tests__/handler/entry_links_test.go
+++ b/dev/__tests__/handler/entry_links_test.go
@@ -1,0 +1,158 @@
+package handler_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+	"github.com/gpwork4u/aibo/dto"
+	"github.com/gpwork4u/aibo/model"
+)
+
+// --- 測試 dto 結構序列化 ---
+
+// TestCreateEntryLinkRequestSerialization 測試建立關聯請求的 JSON 解析
+func TestCreateEntryLinkRequestSerialization(t *testing.T) {
+	toID := uuid.New()
+	lt := model.LinkTypeDerivesFrom
+	rel := "基於概念延伸"
+	conf := 0.95
+	src := model.LinkSourceManual
+
+	req := dto.CreateEntryLinkRequest{
+		ToID:       toID,
+		LinkType:   &lt,
+		Relation:   &rel,
+		Confidence: &conf,
+		Source:     &src,
+	}
+
+	data, err := json.Marshal(req)
+	if err != nil {
+		t.Fatalf("marshal failed: %v", err)
+	}
+
+	var parsed dto.CreateEntryLinkRequest
+	if err := json.Unmarshal(data, &parsed); err != nil {
+		t.Fatalf("unmarshal failed: %v", err)
+	}
+
+	if parsed.ToID != toID {
+		t.Errorf("to_id mismatch: got %s want %s", parsed.ToID, toID)
+	}
+	if parsed.LinkType == nil || *parsed.LinkType != lt {
+		t.Errorf("link_type mismatch")
+	}
+	if parsed.Relation == nil || *parsed.Relation != rel {
+		t.Errorf("relation mismatch")
+	}
+	if parsed.Confidence == nil || *parsed.Confidence != conf {
+		t.Errorf("confidence mismatch")
+	}
+	if parsed.Source == nil || *parsed.Source != src {
+		t.Errorf("source mismatch")
+	}
+}
+
+// TestSelfLinkDetection 測試 handler 層 self-link 邏輯（不依賴 DB）
+func TestSelfLinkDetection(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	// 建立一個簡易 gin router 來驗證 self-link 422 回傳
+	r := gin.New()
+	r.POST("/entries/:id/links", func(c *gin.Context) {
+		idStr := c.Param("id")
+		fromID, err := uuid.Parse(idStr)
+		if err != nil {
+			c.JSON(http.StatusBadRequest, dto.ErrorResponse{Code: model.ErrCodeInvalidInput, Message: "invalid id"})
+			return
+		}
+
+		var req dto.CreateEntryLinkRequest
+		if err := c.ShouldBindJSON(&req); err != nil {
+			c.JSON(http.StatusBadRequest, dto.ErrorResponse{Code: model.ErrCodeInvalidInput, Message: err.Error()})
+			return
+		}
+
+		// self-link check（同 entry_links.go 邏輯）
+		if fromID == req.ToID {
+			c.JSON(http.StatusUnprocessableEntity, dto.ErrorResponse{
+				Code:    model.ErrCodeSelfLink,
+				Message: "不允許自我關聯",
+			})
+			return
+		}
+		c.JSON(http.StatusCreated, gin.H{"ok": true})
+	})
+
+	entryID := uuid.New()
+	body := map[string]interface{}{
+		"to_id":     entryID.String(),
+		"link_type": "derives_from",
+	}
+	bodyBytes, _ := json.Marshal(body)
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/entries/"+entryID.String()+"/links", bytes.NewReader(bodyBytes))
+	req.Header.Set("Content-Type", "application/json")
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusUnprocessableEntity {
+		t.Errorf("expected 422 for self-link, got %d", w.Code)
+	}
+
+	var resp dto.ErrorResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("unmarshal response failed: %v", err)
+	}
+	if resp.Code != model.ErrCodeSelfLink {
+		t.Errorf("expected code %s, got %s", model.ErrCodeSelfLink, resp.Code)
+	}
+}
+
+// TestValidLinkTypes 測試 ValidLinkTypes 常數集合
+func TestValidLinkTypes(t *testing.T) {
+	validTypes := []model.LinkType{
+		model.LinkTypeDerivesFrom,
+		model.LinkTypeContradicts,
+		model.LinkTypeDuplicateOf,
+		model.LinkTypeReferences,
+		model.LinkTypeSupersedes,
+		model.LinkTypeRelatedTo,
+	}
+
+	for _, lt := range validTypes {
+		if !model.ValidLinkTypes[lt] {
+			t.Errorf("expected %s to be valid", lt)
+		}
+	}
+
+	// 非法值
+	invalid := model.LinkType("invalid_type")
+	if model.ValidLinkTypes[invalid] {
+		t.Errorf("expected %s to be invalid", invalid)
+	}
+}
+
+// TestUpdateEntryLinkRequestPartial 測試 PATCH 部分更新結構
+func TestUpdateEntryLinkRequestPartial(t *testing.T) {
+	// 只更新 relation
+	rel := "新的關係描述"
+	req := dto.UpdateEntryLinkRequest{
+		Relation: &rel,
+	}
+
+	if req.LinkType != nil {
+		t.Error("link_type should be nil when not set")
+	}
+	if req.Relation == nil || *req.Relation != rel {
+		t.Error("relation should match")
+	}
+	if req.Confidence != nil {
+		t.Error("confidence should be nil when not set")
+	}
+}

--- a/dev/src/dto/entry_link.go
+++ b/dev/src/dto/entry_link.go
@@ -1,0 +1,72 @@
+package dto
+
+import (
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/gpwork4u/aibo/model"
+)
+
+// CreateEntryLinkRequest 建立關聯的請求 body
+type CreateEntryLinkRequest struct {
+	ToID       uuid.UUID        `json:"to_id"`
+	LinkType   *model.LinkType  `json:"link_type"`   // 預設 related_to
+	Relation   *string          `json:"relation"`
+	Confidence *float64         `json:"confidence"`  // 預設 1.0（manual）
+	Source     *model.LinkSource `json:"source"`     // 預設 manual
+}
+
+// UpdateEntryLinkRequest PATCH /entries/links/:link_id 請求 body（部分更新）
+type UpdateEntryLinkRequest struct {
+	LinkType   *model.LinkType  `json:"link_type"`
+	Relation   *string          `json:"relation"`
+	Confidence *float64         `json:"confidence"`
+}
+
+// EntryRefDTO 關聯中的對端 entry 簡要資訊
+type EntryRefDTO struct {
+	ID      uuid.UUID `json:"id"`
+	Title   *string   `json:"title"`
+	Summary *string   `json:"summary"`
+}
+
+// OutgoingLinkDTO 向外關聯（from_id == 當前 entry）
+type OutgoingLinkDTO struct {
+	ID         uuid.UUID      `json:"id"`
+	ToEntry    EntryRefDTO    `json:"to_entry"`
+	LinkType   model.LinkType `json:"link_type"`
+	Relation   *string        `json:"relation"`
+	Confidence float64        `json:"confidence"`
+	Source     model.LinkSource `json:"source"`
+	CreatedAt  time.Time      `json:"created_at"`
+}
+
+// IncomingLinkDTO 向內關聯（to_id == 當前 entry）
+type IncomingLinkDTO struct {
+	ID         uuid.UUID      `json:"id"`
+	FromEntry  EntryRefDTO    `json:"from_entry"`
+	LinkType   model.LinkType `json:"link_type"`
+	Relation   *string        `json:"relation"`
+	Confidence float64        `json:"confidence"`
+	Source     model.LinkSource `json:"source"`
+	CreatedAt  time.Time      `json:"created_at"`
+}
+
+// EntryLinksResponse GET /entries/:id/links 回應
+type EntryLinksResponse struct {
+	Outgoing []OutgoingLinkDTO `json:"outgoing"`
+	Incoming []IncomingLinkDTO `json:"incoming"`
+}
+
+// EntryLinkResponse 單筆關聯回應（POST / PATCH 回應）
+type EntryLinkResponse struct {
+	ID         uuid.UUID        `json:"id"`
+	FromID     uuid.UUID        `json:"from_id"`
+	ToID       uuid.UUID        `json:"to_id"`
+	LinkType   model.LinkType   `json:"link_type"`
+	Relation   *string          `json:"relation"`
+	Confidence float64          `json:"confidence"`
+	Source     model.LinkSource `json:"source"`
+	CreatedAt  time.Time        `json:"created_at"`
+	UpdatedAt  time.Time        `json:"updated_at"`
+}

--- a/dev/src/handler/entry_links.go
+++ b/dev/src/handler/entry_links.go
@@ -1,0 +1,236 @@
+package handler
+
+import (
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+	"github.com/gpwork4u/aibo/dto"
+	"github.com/gpwork4u/aibo/model"
+	"github.com/gpwork4u/aibo/repository"
+)
+
+// EntryLinksHandler entry_links HTTP handlers（F-044）
+type EntryLinksHandler struct {
+	repo *repository.EntryLinksRepository
+}
+
+// NewEntryLinksHandler 建立 EntryLinksHandler
+func NewEntryLinksHandler(repo *repository.EntryLinksRepository) *EntryLinksHandler {
+	return &EntryLinksHandler{repo: repo}
+}
+
+// writeLinkError 統一輸出 AppError
+func writeLinkError(c *gin.Context, err error) {
+	if appErr, ok := err.(*model.AppError); ok {
+		c.JSON(appErr.Status, dto.ErrorResponse{Code: appErr.Code, Message: appErr.Message})
+		return
+	}
+	c.JSON(http.StatusInternalServerError, dto.ErrorResponse{
+		Code:    "INTERNAL_ERROR",
+		Message: "伺服器內部錯誤",
+	})
+}
+
+// parseLinkUUID 解析 path 中的 UUID 參數
+func parseLinkUUID(c *gin.Context, key string) (uuid.UUID, bool) {
+	id, err := uuid.Parse(c.Param(key))
+	if err != nil {
+		c.JSON(http.StatusBadRequest, dto.ErrorResponse{
+			Code:    model.ErrCodeInvalidInput,
+			Message: key + " 必須為合法的 UUID",
+		})
+		return uuid.Nil, false
+	}
+	return id, true
+}
+
+// toLinkResponse 將 model.EntryLink 轉成 dto.EntryLinkResponse
+func toLinkResponse(l *model.EntryLink) dto.EntryLinkResponse {
+	return dto.EntryLinkResponse{
+		ID:         l.ID,
+		FromID:     l.FromID,
+		ToID:       l.ToID,
+		LinkType:   l.LinkType,
+		Relation:   l.Relation,
+		Confidence: l.Confidence,
+		Source:     l.Source,
+		CreatedAt:  l.CreatedAt,
+		UpdatedAt:  l.UpdatedAt,
+	}
+}
+
+// ListLinks GET /api/v1/entries/:id/links
+// 回傳雙向關聯（outgoing + incoming）
+func (h *EntryLinksHandler) ListLinks(c *gin.Context) {
+	entryID, ok := parseLinkUUID(c, "id")
+	if !ok {
+		return
+	}
+
+	result, err := h.repo.ListBidirectional(c.Request.Context(), entryID)
+	if err != nil {
+		writeLinkError(c, err)
+		return
+	}
+	c.JSON(http.StatusOK, result)
+}
+
+// CreateLink POST /api/v1/entries/:id/links
+func (h *EntryLinksHandler) CreateLink(c *gin.Context) {
+	fromID, ok := parseLinkUUID(c, "id")
+	if !ok {
+		return
+	}
+
+	var req dto.CreateEntryLinkRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, dto.ErrorResponse{
+			Code:    model.ErrCodeInvalidInput,
+			Message: "請求格式錯誤: " + err.Error(),
+		})
+		return
+	}
+
+	// self-link 檢查
+	if fromID == req.ToID {
+		c.JSON(http.StatusUnprocessableEntity, dto.ErrorResponse{
+			Code:    model.ErrCodeSelfLink,
+			Message: "不允許自我關聯",
+		})
+		return
+	}
+
+	// 預設值
+	lt := model.LinkTypeRelatedTo
+	if req.LinkType != nil {
+		lt = *req.LinkType
+		if !model.ValidLinkTypes[lt] {
+			c.JSON(http.StatusBadRequest, dto.ErrorResponse{
+				Code:    model.ErrCodeInvalidInput,
+				Message: "link_type 值不合法",
+			})
+			return
+		}
+	}
+
+	source := model.LinkSourceManual
+	if req.Source != nil {
+		source = *req.Source
+		if !model.ValidLinkSources[source] {
+			c.JSON(http.StatusBadRequest, dto.ErrorResponse{
+				Code:    model.ErrCodeInvalidInput,
+				Message: "source 值不合法",
+			})
+			return
+		}
+	}
+
+	confidence := 1.0
+	if req.Confidence != nil {
+		if *req.Confidence < 0 || *req.Confidence > 1 {
+			c.JSON(http.StatusBadRequest, dto.ErrorResponse{
+				Code:    model.ErrCodeInvalidInput,
+				Message: "confidence 必須在 0.0 ~ 1.0 之間",
+			})
+			return
+		}
+		confidence = *req.Confidence
+	}
+
+	link, err := h.repo.Create(c.Request.Context(), fromID, req.ToID, lt, req.Relation, confidence, source)
+	if err != nil {
+		writeLinkError(c, err)
+		return
+	}
+	c.JSON(http.StatusCreated, toLinkResponse(link))
+}
+
+// UpdateLink PATCH /api/v1/entries/links/:link_id
+func (h *EntryLinksHandler) UpdateLink(c *gin.Context) {
+	linkID, ok := parseLinkUUID(c, "link_id")
+	if !ok {
+		return
+	}
+
+	var req dto.UpdateEntryLinkRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, dto.ErrorResponse{
+			Code:    model.ErrCodeInvalidInput,
+			Message: "請求格式錯誤: " + err.Error(),
+		})
+		return
+	}
+
+	// 驗證 link_type
+	if req.LinkType != nil && !model.ValidLinkTypes[*req.LinkType] {
+		c.JSON(http.StatusBadRequest, dto.ErrorResponse{
+			Code:    model.ErrCodeInvalidInput,
+			Message: "link_type 值不合法",
+		})
+		return
+	}
+
+	// 驗證 confidence
+	if req.Confidence != nil && (*req.Confidence < 0 || *req.Confidence > 1) {
+		c.JSON(http.StatusBadRequest, dto.ErrorResponse{
+			Code:    model.ErrCodeInvalidInput,
+			Message: "confidence 必須在 0.0 ~ 1.0 之間",
+		})
+		return
+	}
+
+	link, err := h.repo.Update(c.Request.Context(), linkID, req)
+	if err != nil {
+		writeLinkError(c, err)
+		return
+	}
+	c.JSON(http.StatusOK, toLinkResponse(link))
+}
+
+// DeleteLink DELETE /api/v1/entries/links/:link_id
+func (h *EntryLinksHandler) DeleteLink(c *gin.Context) {
+	linkID, ok := parseLinkUUID(c, "link_id")
+	if !ok {
+		return
+	}
+
+	if err := h.repo.Delete(c.Request.Context(), linkID); err != nil {
+		writeLinkError(c, err)
+		return
+	}
+	c.Status(http.StatusNoContent)
+}
+
+// GetGraph GET /api/v1/graph?entry_id=...
+// 回傳指定 entry 所有關聯的扁平列表（供 F-045 前端圖形視覺化使用）
+func (h *EntryLinksHandler) GetGraph(c *gin.Context) {
+	entryIDStr := c.Query("entry_id")
+	if entryIDStr == "" {
+		c.JSON(http.StatusBadRequest, dto.ErrorResponse{
+			Code:    model.ErrCodeInvalidInput,
+			Message: "entry_id 為必填參數",
+		})
+		return
+	}
+	entryID, err := uuid.Parse(entryIDStr)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, dto.ErrorResponse{
+			Code:    model.ErrCodeInvalidInput,
+			Message: "entry_id 必須為合法的 UUID",
+		})
+		return
+	}
+
+	links, err := h.repo.ListByEntryForGraph(c.Request.Context(), entryID)
+	if err != nil {
+		writeLinkError(c, err)
+		return
+	}
+
+	resp := make([]dto.EntryLinkResponse, 0, len(links))
+	for i := range links {
+		resp = append(resp, toLinkResponse(&links[i]))
+	}
+	c.JSON(http.StatusOK, gin.H{"entry_id": entryID, "links": resp})
+}

--- a/dev/src/main.go
+++ b/dev/src/main.go
@@ -167,8 +167,12 @@ func main() {
 	viewSvc := service.NewViewService(viewRepo)
 	viewHandler := handler.NewViewHandler(viewSvc)
 
+	// 初始化 Entry Links（F-044）
+	entryLinksRepo := repository.NewEntryLinksRepository(pool)
+	entryLinksHandler := handler.NewEntryLinksHandler(entryLinksRepo)
+
 	// 設定路由
-	r := router.Setup(pool, apiKeySvc, apiKeyHandler, categoryHandler, llmProviderHandler, entryHandler, classifyHandler, searchHandler, gitImportHandler, gcalHandler, confidenceHandler, statsHandler, systemHandler, lifecycleHandler, calendarConvertHandler, calendarHandler, journalHandler, journalDraftHandler, journalAutoHandler, projectHandler, taskHandler, githubIntegrationHandler, githubCommitsHandler, viewHandler)
+	r := router.Setup(pool, apiKeySvc, apiKeyHandler, categoryHandler, llmProviderHandler, entryHandler, classifyHandler, searchHandler, gitImportHandler, gcalHandler, confidenceHandler, statsHandler, systemHandler, lifecycleHandler, calendarConvertHandler, calendarHandler, journalHandler, journalDraftHandler, journalAutoHandler, projectHandler, taskHandler, githubIntegrationHandler, githubCommitsHandler, viewHandler, entryLinksHandler)
 
 	// 啟動 HTTP server（graceful shutdown）
 	srv := &http.Server{

--- a/dev/src/migration/019_create_entry_links.down.sql
+++ b/dev/src/migration/019_create_entry_links.down.sql
@@ -1,0 +1,4 @@
+-- migration 019 rollback: 刪除 entry_links 表與 ENUM
+DROP TABLE IF EXISTS entry_links;
+DROP TYPE IF EXISTS link_source_enum;
+DROP TYPE IF EXISTS link_type_enum;

--- a/dev/src/migration/019_create_entry_links.up.sql
+++ b/dev/src/migration/019_create_entry_links.up.sql
@@ -1,0 +1,28 @@
+-- migration 019: entry_links 語意關聯表
+CREATE TYPE link_type_enum AS ENUM (
+  'derives_from',
+  'contradicts',
+  'duplicate_of',
+  'references',
+  'supersedes',
+  'related_to'
+);
+
+CREATE TYPE link_source_enum AS ENUM ('manual', 'llm', 'auto_merge');
+
+CREATE TABLE entry_links (
+  id          UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  from_id     UUID NOT NULL REFERENCES entries(id) ON DELETE CASCADE,
+  to_id       UUID NOT NULL REFERENCES entries(id) ON DELETE CASCADE,
+  link_type   link_type_enum NOT NULL DEFAULT 'related_to',
+  relation    VARCHAR(200),
+  confidence  NUMERIC(4,3) NOT NULL DEFAULT 1.000
+              CHECK (confidence >= 0 AND confidence <= 1),
+  source      link_source_enum NOT NULL DEFAULT 'manual',
+  created_at  TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at  TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  CONSTRAINT uq_entry_links UNIQUE (from_id, to_id, link_type)
+);
+
+CREATE INDEX idx_entry_links_from ON entry_links(from_id);
+CREATE INDEX idx_entry_links_to ON entry_links(to_id);

--- a/dev/src/model/entry_link.go
+++ b/dev/src/model/entry_link.go
@@ -1,0 +1,64 @@
+package model
+
+import (
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// LinkType entry_links 關聯類型
+type LinkType string
+
+const (
+	LinkTypeDerivesFrom  LinkType = "derives_from"
+	LinkTypeContradicts  LinkType = "contradicts"
+	LinkTypeDuplicateOf  LinkType = "duplicate_of"
+	LinkTypeReferences   LinkType = "references"
+	LinkTypeSupersedes   LinkType = "supersedes"
+	LinkTypeRelatedTo    LinkType = "related_to"
+)
+
+// ValidLinkTypes 合法的 link_type 值集合
+var ValidLinkTypes = map[LinkType]bool{
+	LinkTypeDerivesFrom: true,
+	LinkTypeContradicts: true,
+	LinkTypeDuplicateOf: true,
+	LinkTypeReferences:  true,
+	LinkTypeSupersedes:  true,
+	LinkTypeRelatedTo:   true,
+}
+
+// LinkSource entry_links 建立來源
+type LinkSource string
+
+const (
+	LinkSourceManual    LinkSource = "manual"
+	LinkSourceLLM       LinkSource = "llm"
+	LinkSourceAutoMerge LinkSource = "auto_merge"
+)
+
+// ValidLinkSources 合法的 source 值集合
+var ValidLinkSources = map[LinkSource]bool{
+	LinkSourceManual:    true,
+	LinkSourceLLM:       true,
+	LinkSourceAutoMerge: true,
+}
+
+// EntryLink 語意關聯資料庫模型
+type EntryLink struct {
+	ID         uuid.UUID  `json:"id"`
+	FromID     uuid.UUID  `json:"from_id"`
+	ToID       uuid.UUID  `json:"to_id"`
+	LinkType   LinkType   `json:"link_type"`
+	Relation   *string    `json:"relation"`
+	Confidence float64    `json:"confidence"`
+	Source     LinkSource `json:"source"`
+	CreatedAt  time.Time  `json:"created_at"`
+	UpdatedAt  time.Time  `json:"updated_at"`
+}
+
+// ErrCodeSelfLink 自我關聯錯誤碼
+const ErrCodeSelfLink = "SELF_LINK"
+
+// ErrCodeDuplicateLink 重複關聯錯誤碼
+const ErrCodeDuplicateLink = "DUPLICATE"

--- a/dev/src/repository/entry_links.go
+++ b/dev/src/repository/entry_links.go
@@ -1,0 +1,220 @@
+package repository
+
+import (
+	"context"
+	"errors"
+	"net/http"
+
+	"github.com/google/uuid"
+	"github.com/gpwork4u/aibo/dto"
+	"github.com/gpwork4u/aibo/model"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+// EntryLinksRepository entry_links 資料庫操作（F-044）
+type EntryLinksRepository struct {
+	pool *pgxpool.Pool
+}
+
+// NewEntryLinksRepository 建立新的 EntryLinksRepository
+func NewEntryLinksRepository(pool *pgxpool.Pool) *EntryLinksRepository {
+	return &EntryLinksRepository{pool: pool}
+}
+
+// mapLinkPgErr 將常見 PgError 轉成 AppError
+func mapLinkPgErr(err error) error {
+	if err == nil {
+		return nil
+	}
+	var pgErr *pgconn.PgError
+	if errors.As(err, &pgErr) {
+		switch pgErr.Code {
+		case "23505": // unique_violation
+			return model.NewAppError(http.StatusConflict, model.ErrCodeDuplicateLink, "相同的關聯已存在")
+		case "23503": // foreign_key_violation
+			return model.NewAppError(http.StatusNotFound, model.ErrCodeNotFound, "指定的 entry 不存在")
+		case "23514": // check_violation
+			return model.NewAppError(http.StatusBadRequest, model.ErrCodeInvalidInput, "欄位值不符合限制")
+		}
+	}
+	return err
+}
+
+// Create 建立新的 entry_link，回傳建立後的完整記錄
+func (r *EntryLinksRepository) Create(ctx context.Context, fromID, toID uuid.UUID, lt model.LinkType, relation *string, confidence float64, source model.LinkSource) (*model.EntryLink, error) {
+	link := &model.EntryLink{}
+	err := r.pool.QueryRow(ctx, `
+		INSERT INTO entry_links (from_id, to_id, link_type, relation, confidence, source)
+		VALUES ($1, $2, $3, $4, $5, $6)
+		RETURNING id, from_id, to_id, link_type, relation, confidence, source, created_at, updated_at
+	`, fromID, toID, string(lt), relation, confidence, string(source)).Scan(
+		&link.ID, &link.FromID, &link.ToID, &link.LinkType, &link.Relation,
+		&link.Confidence, &link.Source, &link.CreatedAt, &link.UpdatedAt,
+	)
+	if err != nil {
+		return nil, mapLinkPgErr(err)
+	}
+	return link, nil
+}
+
+// ListBidirectional 雙向查詢：傳回指定 entry 的 outgoing + incoming
+func (r *EntryLinksRepository) ListBidirectional(ctx context.Context, entryID uuid.UUID) (*dto.EntryLinksResponse, error) {
+	// outgoing: from_id = entryID，JOIN to_id entry
+	outRows, err := r.pool.Query(ctx, `
+		SELECT el.id, el.link_type, el.relation, el.confidence, el.source, el.created_at,
+		       e.id, e.title, e.summary
+		FROM entry_links el
+		JOIN entries e ON e.id = el.to_id
+		WHERE el.from_id = $1
+		ORDER BY el.created_at DESC
+	`, entryID)
+	if err != nil {
+		return nil, err
+	}
+	defer outRows.Close()
+
+	outgoing := make([]dto.OutgoingLinkDTO, 0)
+	for outRows.Next() {
+		var d dto.OutgoingLinkDTO
+		err := outRows.Scan(
+			&d.ID, &d.LinkType, &d.Relation, &d.Confidence, &d.Source, &d.CreatedAt,
+			&d.ToEntry.ID, &d.ToEntry.Title, &d.ToEntry.Summary,
+		)
+		if err != nil {
+			return nil, err
+		}
+		outgoing = append(outgoing, d)
+	}
+	if err := outRows.Err(); err != nil {
+		return nil, err
+	}
+
+	// incoming: to_id = entryID，JOIN from_id entry
+	inRows, err := r.pool.Query(ctx, `
+		SELECT el.id, el.link_type, el.relation, el.confidence, el.source, el.created_at,
+		       e.id, e.title, e.summary
+		FROM entry_links el
+		JOIN entries e ON e.id = el.from_id
+		WHERE el.to_id = $1
+		ORDER BY el.created_at DESC
+	`, entryID)
+	if err != nil {
+		return nil, err
+	}
+	defer inRows.Close()
+
+	incoming := make([]dto.IncomingLinkDTO, 0)
+	for inRows.Next() {
+		var d dto.IncomingLinkDTO
+		err := inRows.Scan(
+			&d.ID, &d.LinkType, &d.Relation, &d.Confidence, &d.Source, &d.CreatedAt,
+			&d.FromEntry.ID, &d.FromEntry.Title, &d.FromEntry.Summary,
+		)
+		if err != nil {
+			return nil, err
+		}
+		incoming = append(incoming, d)
+	}
+	if err := inRows.Err(); err != nil {
+		return nil, err
+	}
+
+	return &dto.EntryLinksResponse{
+		Outgoing: outgoing,
+		Incoming: incoming,
+	}, nil
+}
+
+// GetByID 取得單筆 link
+func (r *EntryLinksRepository) GetByID(ctx context.Context, linkID uuid.UUID) (*model.EntryLink, error) {
+	link := &model.EntryLink{}
+	err := r.pool.QueryRow(ctx, `
+		SELECT id, from_id, to_id, link_type, relation, confidence, source, created_at, updated_at
+		FROM entry_links WHERE id = $1
+	`, linkID).Scan(
+		&link.ID, &link.FromID, &link.ToID, &link.LinkType, &link.Relation,
+		&link.Confidence, &link.Source, &link.CreatedAt, &link.UpdatedAt,
+	)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return nil, model.NewAppError(http.StatusNotFound, model.ErrCodeNotFound, "關聯不存在")
+	}
+	if err != nil {
+		return nil, err
+	}
+	return link, nil
+}
+
+// Update 部分更新 link（link_type / relation / confidence）
+func (r *EntryLinksRepository) Update(ctx context.Context, linkID uuid.UUID, req dto.UpdateEntryLinkRequest) (*model.EntryLink, error) {
+	link, err := r.GetByID(ctx, linkID)
+	if err != nil {
+		return nil, err
+	}
+
+	if req.LinkType != nil {
+		link.LinkType = *req.LinkType
+	}
+	if req.Relation != nil {
+		link.Relation = req.Relation
+	}
+	if req.Confidence != nil {
+		link.Confidence = *req.Confidence
+	}
+
+	updated := &model.EntryLink{}
+	err = r.pool.QueryRow(ctx, `
+		UPDATE entry_links
+		SET link_type = $1, relation = $2, confidence = $3, updated_at = NOW()
+		WHERE id = $4
+		RETURNING id, from_id, to_id, link_type, relation, confidence, source, created_at, updated_at
+	`, string(link.LinkType), link.Relation, link.Confidence, linkID).Scan(
+		&updated.ID, &updated.FromID, &updated.ToID, &updated.LinkType, &updated.Relation,
+		&updated.Confidence, &updated.Source, &updated.CreatedAt, &updated.UpdatedAt,
+	)
+	if err != nil {
+		return nil, mapLinkPgErr(err)
+	}
+	return updated, nil
+}
+
+// Delete 刪除 link，若不存在回傳 404
+func (r *EntryLinksRepository) Delete(ctx context.Context, linkID uuid.UUID) error {
+	tag, err := r.pool.Exec(ctx, `DELETE FROM entry_links WHERE id = $1`, linkID)
+	if err != nil {
+		return err
+	}
+	if tag.RowsAffected() == 0 {
+		return model.NewAppError(http.StatusNotFound, model.ErrCodeNotFound, "關聯不存在")
+	}
+	return nil
+}
+
+// ListByEntryForGraph 取得指定 entry 的所有關聯（for graph endpoint）
+func (r *EntryLinksRepository) ListByEntryForGraph(ctx context.Context, entryID uuid.UUID) ([]model.EntryLink, error) {
+	rows, err := r.pool.Query(ctx, `
+		SELECT id, from_id, to_id, link_type, relation, confidence, source, created_at, updated_at
+		FROM entry_links
+		WHERE from_id = $1 OR to_id = $1
+		ORDER BY created_at DESC
+	`, entryID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	links := make([]model.EntryLink, 0)
+	for rows.Next() {
+		var l model.EntryLink
+		err := rows.Scan(
+			&l.ID, &l.FromID, &l.ToID, &l.LinkType, &l.Relation,
+			&l.Confidence, &l.Source, &l.CreatedAt, &l.UpdatedAt,
+		)
+		if err != nil {
+			return nil, err
+		}
+		links = append(links, l)
+	}
+	return links, rows.Err()
+}

--- a/dev/src/router/router.go
+++ b/dev/src/router/router.go
@@ -12,7 +12,7 @@ import (
 )
 
 // Setup 設定路由
-func Setup(pool *pgxpool.Pool, apiKeySvc *service.ApiKeyService, apiKeyHandler *handler.ApiKeyHandler, categoryHandler *handler.CategoryHandler, llmProviderHandler *handler.LlmProviderHandler, entryHandler *handler.EntryHandler, classifyHandler *handler.ClassifyHandler, searchHandler *handler.SearchHandler, gitImportHandler *handler.GitImportHandler, gcalHandler *handler.GcalHandler, confidenceHandler *handler.ConfidenceHandler, statsHandler *handler.StatsHandler, systemHandler *handler.SystemHandler, lifecycleHandler *handler.LifecycleHandler, calendarConvertHandler *handler.CalendarConvertHandler, calendarHandler *handler.CalendarHandler, journalHandler *handler.JournalHandler, journalDraftHandler *handler.JournalDraftHandler, journalAutoHandler *handler.JournalAutoHandler, projectHandler *handler.ProjectHandler, taskHandler *handler.TaskHandler, githubIntegrationHandler *handler.GitHubIntegrationHandler, githubCommitsHandler *handler.GitHubCommitsHandler, viewHandler *handler.ViewHandler) *gin.Engine {
+func Setup(pool *pgxpool.Pool, apiKeySvc *service.ApiKeyService, apiKeyHandler *handler.ApiKeyHandler, categoryHandler *handler.CategoryHandler, llmProviderHandler *handler.LlmProviderHandler, entryHandler *handler.EntryHandler, classifyHandler *handler.ClassifyHandler, searchHandler *handler.SearchHandler, gitImportHandler *handler.GitImportHandler, gcalHandler *handler.GcalHandler, confidenceHandler *handler.ConfidenceHandler, statsHandler *handler.StatsHandler, systemHandler *handler.SystemHandler, lifecycleHandler *handler.LifecycleHandler, calendarConvertHandler *handler.CalendarConvertHandler, calendarHandler *handler.CalendarHandler, journalHandler *handler.JournalHandler, journalDraftHandler *handler.JournalDraftHandler, journalAutoHandler *handler.JournalAutoHandler, projectHandler *handler.ProjectHandler, taskHandler *handler.TaskHandler, githubIntegrationHandler *handler.GitHubIntegrationHandler, githubCommitsHandler *handler.GitHubCommitsHandler, viewHandler *handler.ViewHandler, entryLinksHandler *handler.EntryLinksHandler) *gin.Engine {
 	r := gin.Default()
 
 	// CORS middleware — 允許跨網域（前端 localhost:3000 呼叫 API localhost:8080）
@@ -197,6 +197,16 @@ func Setup(pool *pgxpool.Pool, apiKeySvc *service.ApiKeyService, apiKeyHandler *
 			views.PATCH("/:id", viewHandler.Update)
 			views.DELETE("/:id", viewHandler.Delete)
 		}
+
+		// Entry Links（F-044）—— 語意關聯
+		// 注意：/links/:link_id 必須在 /:id/links 之前定義以避免 Gin 路由衝突
+		entries.GET("/:id/links", entryLinksHandler.ListLinks)
+		entries.POST("/:id/links", entryLinksHandler.CreateLink)
+		entries.PATCH("/links/:link_id", entryLinksHandler.UpdateLink)
+		entries.DELETE("/links/:link_id", entryLinksHandler.DeleteLink)
+
+		// Knowledge Graph（F-044）
+		v1.GET("/graph", entryLinksHandler.GetGraph)
 	}
 
 	return r


### PR DESCRIPTION
## Summary
- 實作 entry_links 語意關聯後端（F-044）
- Migration 019：`entry_links` 表 + `link_type_enum` + `link_source_enum` ENUM
- 雙向查詢 API、self-link / duplicate 保護、CASCADE 刪除

## Changes
- `dev/src/migration/019_create_entry_links.up.sql` — entry_links 表 + ENUM 建立
- `dev/src/migration/019_create_entry_links.down.sql` — rollback
- `dev/src/model/entry_link.go` — EntryLink model + LinkType/LinkSource 常數
- `dev/src/dto/entry_link.go` — Create/Update/Response DTO 結構
- `dev/src/repository/entry_links.go` — CRUD + 雙向查詢 + graph 查詢
- `dev/src/handler/entry_links.go` — 4 個 endpoint + GetGraph
- `dev/src/router/router.go` — 路由註冊
- `dev/src/main.go` — 初始化注入
- `dev/__tests__/handler/entry_links_test.go` — unit tests

## API Endpoints
| Method | Path | 說明 |
|--------|------|------|
| GET | `/api/v1/entries/:id/links` | 雙向關聯（outgoing + incoming） |
| POST | `/api/v1/entries/:id/links` | 建立關聯 |
| PATCH | `/api/v1/entries/links/:link_id` | 部分更新 |
| DELETE | `/api/v1/entries/links/:link_id` | 刪除（204） |
| GET | `/api/v1/graph?entry_id=...` | 圖形查詢（F-045 前置） |

## Scenario 覆蓋
- [x] Scenario: 建立 derives_from 連結 — POST 201 + confidence 1.0 預設
- [x] Scenario: 查詢雙向連結 — outgoing + incoming JOIN entry 資訊
- [x] Scenario: 刪除連結 — DELETE 204
- [x] Scenario: self-link 拒絕 — 422 SELF_LINK
- [x] Scenario: 重複連結拒絕 — PG 23505 → 409 DUPLICATE
- [x] Scenario: to_id 不存在 — PG 23503 → 404 NOT_FOUND
- [x] Scenario: 同 pair 不同 link_type 允許 — UNIQUE(from_id, to_id, link_type)
- [x] Scenario: Entry 刪除時 links cascade — ON DELETE CASCADE

## 測試
- `go build ./...` 通過，無編譯錯誤
- Unit tests 通過：self-link 422、ValidLinkTypes 驗證、DTO 序列化
- 既有 31 個 tests 通過（2 個 journal 相關既有失敗，非本次改動）

## Related Issues
Closes #219