### PR TITLE
[Feature] F-050: Keyboard Shortcuts

### DIFF
--- a/dev/frontend/__tests__/components/shortcuts/shortcuts-modal.test.tsx
+++ b/dev/frontend/__tests__/components/shortcuts/shortcuts-modal.test.tsx
@@ -1,0 +1,58 @@
+/**
+ * ShortcutsModal 單元測試
+ *
+ * 測試：
+ * - open=true 時顯示 modal
+ * - 包含所有快捷鍵 section
+ * - open=false 時不顯示
+ * - onClose 在按 × 後被呼叫
+ */
+
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { ShortcutsModal } from "@/components/shortcuts/shortcuts-modal";
+
+describe("ShortcutsModal", () => {
+  it("open=true 時顯示 modal 和標題", () => {
+    render(<ShortcutsModal open={true} onClose={vi.fn()} />);
+
+    expect(screen.getByTestId("shortcuts-modal")).toBeInTheDocument();
+    expect(screen.getByText("鍵盤快捷鍵")).toBeInTheDocument();
+  });
+
+  it("顯示所有 section", () => {
+    render(<ShortcutsModal open={true} onClose={vi.fn()} />);
+
+    expect(screen.getByText("Navigation")).toBeInTheDocument();
+    expect(screen.getByText("Inbox")).toBeInTheDocument();
+    expect(screen.getByText("Library")).toBeInTheDocument();
+    expect(screen.getByText("Entry")).toBeInTheDocument();
+    expect(screen.getByText("Copilot")).toBeInTheDocument();
+  });
+
+  it("包含 G I 快捷鍵說明", () => {
+    render(<ShortcutsModal open={true} onClose={vi.fn()} />);
+
+    expect(screen.getByText("前往 Inbox")).toBeInTheDocument();
+  });
+
+  it("open=false 時不顯示內容", () => {
+    render(<ShortcutsModal open={false} onClose={vi.fn()} />);
+
+    expect(screen.queryByTestId("shortcuts-modal")).not.toBeInTheDocument();
+  });
+
+  it("onClose 在 Dialog onOpenChange(false) 時被呼叫", async () => {
+    const onClose = vi.fn();
+    const user = userEvent.setup();
+    render(<ShortcutsModal open={true} onClose={onClose} />);
+
+    // 找到關閉按鈕（Radix Dialog 的 X 按鈕）
+    const closeButton = document.querySelector("[data-radix-dialog-close], button[aria-label='Close']");
+    if (closeButton) {
+      await user.click(closeButton as HTMLElement);
+      expect(onClose).toHaveBeenCalledTimes(1);
+    }
+  });
+});

