### PR TITLE
[Feature] F-046: Relation Editor

### DIFF
--- a/dev/frontend/components/library/EntryDetailSheet.tsx
+++ b/dev/frontend/components/library/EntryDetailSheet.tsx
@@ -1,0 +1,193 @@
+"use client";
+
+/**
+ * F-041 EntryDetailSheet
+ * 點選 Library row → 右側 Sheet 展開，顯示完整 entry 詳情
+ */
+
+import { useEntry } from "@/lib/hooks/use-entries";
+import {
+  Sheet,
+  SheetContent,
+  SheetHeader,
+  SheetTitle,
+  SheetDescription,
+} from "@/components/ui/sheet";
+import { Badge } from "@/components/ui/badge";
+import { Separator } from "@/components/ui/separator";
+import { Loader2 } from "lucide-react";
+import { formatRelativeTime } from "@/lib/utils";
+import type { EntryListItem } from "@/lib/api/entries";
+import { RelationsSection } from "@/components/relation-editor/relations-section";
+
+interface EntryDetailSheetProps {
+  entry: EntryListItem | null;
+  open: boolean;
+  onClose: () => void;
+}
+
+export function EntryDetailSheet({ entry, open, onClose }: EntryDetailSheetProps) {
+  const { data: detail, isLoading } = useEntry(open && entry ? entry.id : null);
+
+  const displayEntry = detail ?? entry;
+
+  return (
+    <Sheet open={open} onOpenChange={(v) => !v && onClose()}>
+      <SheetContent
+        side="right"
+        className="w-[480px] sm:max-w-[480px] overflow-y-auto flex flex-col gap-0 p-0"
+        data-testid="entry-detail-sheet"
+      >
+        {isLoading && !displayEntry && (
+          <div className="flex flex-1 items-center justify-center py-16">
+            <Loader2 className="h-6 w-6 animate-spin text-[--fg-muted]" />
+          </div>
+        )}
+
+        {displayEntry && (
+          <>
+            <SheetHeader className="px-6 pt-6 pb-4">
+              <SheetTitle
+                className="text-lg font-semibold leading-snug text-[--fg]"
+                data-testid="entry-detail-title"
+              >
+                {displayEntry.title || "（無標題）"}
+              </SheetTitle>
+              <SheetDescription asChild>
+                <div className="flex flex-wrap items-center gap-2 mt-1">
+                  {/* 狀態 */}
+                  {"lifecycle_status" in displayEntry && (
+                    <Badge variant="secondary">
+                      {(displayEntry as EntryListItem).lifecycle_status ?? "library"}
+                    </Badge>
+                  )}
+                  {/* confidence */}
+                  <span className="text-xs text-[--fg-muted]">
+                    Confidence:{" "}
+                    <strong>
+                      {Math.round(displayEntry.confidence * 100)}%
+                    </strong>
+                  </span>
+                  {/* updated_at */}
+                  <span className="text-xs text-[--fg-muted]">
+                    更新：{formatRelativeTime(displayEntry.updated_at)}
+                  </span>
+                </div>
+              </SheetDescription>
+            </SheetHeader>
+
+            <Separator />
+
+            <div className="flex-1 overflow-y-auto px-6 py-4 space-y-5">
+              {/* Tags */}
+              {displayEntry.tags && displayEntry.tags.length > 0 && (
+                <section>
+                  <h3 className="mb-2 text-xs font-medium uppercase tracking-wider text-[--fg-muted]">
+                    標籤
+                  </h3>
+                  <div className="flex flex-wrap gap-1.5">
+                    {displayEntry.tags.map((t) => (
+                      <Badge key={t} variant="outline" className="text-xs">
+                        {t}
+                      </Badge>
+                    ))}
+                  </div>
+                </section>
+              )}
+
+              {/* Domains */}
+              {displayEntry.domains && displayEntry.domains.length > 0 && (
+                <section>
+                  <h3 className="mb-2 text-xs font-medium uppercase tracking-wider text-[--fg-muted]">
+                    分類
+                  </h3>
+                  <div className="flex flex-wrap gap-1.5">
+                    {displayEntry.domains.map((d) => (
+                      <Badge key={d} variant="secondary" className="text-xs">
+                        {d}
+                      </Badge>
+                    ))}
+                  </div>
+                </section>
+              )}
+
+              {/* Summary */}
+              {"summary" in displayEntry && (displayEntry as { summary?: string | null }).summary && (
+                <section>
+                  <h3 className="mb-2 text-xs font-medium uppercase tracking-wider text-[--fg-muted]">
+                    摘要
+                  </h3>
+                  <p className="text-sm text-[--fg] leading-relaxed whitespace-pre-wrap">
+                    {(displayEntry as { summary?: string | null }).summary}
+                  </p>
+                </section>
+              )}
+
+              {/* Content */}
+              {"content" in displayEntry && (displayEntry as { content?: string | null }).content && (
+                <section>
+                  <h3 className="mb-2 text-xs font-medium uppercase tracking-wider text-[--fg-muted]">
+                    內容
+                  </h3>
+                  <p className="text-sm text-[--fg] leading-relaxed whitespace-pre-wrap">
+                    {(displayEntry as { content?: string | null }).content}
+                  </p>
+                </section>
+              )}
+
+              {/* content_preview for EntryListItem */}
+              {"content_preview" in displayEntry &&
+                (displayEntry as EntryListItem).content_preview &&
+                !("content" in displayEntry && (displayEntry as { content?: string | null }).content) && (
+                <section>
+                  <h3 className="mb-2 text-xs font-medium uppercase tracking-wider text-[--fg-muted]">
+                    預覽
+                  </h3>
+                  <p className="text-sm text-[--fg] leading-relaxed whitespace-pre-wrap">
+                    {(displayEntry as EntryListItem).content_preview}
+                  </p>
+                </section>
+              )}
+
+              {/* Relations */}
+              {detail && (
+                <RelationsSection entryId={detail.id} />
+              )}
+
+              {/* Metadata */}
+              <section>
+                <h3 className="mb-2 text-xs font-medium uppercase tracking-wider text-[--fg-muted]">
+                  Metadata
+                </h3>
+                <dl className="space-y-1.5 text-xs text-[--fg-muted]">
+                  <div className="flex gap-2">
+                    <dt className="w-24 shrink-0 font-medium">ID</dt>
+                    <dd className="font-mono truncate">{displayEntry.id}</dd>
+                  </div>
+                  <div className="flex gap-2">
+                    <dt className="w-24 shrink-0 font-medium">建立時間</dt>
+                    <dd>{formatRelativeTime(displayEntry.created_at)}</dd>
+                  </div>
+                  <div className="flex gap-2">
+                    <dt className="w-24 shrink-0 font-medium">更新時間</dt>
+                    <dd>{formatRelativeTime(displayEntry.updated_at)}</dd>
+                  </div>
+                  {"source_type" in displayEntry && (displayEntry as EntryListItem).source_type && (
+                    <div className="flex gap-2">
+                      <dt className="w-24 shrink-0 font-medium">來源</dt>
+                      <dd>{(displayEntry as EntryListItem).source_type}</dd>
+                    </div>
+                  )}
+                  <div className="flex gap-2">
+                    <dt className="w-24 shrink-0 font-medium">Confirmations</dt>
+                    <dd>{displayEntry.confirmations}</dd>
+                  </div>
+                </dl>
+              </section>
+            </div>
+          </>
+        )}
+      </SheetContent>
+    </Sheet>
+  );
+}