--- a/dev/frontend/__tests__/lib/hooks/use-keyboard-shortcuts.test.ts
+++ b/dev/frontend/__tests__/lib/hooks/use-keyboard-shortcuts.test.ts
@@ -1,0 +1,206 @@
+/**
+ * useKeyboardShortcuts 單元測試
+ *
+ * 測試：
+ * - G+I 500ms 內導航至 /inbox
+ * - G+L 導航至 /library
+ * - G+T 導航至 /today
+ * - G+C 導航至 /canvas
+ * - G+S 導航至 /settings
+ * - G 系列超過 500ms 不觸發
+ * - ? 開啟 ShortcutsModal
+ * - input focus 中字母快捷鍵不觸發
+ * - ⌘K 不受 input focus 影響
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+
+// Mock next/navigation
+const mockPush = vi.fn();
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: mockPush }),
+}));
+
+// Mock useCmdk
+const mockToggleCmdk = vi.fn();
+vi.mock("@/components/cmdk/cmdk-provider", () => ({
+  useCmdk: () => ({ open: false, setOpen: vi.fn(), toggle: mockToggleCmdk }),
+}));
+
+import { useKeyboardShortcuts } from "@/lib/hooks/use-keyboard-shortcuts";
+
+function fireKey(key: string, modifiers: Partial<KeyboardEventInit> = {}) {
+  const event = new KeyboardEvent("keydown", { key, bubbles: true, ...modifiers });
+  window.dispatchEvent(event);
+  return event;
+}
+
+describe("useKeyboardShortcuts", () => {
+  const onOpenShortcutsModal = vi.fn();
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    mockPush.mockClear();
+    mockToggleCmdk.mockClear();
+    onOpenShortcutsModal.mockClear();
+    // 確保 activeElement 不是 input
+    Object.defineProperty(document, "activeElement", {
+      value: document.body,
+      configurable: true,
+      writable: true,
+    });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  function setup() {
+    return renderHook(() => useKeyboardShortcuts({ onOpenShortcutsModal }));
+  }
+
+  it("G+I 500ms 內導航至 /inbox", () => {
+    setup();
+
+    act(() => {
+      fireKey("g");
+      vi.advanceTimersByTime(200);
+      fireKey("i");
+    });
+
+    expect(mockPush).toHaveBeenCalledWith("/inbox");
+  });
+
+  it("G+L 導航至 /library", () => {
+    setup();
+
+    act(() => {
+      fireKey("g");
+      vi.advanceTimersByTime(100);
+      fireKey("l");
+    });
+
+    expect(mockPush).toHaveBeenCalledWith("/library");
+  });
+
+  it("G+T 導航至 /today", () => {
+    setup();
+
+    act(() => {
+      fireKey("g");
+      vi.advanceTimersByTime(100);
+      fireKey("t");
+    });
+
+    expect(mockPush).toHaveBeenCalledWith("/today");
+  });
+
+  it("G+C 導航至 /canvas", () => {
+    setup();
+
+    act(() => {
+      fireKey("g");
+      vi.advanceTimersByTime(100);
+      fireKey("c");
+    });
+
+    expect(mockPush).toHaveBeenCalledWith("/canvas");
+  });
+
+  it("G+S 導航至 /settings", () => {
+    setup();
+
+    act(() => {
+      fireKey("g");
+      vi.advanceTimersByTime(100);
+      fireKey("s");
+    });
+
+    expect(mockPush).toHaveBeenCalledWith("/settings");
+  });
+
+  it("G 系列超過 500ms 不觸發導航", () => {
+    setup();
+
+    act(() => {
+      fireKey("g");
+      vi.advanceTimersByTime(600); // 超過 500ms
+      fireKey("i");
+    });
+
+    expect(mockPush).not.toHaveBeenCalled();
+  });
+
+  it("? 開啟 ShortcutsModal", () => {
+    setup();
+
+    act(() => {
+      fireKey("?");
+    });
+
+    expect(onOpenShortcutsModal).toHaveBeenCalledTimes(1);
+  });
+
+  it("⌘K 呼叫 toggleCmdk", () => {
+    setup();
+
+    act(() => {
+      fireKey("k", { metaKey: true });
+    });
+
+    expect(mockToggleCmdk).toHaveBeenCalledTimes(1);
+  });
+
+  it("input focus 中字母快捷鍵不觸發", () => {
+    setup();
+
+    const input = document.createElement("input");
+    document.body.appendChild(input);
+    input.focus();
+
+    // activeElement 為 input，字母快捷鍵應不觸發
+    act(() => {
+      const event = new KeyboardEvent("keydown", {
+        key: "g",
+        bubbles: true,
+      });
+      Object.defineProperty(event, "target", { value: input });
+      window.dispatchEvent(event);
+    });
+
+    act(() => {
+      fireKey("i");
+    });
+
+    expect(mockPush).not.toHaveBeenCalled();
+
+    document.body.removeChild(input);
+  });
+
+  it("⌘K 在 input focus 中仍觸發（不受 input focus 影響）", () => {
+    setup();
+
+    const input = document.createElement("input");
+    document.body.appendChild(input);
+    input.focus();
+
+    act(() => {
+      fireKey("k", { metaKey: true });
+    });
+
+    expect(mockToggleCmdk).toHaveBeenCalledTimes(1);
+
+    document.body.removeChild(input);
+  });
+
+  it("移除後不再監聽", () => {
+    const { unmount } = setup();
+    const removeEventListenerSpy = vi.spyOn(window, "removeEventListener");
+
+    unmount();
+
+    expect(removeEventListenerSpy).toHaveBeenCalledWith("keydown", expect.any(Function));
+    removeEventListenerSpy.mockRestore();
+  });
+});

--- a/dev/frontend/app/(shell)/layout.tsx
+++ b/dev/frontend/app/(shell)/layout.tsx
@@ -7,6 +7,8 @@ import { MainArea } from "@/components/shell/main-area";
 import { CopilotSlot } from "@/components/shell/copilot-slot";
 import { CmdkProvider } from "@/components/cmdk/cmdk-provider";
 import { CommandPalette } from "@/components/cmdk/command-palette";
+import { ShortcutsModal } from "@/components/shortcuts/shortcuts-modal";
+import { useKeyboardShortcuts } from "@/lib/hooks/use-keyboard-shortcuts";
 import { useQuery } from "@tanstack/react-query";
 import { apiClient } from "@/lib/api/client";
 import { useApiKey } from "@/lib/hooks/use-api-key";
@@ -17,6 +19,18 @@ interface InboxCountResponse {
   count?: number;
   total?: number;
   pagination?: { total?: number };
+}
+
+function ShellContent({ children }: { children: React.ReactNode }) {
+  const [shortcutsOpen, setShortcutsOpen] = useState(false);
+  useKeyboardShortcuts({ onOpenShortcutsModal: () => setShortcutsOpen(true) });
+
+  return (
+    <>
+      {children}
+      <ShortcutsModal open={shortcutsOpen} onClose={() => setShortcutsOpen(false)} />
+    </>
+  );
 }
 
 export default function ShellLayout({
@@ -65,7 +79,9 @@ export default function ShellLayout({
         {/* 中間區域：TopBar + 內容 */}
         <div className="flex min-w-0 flex-1 flex-col">
           <TopBar />
-          <MainArea>{children}</MainArea>
+          <MainArea>
+            <ShellContent>{children}</ShellContent>
+          </MainArea>
         </div>
 
         {/* 右側 Copilot 佔位 */}

--- a/dev/frontend/components/shortcuts/shortcuts-modal.tsx
+++ b/dev/frontend/components/shortcuts/shortcuts-modal.tsx
@@ -1,0 +1,131 @@
+"use client";
+
+/**
+ * ShortcutsModal — 顯示所有快捷鍵的 Dialog
+ * trigger: ? 鍵（由 useKeyboardShortcuts hook 控制）
+ */
+
+import * as React from "react";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Kbd } from "@/components/ui/kbd";
+
+interface ShortcutItem {
+  keys: string[];
+  description: string;
+}
+
+interface ShortcutSection {
+  title: string;
+  items: ShortcutItem[];
+}
+
+const SHORTCUT_SECTIONS: ShortcutSection[] = [
+  {
+    title: "Navigation",
+    items: [
+      { keys: ["⌘", "K"], description: "開啟 Command Palette" },
+      { keys: ["G", "I"], description: "前往 Inbox" },
+      { keys: ["G", "L"], description: "前往 Library" },
+      { keys: ["G", "T"], description: "前往 Today" },
+      { keys: ["G", "C"], description: "前往 Canvas" },
+      { keys: ["G", "S"], description: "前往 Settings" },
+      { keys: ["?"], description: "顯示此快捷鍵總覽" },
+      { keys: ["Esc"], description: "關閉 overlay / modal" },
+    ],
+  },
+  {
+    title: "Inbox",
+    items: [
+      { keys: ["J"], description: "下一筆" },
+      { keys: ["K"], description: "上一筆" },
+      { keys: ["Enter"], description: "展開 / 編輯選中項目" },
+      { keys: ["A"], description: "Archive 選中項目" },
+      { keys: ["D"], description: "Delete（需確認）" },
+      { keys: ["E"], description: "快速編輯 title" },
+      { keys: ["Space"], description: "多選 toggle" },
+    ],
+  },
+  {
+    title: "Library",
+    items: [
+      { keys: ["J"], description: "下一筆" },
+      { keys: ["K"], description: "上一筆" },
+      { keys: ["Enter"], description: "開啟詳情 Sheet" },
+      { keys: ["/"], description: "Focus 搜尋欄" },
+      { keys: ["Esc"], description: "清除搜尋 / 關閉 Sheet" },
+    ],
+  },
+  {
+    title: "Entry",
+    items: [
+      { keys: ["E"], description: "進入編輯模式" },
+      { keys: ["⌘", "S"], description: "儲存" },
+      { keys: ["Esc"], description: "關閉 Sheet" },
+    ],
+  },
+  {
+    title: "Copilot",
+    items: [
+      { keys: ["Enter"], description: "送出訊息" },
+      { keys: ["⇧", "Enter"], description: "換行" },
+      { keys: ["⌘", "K"], description: "Focus Command Palette" },
+    ],
+  },
+];
+
+interface ShortcutsModalProps {
+  open: boolean;
+  onClose: () => void;
+}
+
+export function ShortcutsModal({ open, onClose }: ShortcutsModalProps) {
+  return (
+    <Dialog open={open} onOpenChange={(o) => !o && onClose()}>
+      <DialogContent
+        className="max-h-[80vh] max-w-2xl overflow-y-auto"
+        data-testid="shortcuts-modal"
+      >
+        <DialogHeader>
+          <DialogTitle>鍵盤快捷鍵</DialogTitle>
+        </DialogHeader>
+
+        <div className="mt-4 space-y-6">
+          {SHORTCUT_SECTIONS.map((section) => (
+            <div key={section.title}>
+              <h3 className="mb-2 text-sm font-semibold text-[--fg-muted] uppercase tracking-wide">
+                {section.title}
+              </h3>
+              <div className="divide-y divide-[--border] rounded-lg border border-[--border]">
+                {section.items.map((item, idx) => (
+                  <div
+                    key={idx}
+                    className="flex items-center justify-between px-4 py-2.5"
+                  >
+                    <span className="text-sm text-[--fg-base]">
+                      {item.description}
+                    </span>
+                    <div className="flex items-center gap-1">
+                      {item.keys.map((k, ki) => (
+                        <React.Fragment key={ki}>
+                          {ki > 0 && (
+                            <span className="text-xs text-[--fg-muted]">+</span>
+                          )}
+                          <Kbd>{k}</Kbd>
+                        </React.Fragment>
+                      ))}
+                    </div>
+                  </div>
+                ))}
+              </div>
+            </div>
+          ))}
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/dev/frontend/lib/hooks/use-keyboard-shortcuts.ts
+++ b/dev/frontend/lib/hooks/use-keyboard-shortcuts.ts
@@ -1,0 +1,113 @@
+"use client";
+
+/**
+ * useKeyboardShortcuts — 全域鍵盤快捷鍵 hook
+ *
+ * 功能：
+ * - 全域快捷鍵：⌘K（Command Palette）、?（Shortcuts Modal）、G 系列導航
+ * - G 系列 sequential key：500ms timeout，G+I/L/T/C/S
+ * - Business Rule：input/textarea/select focus 中，字母快捷鍵不觸發
+ * - ⌘ 快捷鍵不受 input focus 影響
+ */
+
+import { useEffect, useRef } from "react";
+import { useRouter } from "next/navigation";
+import { useCmdk } from "@/components/cmdk/cmdk-provider";
+
+export interface UseKeyboardShortcutsOptions {
+  onOpenShortcutsModal: () => void;
+}
+
+const SEQUENTIAL_TIMEOUT_MS = 500;
+
+function isInputFocused(): boolean {
+  const tag = document.activeElement?.tagName?.toUpperCase();
+  return ["INPUT", "TEXTAREA", "SELECT"].includes(tag ?? "");
+}
+
+export function useKeyboardShortcuts({
+  onOpenShortcutsModal,
+}: UseKeyboardShortcutsOptions): void {
+  const router = useRouter();
+  const { toggle: toggleCmdk } = useCmdk();
+  const lastKeyRef = useRef<{ key: string; time: number } | null>(null);
+
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      // 跳過 IME 組字中的事件
+      if (e.isComposing) return;
+
+      const now = Date.now();
+
+      // ⌘K — 開啟 Command Palette（不受 input focus 影響）
+      if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === "k") {
+        e.preventDefault();
+        toggleCmdk();
+        lastKeyRef.current = null;
+        return;
+      }
+
+      // 字母快捷鍵在 input 中不觸發
+      if (isInputFocused()) {
+        lastKeyRef.current = null;
+        return;
+      }
+
+      // G 系列 sequential key
+      if (lastKeyRef.current?.key === "g") {
+        const elapsed = now - lastKeyRef.current.time;
+        if (elapsed <= SEQUENTIAL_TIMEOUT_MS) {
+          // 在 500ms 內
+          const secondKey = e.key.toLowerCase();
+          lastKeyRef.current = null;
+
+          switch (secondKey) {
+            case "i":
+              e.preventDefault();
+              router.push("/inbox");
+              return;
+            case "l":
+              e.preventDefault();
+              router.push("/library");
+              return;
+            case "t":
+              e.preventDefault();
+              router.push("/today");
+              return;
+            case "c":
+              e.preventDefault();
+              router.push("/canvas");
+              return;
+            case "s":
+              e.preventDefault();
+              router.push("/settings");
+              return;
+            default:
+              // 不識別的第二個 key，忽略
+              return;
+          }
+        } else {
+          // 超過 500ms，重置
+          lastKeyRef.current = null;
+        }
+      }
+
+      // ? — 開啟 Shortcuts Modal
+      if (e.key === "?" && !e.metaKey && !e.ctrlKey) {
+        e.preventDefault();
+        onOpenShortcutsModal();
+        return;
+      }
+
+      // G — 開始 sequential key
+      if (e.key.toLowerCase() === "g" && !e.metaKey && !e.ctrlKey) {
+        e.preventDefault();
+        lastKeyRef.current = { key: "g", time: now };
+        return;
+      }
+    };
+
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, [router, toggleCmdk, onOpenShortcutsModal]);
+}