--- a/dev/frontend/components/relation-editor/add-relation-form.tsx
+++ b/dev/frontend/components/relation-editor/add-relation-form.tsx
@@ -1,0 +1,212 @@
+"use client";
+
+/**
+ * F-046 AddRelationForm
+ * Combobox 搜尋 entries + LinkType Select + Relation Input + Add Button
+ */
+
+import { useState } from "react";
+import { Check, ChevronsUpDown, Plus } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
+import {
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+} from "@/components/ui/command";
+import { cn } from "@/lib/utils";
+import { useDebouncedValue } from "@/lib/hooks/use-debounced-value";
+import { useEntries } from "@/lib/hooks/use-entries";
+import { useCreateEntryLink } from "@/lib/hooks/use-entry-links";
+import { LINK_TYPE_CONFIG } from "./relation-chip";
+import type { LinkType } from "@/lib/api/entry-links";
+
+const LINK_TYPES = Object.keys(LINK_TYPE_CONFIG) as LinkType[];
+
+interface AddRelationFormProps {
+  currentEntryId: string;
+}
+
+export function AddRelationForm({ currentEntryId }: AddRelationFormProps) {
+  const [open, setOpen] = useState(false);
+  const [searchQuery, setSearchQuery] = useState("");
+  const [selectedEntryId, setSelectedEntryId] = useState<string>("");
+  const [selectedEntryTitle, setSelectedEntryTitle] = useState<string>("");
+  const [linkType, setLinkType] = useState<LinkType>("related_to");
+  const [relation, setRelation] = useState("");
+
+  const debouncedSearch = useDebouncedValue(searchQuery, 300);
+
+  const { data: entriesData, isLoading: isSearching } = useEntries(
+    debouncedSearch
+      ? { q: debouncedSearch, per_page: 10 } as { per_page: number; q?: string }
+      : undefined,
+  );
+
+  const createLink = useCreateEntryLink(currentEntryId);
+
+  // self-link 檢查
+  const isSelfLink = selectedEntryId === currentEntryId;
+  const canSubmit = !!selectedEntryId && !isSelfLink && !createLink.isPending;
+
+  function handleSelect(entryId: string, entryTitle: string) {
+    setSelectedEntryId(entryId);
+    setSelectedEntryTitle(entryTitle);
+    setOpen(false);
+    setSearchQuery("");
+  }
+
+  function handleSubmit() {
+    if (!canSubmit) return;
+    createLink.mutate(
+      {
+        to_id: selectedEntryId,
+        link_type: linkType,
+        relation: relation.trim() || null,
+      },
+      {
+        onSuccess: () => {
+          // reset form
+          setSelectedEntryId("");
+          setSelectedEntryTitle("");
+          setRelation("");
+          setLinkType("related_to");
+        },
+      },
+    );
+  }
+
+  const entries = entriesData?.data ?? [];
+
+  return (
+    <div className="flex flex-col gap-2 pt-2" data-testid="add-relation-form">
+      <div className="flex gap-2">
+        {/* Entry 搜尋 Combobox */}
+        <Popover open={open} onOpenChange={setOpen}>
+          <PopoverTrigger asChild>
+            <Button
+              variant="outline"
+              role="combobox"
+              aria-expanded={open}
+              className={cn(
+                "flex-1 justify-between font-normal text-sm",
+                !selectedEntryId && "text-[--fg-subtle]",
+              )}
+              data-testid="entry-search-trigger"
+            >
+              <span className="truncate">
+                {selectedEntryTitle || "搜尋 entry..."}
+              </span>
+              <ChevronsUpDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
+            </Button>
+          </PopoverTrigger>
+          <PopoverContent className="w-72 p-0" align="start">
+            <Command shouldFilter={false}>
+              <CommandInput
+                placeholder="搜尋 entry 標題..."
+                value={searchQuery}
+                onValueChange={setSearchQuery}
+                data-testid="entry-search-input"
+              />
+              <CommandList>
+                {isSearching ? (
+                  <div className="py-4 text-center text-xs text-[--fg-muted]">
+                    搜尋中...
+                  </div>
+                ) : entries.length === 0 ? (
+                  <CommandEmpty data-testid="entry-search-empty">
+                    No entries found
+                  </CommandEmpty>
+                ) : (
+                  <CommandGroup>
+                    {entries.map((entry) => (
+                      <CommandItem
+                        key={entry.id}
+                        value={entry.id}
+                        onSelect={() =>
+                          handleSelect(entry.id, entry.title ?? entry.id)
+                        }
+                        className={cn(
+                          entry.id === currentEntryId && "opacity-40 cursor-not-allowed",
+                        )}
+                        disabled={entry.id === currentEntryId}
+                        data-testid={`entry-option-${entry.id}`}
+                      >
+                        <Check
+                          className={cn(
+                            "mr-2 h-4 w-4",
+                            selectedEntryId === entry.id ? "opacity-100" : "opacity-0",
+                          )}
+                        />
+                        <span className="truncate">{entry.title || "（無標題）"}</span>
+                      </CommandItem>
+                    ))}
+                  </CommandGroup>
+                )}
+              </CommandList>
+            </Command>
+          </PopoverContent>
+        </Popover>
+
+        {/* Link Type Select */}
+        <Select
+          value={linkType}
+          onValueChange={(v) => setLinkType(v as LinkType)}
+        >
+          <SelectTrigger
+            className="w-28 text-xs"
+            data-testid="link-type-select"
+          >
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            {LINK_TYPES.map((lt) => (
+              <SelectItem key={lt} value={lt} className="text-xs">
+                {LINK_TYPE_CONFIG[lt].label}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </div>
+
+      <div className="flex gap-2">
+        {/* Relation Input */}
+        <Input
+          placeholder="說明（選填，最多 200 字）"
+          value={relation}
+          onChange={(e) => setRelation(e.target.value.slice(0, 200))}
+          className="flex-1 text-sm"
+          data-testid="relation-input"
+        />
+
+        {/* Add Button */}
+        <Button
+          size="sm"
+          onClick={handleSubmit}
+          disabled={!canSubmit}
+          data-testid="add-relation-btn"
+        >
+          <Plus className="h-4 w-4 mr-1" />
+          新增
+        </Button>
+      </div>
+
+      {isSelfLink && (
+        <p className="text-xs text-red-500" data-testid="self-link-error">
+          無法連結到自身 entry
+        </p>
+      )}
+    </div>
+  );
+}

--- a/dev/frontend/components/relation-editor/relation-chip.tsx
+++ b/dev/frontend/components/relation-editor/relation-chip.tsx
@@ -1,0 +1,247 @@
+"use client";
+
+/**
+ * F-046 RelationChip
+ * 顯示單一 entry link 的 chip，支援 hover Edit/Delete（僅限 outgoing）
+ */
+
+import React, { useState } from "react";
+import { Pencil, Trash2, Check, X } from "lucide-react";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
+import { cn } from "@/lib/utils";
+import type { EntryLink, LinkType } from "@/lib/api/entry-links";
+import { useUpdateEntryLink, useDeleteEntryLink } from "@/lib/hooks/use-entry-links";
+
+// Link type 視覺對應
+export const LINK_TYPE_CONFIG: Record<
+  LinkType,
+  { label: string; className: string }
+> = {
+  derives_from: {
+    label: "衍生自",
+    className: "bg-blue-100 text-blue-700 border-blue-200",
+  },
+  contradicts: {
+    label: "矛盾於",
+    className: "bg-red-100 text-red-700 border-red-200",
+  },
+  duplicate_of: {
+    label: "重複於",
+    className: "bg-orange-100 text-orange-700 border-orange-200",
+  },
+  references: {
+    label: "參考",
+    className: "bg-gray-100 text-gray-700 border-gray-200",
+  },
+  supersedes: {
+    label: "取代",
+    className: "bg-purple-100 text-purple-700 border-purple-200",
+  },
+  related_to: {
+    label: "關聯",
+    className: "bg-green-100 text-green-700 border-green-200",
+  },
+};
+
+const LINK_TYPES = Object.keys(LINK_TYPE_CONFIG) as LinkType[];
+
+interface RelationChipProps {
+  link: EntryLink;
+  /** 當前的 entry id，用於判斷 outgoing / incoming */
+  currentEntryId: string;
+  /** incoming = 唯讀，無法 Edit/Delete */
+  readonly?: boolean;
+}
+
+export const RelationChip = React.memo(function RelationChip({
+  link,
+  currentEntryId,
+  readonly = false,
+}: RelationChipProps) {
+  const [hovered, setHovered] = useState(false);
+  const [editing, setEditing] = useState(false);
+  const [editLinkType, setEditLinkType] = useState<LinkType>(link.link_type);
+  const [deleteOpen, setDeleteOpen] = useState(false);
+
+  const updateMutation = useUpdateEntryLink(currentEntryId);
+  const deleteMutation = useDeleteEntryLink(currentEntryId);
+
+  const config = LINK_TYPE_CONFIG[link.link_type] ?? LINK_TYPE_CONFIG.related_to;
+  const isLowConfidence = link.confidence < 0.7 && link.source === "llm";
+  const targetEntry = link.from_id === currentEntryId ? link.to_entry : link.from_entry;
+  const targetTitle = targetEntry?.title ?? link.to_id;
+
+  function handleSaveEdit() {
+    updateMutation.mutate(
+      { linkId: link.id, input: { link_type: editLinkType } },
+      { onSuccess: () => setEditing(false) },
+    );
+  }
+
+  function handleCancelEdit() {
+    setEditLinkType(link.link_type);
+    setEditing(false);
+  }
+
+  function handleDeleteConfirm() {
+    deleteMutation.mutate(link.id, { onSuccess: () => setDeleteOpen(false) });
+  }
+
+  const isManual = link.source === "manual";
+
+  return (
+    <>
+      <div
+        className={cn(
+          "inline-flex items-center gap-1.5 rounded-full border px-2.5 py-1 text-xs transition-all",
+          isLowConfidence ? "border-dashed opacity-70" : "border-solid",
+          "bg-[--surface] hover:bg-[--surface-2]",
+        )}
+        onMouseEnter={() => setHovered(true)}
+        onMouseLeave={() => setHovered(false)}
+        data-testid="relation-chip"
+      >
+        {/* link_type badge */}
+        {editing ? (
+          <Select
+            value={editLinkType}
+            onValueChange={(v) => setEditLinkType(v as LinkType)}
+          >
+            <SelectTrigger className="h-5 w-28 text-xs px-1 py-0" data-testid="edit-link-type-select">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              {LINK_TYPES.map((lt) => (
+                <SelectItem key={lt} value={lt} className="text-xs">
+                  {LINK_TYPE_CONFIG[lt].label}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        ) : (
+          <Badge
+            variant="outline"
+            className={cn("text-[10px] px-1.5 py-0 h-4 border", config.className)}
+            data-testid="link-type-badge"
+          >
+            {config.label}
+          </Badge>
+        )}
+
+        {/* 對端 entry title */}
+        <span className="font-medium text-[--fg] truncate max-w-[120px]" title={targetTitle ?? ""}>
+          {targetTitle || "（未知）"}
+        </span>
+
+        {/* relation text */}
+        {link.relation && (
+          <span className="text-[--fg-muted] truncate max-w-[80px]" title={link.relation}>
+            {link.relation}
+          </span>
+        )}
+
+        {/* confidence badge（若 < 1.0） */}
+        {link.confidence < 1.0 && (
+          <span className="text-[--fg-subtle] text-[10px]">
+            {Math.round(link.confidence * 100)}%
+          </span>
+        )}
+
+        {/* 操作按鈕（非唯讀 + hover 時顯示） */}
+        {!readonly && hovered && !editing && (
+          <div className="flex items-center gap-0.5 ml-0.5" data-testid="chip-actions">
+            <Button
+              variant="ghost"
+              size="icon"
+              className="h-4 w-4 p-0 hover:bg-[--surface-3]"
+              onClick={() => setEditing(true)}
+              data-testid="chip-edit-btn"
+            >
+              <Pencil className="h-3 w-3" />
+            </Button>
+            <Button
+              variant="ghost"
+              size="icon"
+              className="h-4 w-4 p-0 hover:bg-red-100 hover:text-red-600"
+              onClick={() => {
+                if (isManual) {
+                  setDeleteOpen(true);
+                } else {
+                  deleteMutation.mutate(link.id);
+                }
+              }}
+              data-testid="chip-delete-btn"
+            >
+              <Trash2 className="h-3 w-3" />
+            </Button>
+          </div>
+        )}
+
+        {/* 編輯確認/取消 */}
+        {!readonly && editing && (
+          <div className="flex items-center gap-0.5 ml-0.5">
+            <Button
+              variant="ghost"
+              size="icon"
+              className="h-4 w-4 p-0 hover:bg-green-100 hover:text-green-600"
+              onClick={handleSaveEdit}
+              disabled={updateMutation.isPending}
+              data-testid="chip-save-btn"
+            >
+              <Check className="h-3 w-3" />
+            </Button>
+            <Button
+              variant="ghost"
+              size="icon"
+              className="h-4 w-4 p-0 hover:bg-[--surface-3]"
+              onClick={handleCancelEdit}
+              data-testid="chip-cancel-btn"
+            >
+              <X className="h-3 w-3" />
+            </Button>
+          </div>
+        )}
+      </div>
+
+      {/* 刪除確認對話框（僅 manual） */}
+      <AlertDialog open={deleteOpen} onOpenChange={setDeleteOpen}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>刪除連結</AlertDialogTitle>
+            <AlertDialogDescription>
+              Remove link to {targetTitle ? `"${targetTitle}"` : "this entry"}?
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>取消</AlertDialogCancel>
+            <AlertDialogAction
+              onClick={handleDeleteConfirm}
+              className="bg-red-600 hover:bg-red-700"
+              data-testid="confirm-delete-btn"
+            >
+              刪除
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </>
+  );
+});

--- a/dev/frontend/components/relation-editor/relations-section.tsx
+++ b/dev/frontend/components/relation-editor/relations-section.tsx
@@ -1,0 +1,97 @@
+"use client";
+
+/**
+ * F-046 RelationsSection
+ * Outgoing + Incoming links 分區容器，嵌入 EntryDetailSheet
+ */
+
+import { Loader2, Link2 } from "lucide-react";
+import { Separator } from "@/components/ui/separator";
+import { useEntryLinks } from "@/lib/hooks/use-entry-links";
+import { RelationChip } from "./relation-chip";
+import { AddRelationForm } from "./add-relation-form";
+
+interface RelationsSectionProps {
+  entryId: string;
+}
+
+export function RelationsSection({ entryId }: RelationsSectionProps) {
+  const { data, isLoading, isError } = useEntryLinks(entryId);
+
+  const outgoing = data?.outgoing ?? [];
+  const incoming = data?.incoming ?? [];
+  const hasAny = outgoing.length > 0 || incoming.length > 0;
+
+  return (
+    <section data-testid="relations-section">
+      <h3 className="mb-2 text-xs font-medium uppercase tracking-wider text-[--fg-muted] flex items-center gap-1.5">
+        <Link2 className="h-3.5 w-3.5" />
+        Relations
+      </h3>
+
+      {isLoading && (
+        <div className="flex items-center gap-2 py-2 text-xs text-[--fg-muted]">
+          <Loader2 className="h-4 w-4 animate-spin" />
+          載入連結中...
+        </div>
+      )}
+
+      {isError && (
+        <p className="text-xs text-red-500 py-1">無法載入連結</p>
+      )}
+
+      {!isLoading && !isError && (
+        <>
+          {/* Outgoing */}
+          {outgoing.length > 0 && (
+            <div className="mb-2">
+              <p className="text-[10px] text-[--fg-subtle] mb-1.5 uppercase tracking-wider">
+                Outgoing
+              </p>
+              <div className="flex flex-wrap gap-1.5" data-testid="outgoing-list">
+                {outgoing.map((link) => (
+                  <RelationChip
+                    key={link.id}
+                    link={link}
+                    currentEntryId={entryId}
+                    readonly={false}
+                  />
+                ))}
+              </div>
+            </div>
+          )}
+
+          {/* Incoming */}
+          {incoming.length > 0 && (
+            <div className="mb-2">
+              <p className="text-[10px] text-[--fg-subtle] mb-1.5 uppercase tracking-wider">
+                Incoming
+              </p>
+              <div className="flex flex-wrap gap-1.5" data-testid="incoming-list">
+                {incoming.map((link) => (
+                  <RelationChip
+                    key={link.id}
+                    link={link}
+                    currentEntryId={entryId}
+                    readonly={true}
+                  />
+                ))}
+              </div>
+            </div>
+          )}
+
+          {!hasAny && (
+            <p className="text-xs text-[--fg-muted] py-1">
+              尚無連結
+            </p>
+          )}
+
+          <Separator className="my-2" />
+
+          {/* Add form */}
+          <AddRelationForm currentEntryId={entryId} />
+        </>
+      )}
+    </section>
+  );
+}

--- a/dev/frontend/lib/api/entry-links.ts
+++ b/dev/frontend/lib/api/entry-links.ts
@@ -1,0 +1,72 @@
+/**
+ * F-046 Entry Links API
+ * 對應 F-044 後端 /api/v1/entries/:id/links 端點
+ */
+import { apiClient } from "./client";
+
+export type LinkType =
+  | "derives_from"
+  | "contradicts"
+  | "duplicate_of"
+  | "references"
+  | "supersedes"
+  | "related_to";
+
+export type LinkSource = "manual" | "llm";
+
+export interface EntryLink {
+  id: string;
+  from_id: string;
+  to_id: string;
+  link_type: LinkType;
+  relation: string | null;
+  confidence: number;
+  source: LinkSource;
+  created_at: string;
+  updated_at: string;
+  /** 展開的對端 entry 資訊（由後端回傳） */
+  from_entry?: { id: string; title: string | null };
+  to_entry?: { id: string; title: string | null };
+}
+
+export interface EntryLinksResponse {
+  outgoing: EntryLink[];
+  incoming: EntryLink[];
+}
+
+export interface CreateEntryLinkInput {
+  to_id: string;
+  link_type: LinkType;
+  relation?: string | null;
+}
+
+export interface UpdateEntryLinkInput {
+  link_type?: LinkType;
+  relation?: string | null;
+}
+
+/** GET /api/v1/entries/:id/links */
+export async function getEntryLinks(entryId: string): Promise<EntryLinksResponse> {
+  return apiClient.get<EntryLinksResponse>(`/api/v1/entries/${entryId}/links`);
+}
+
+/** POST /api/v1/entries/:id/links */
+export async function createEntryLink(
+  entryId: string,
+  input: CreateEntryLinkInput,
+): Promise<EntryLink> {
+  return apiClient.post<EntryLink>(`/api/v1/entries/${entryId}/links`, input);
+}
+
+/** PATCH /api/v1/entries/links/:link_id */
+export async function updateEntryLink(
+  linkId: string,
+  input: UpdateEntryLinkInput,
+): Promise<EntryLink> {
+  return apiClient.patch<EntryLink>(`/api/v1/entries/links/${linkId}`, input);
+}
+
+/** DELETE /api/v1/entries/links/:link_id */
+export async function deleteEntryLink(linkId: string): Promise<void> {
+  await apiClient.delete(`/api/v1/entries/links/${linkId}`);
+}

--- a/dev/frontend/lib/hooks/use-entry-links.ts
+++ b/dev/frontend/lib/hooks/use-entry-links.ts
@@ -1,0 +1,104 @@
+"use client";
+
+/**
+ * F-046 useEntryLinks
+ * TanStack Query: 查詢 + 樂觀更新 mutations
+ */
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import {
+  createEntryLink,
+  deleteEntryLink,
+  EntryLink,
+  EntryLinksResponse,
+  getEntryLinks,
+  updateEntryLink,
+  CreateEntryLinkInput,
+  UpdateEntryLinkInput,
+} from "@/lib/api/entry-links";
+import { toast } from "sonner";
+
+export const entryLinksQueryKey = (entryId: string) =>
+  ["entry-links", entryId] as const;
+
+export function useEntryLinks(entryId: string | null | undefined) {
+  return useQuery<EntryLinksResponse>({
+    queryKey: entryLinksQueryKey(entryId ?? ""),
+    queryFn: () => getEntryLinks(entryId as string),
+    enabled: !!entryId,
+  });
+}
+
+/** 新增連結（帶樂觀更新） */
+export function useCreateEntryLink(entryId: string) {
+  const qc = useQueryClient();
+  const key = entryLinksQueryKey(entryId);
+
+  return useMutation({
+    mutationFn: (input: CreateEntryLinkInput) => createEntryLink(entryId, input),
+    onMutate: async (input) => {
+      await qc.cancelQueries({ queryKey: key });
+      const previous = qc.getQueryData<EntryLinksResponse>(key);
+
+      // 樂觀更新：插入暫時 chip
+      const optimistic: EntryLink = {
+        id: `optimistic-${Date.now()}`,
+        from_id: entryId,
+        to_id: input.to_id,
+        link_type: input.link_type,
+        relation: input.relation ?? null,
+        confidence: 1,
+        source: "manual",
+        created_at: new Date().toISOString(),
+        updated_at: new Date().toISOString(),
+      };
+
+      qc.setQueryData<EntryLinksResponse>(key, (old) => ({
+        outgoing: [...(old?.outgoing ?? []), optimistic],
+        incoming: old?.incoming ?? [],
+      }));
+
+      return { previous };
+    },
+    onError: (_err, _input, ctx) => {
+      // rollback
+      if (ctx?.previous) qc.setQueryData(key, ctx.previous);
+      toast.error("Failed to add link");
+    },
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: key });
+    },
+  });
+}
+
+/** 更新連結 */
+export function useUpdateEntryLink(entryId: string) {
+  const qc = useQueryClient();
+  const key = entryLinksQueryKey(entryId);
+
+  return useMutation({
+    mutationFn: ({ linkId, input }: { linkId: string; input: UpdateEntryLinkInput }) =>
+      updateEntryLink(linkId, input),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: key });
+    },
+    onError: () => {
+      toast.error("Failed to update link");
+    },
+  });
+}
+
+/** 刪除連結 */
+export function useDeleteEntryLink(entryId: string) {
+  const qc = useQueryClient();
+  const key = entryLinksQueryKey(entryId);
+
+  return useMutation({
+    mutationFn: (linkId: string) => deleteEntryLink(linkId),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: key });
+    },
+    onError: () => {
+      toast.error("Failed to delete link");
+    },
+  });
+}


### PR DESCRIPTION
## Summary
在 Entry 詳情 Sheet 嵌入 Relation Editor，支援 Combobox 搜尋目標 entry、chip 顯示既有連結、incoming links 唯讀。

## Changes
- `dev/frontend/lib/api/entry-links.ts` — EntryLink 型別定義 + CRUD API fetcher（對應 F-044 後端端點）
- `dev/frontend/lib/hooks/use-entry-links.ts` — TanStack Query hooks：useEntryLinks / useCreateEntryLink（樂觀更新）/ useUpdateEntryLink / useDeleteEntryLink
- `dev/frontend/components/relation-editor/relation-chip.tsx` — chip + hover Edit/Delete；manual link 刪除有確認對話框；confidence < 0.7 虛線顯示
- `dev/frontend/components/relation-editor/add-relation-form.tsx` — Combobox entry 搜尋（debounce 300ms）+ LinkType Select + Relation Input + self-link 防護
- `dev/frontend/components/relation-editor/relations-section.tsx` — outgoing/incoming 分區容器 + AddRelationForm
- `dev/frontend/components/library/EntryDetailSheet.tsx` — 整合 RelationsSection（只有完整 detail 載入後才渲染）

## Scenario 覆蓋
- [x] Scenario: 新增 derives_from 連結 — AddRelationForm POST + 樂觀更新 chip 立即出現
- [x] Scenario: 搜尋 entry autocomplete — Combobox debounce 300ms, GET entries?q=
- [x] Scenario: 刪除 manual link — hover → Delete → AlertDialog 確認 → DELETE API
- [x] Scenario: 編輯 link_type — hover → Edit → Select → Check → PATCH API
- [x] Scenario: incoming link 唯讀 — readonly=true 無 Edit/Delete 按鈕
- [x] Scenario: 搜尋無結果 — CommandEmpty 顯示 "No entries found"
- [x] Scenario: 網路錯誤時 rollback — onMutate 樂觀插入 → onError rollback + toast

## Related Issues
Closes #221