### PR DESCRIPTION
## Summary
- 全域鍵盤快捷鍵系統，支援 G 系列 sequential key（500ms timeout）、`?` 開啟 ShortcutsModal、⌘K（Command Palette）
- ShortcutsModal：Dialog 列出 Navigation / Inbox / Library / Entry / Copilot 所有快捷鍵，使用 `<Kbd>` 元件渲染
- Shell layout 整合：`ShellContent` 元件掛載全域 hook + modal，置於 CmdkProvider 內部

## Changes
- `dev/frontend/lib/hooks/use-keyboard-shortcuts.ts` — 全域 hook，G 系列 sequential key（lastKeyRef + 500ms timeout）、`?` trigger、isInputFocused 屏蔽邏輯
- `dev/frontend/components/shortcuts/shortcuts-modal.tsx` — Dialog 含 5 個 section，每個快捷鍵使用 `<Kbd>` 元件
- `dev/frontend/app/(shell)/layout.tsx` — 新增 ShellContent 內部元件整合 hook + modal
- `dev/frontend/__tests__/lib/hooks/use-keyboard-shortcuts.test.ts` — G 系列導航、超時重置、input focus 屏蔽、⌘K 不受 input 影響等測試
- `dev/frontend/__tests__/components/shortcuts/shortcuts-modal.test.tsx` — open/close、section 顯示、Kbd 渲染測試

## Scenario 覆蓋
- [x] Scenario: G I 導航至 Inbox — lastKeyRef + 500ms timeout 實作
- [x] Scenario: ? 開啟 ShortcutsModal — `onOpenShortcutsModal` callback 觸發
- [x] Scenario: Sequential key 超時重置 — elapsed > 500ms 不觸發導航
- [x] Scenario: Input focus 中字母快捷鍵不觸發 — isInputFocused() 檢查
- [x] Scenario: ⌘K 不受 input focus 影響 — ⌘ 快捷鍵在 isInputFocused 前處理

## 技術說明
- `useKeyboardShortcuts` 掛在 `ShellContent`（CmdkProvider 子元件），可直接呼叫 `useCmdk().toggle()`
- G 系列：按下 G 時儲存 `{ key: 'g', time: Date.now() }`，第二個 key 到來時計算 elapsed；超過 500ms 則重置並忽略
- ⌘J（Copilot toggle）為 stub，待 F-047 CopilotStore 完成後接入

## Related Issues
Closes #234