### PR TITLE
test: Sprint 16 Playwright browser test skeletons (F-047~F-050)

### DIFF
--- a/test/browser/specs/f047_copilot_panel.spec.ts
+++ b/test/browser/specs/f047_copilot_panel.spec.ts
@@ -1,0 +1,257 @@
+/**
+ * F-047: Copilot Side Panel
+ *
+ * Spec: specs/features/f047-copilot-side-panel.md
+ * Issue: #232
+ * QA Issue: #236
+ *
+ * 涵蓋 Sprint 16 QA scenarios：
+ * CP-1  ⌘J 開啟 Panel
+ * CP-2  ⌘J 關閉 Panel
+ * CP-3  跨路由切換 Panel 保持
+ * CP-4  送出訊息 streaming 顯示
+ * CP-5  Clear session 清空訊息
+ * CP-6  resize Panel 寬度
+ */
+
+import { test, expect } from "@playwright/test";
+import { loginWithCookie } from "../helpers/cookie-auth";
+
+const FEATURE = "F-047";
+const API_BASE = process.env.API_BASE_URL || "http://localhost:8081";
+const SESSION_ID = "session-test-uuid-001";
+
+// --- Helpers ---
+
+function makeSession() {
+  return { session_id: SESSION_ID, created_at: "2026-04-28T10:00:00Z" };
+}
+
+function makeMessages(count = 3) {
+  return Array.from({ length: count }, (_, i) => ({
+    id: `msg-${i + 1}`,
+    session_id: SESSION_ID,
+    role: i % 2 === 0 ? "user" : "assistant",
+    content: `Message ${i + 1}`,
+    created_at: "2026-04-28T10:00:00Z",
+  }));
+}
+
+test.describe(`[${FEATURE}] Copilot Side Panel`, () => {
+  test.beforeEach(async ({ context }) => {
+    await context.clearCookies();
+    const apiKey = process.env.AIBO_E2E_API_KEY!;
+    await loginWithCookie(context, apiKey);
+  });
+
+  // --- CP-1: ⌘J 開啟 Panel ---
+
+  test("CP-1 ⌘J 開啟 CopilotPanel（slide-in from right）", async ({ page }) => {
+    test.skip(true, "skeleton：等 F-047 CopilotPanel + ⌘J 快捷鍵實作");
+
+    await page.goto("/dashboard");
+    await page.waitForLoadState("networkidle");
+
+    // Panel 初始應為隱藏
+    const panel = page.getByTestId("copilot-panel");
+    await expect(panel).not.toBeVisible();
+
+    // 按 ⌘J 開啟
+    await page.keyboard.press("Meta+j");
+    await expect(panel).toBeVisible();
+
+    await page.screenshot({ path: `../screenshots/${FEATURE}/cp1-panel-open.png` });
+  });
+
+  // --- CP-2: ⌘J 關閉 Panel ---
+
+  test("CP-2 ⌘J 再次按下關閉 CopilotPanel", async ({ page }) => {
+    test.skip(true, "skeleton：等 F-047 CopilotPanel toggle 實作");
+
+    await page.goto("/dashboard");
+    await page.waitForLoadState("networkidle");
+
+    const panel = page.getByTestId("copilot-panel");
+
+    // 開啟
+    await page.keyboard.press("Meta+j");
+    await expect(panel).toBeVisible();
+
+    // 關閉
+    await page.keyboard.press("Meta+j");
+    await expect(panel).not.toBeVisible();
+
+    await page.screenshot({ path: `../screenshots/${FEATURE}/cp2-panel-closed.png` });
+  });
+
+  // --- CP-3: 跨路由切換 Panel 保持 ---
+
+  test("CP-3 跨路由切換後 Panel 仍顯示且訊息保留", async ({ page }) => {
+    test.skip(true, "skeleton：等 F-047 Panel 跨路由持久化實作");
+
+    // Mock sessions + messages
+    await page.route(`${API_BASE}/api/v1/copilot/sessions`, (route) => {
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ sessions: [makeSession()] }),
+      });
+    });
+
+    await page.route(`${API_BASE}/api/v1/copilot/sessions/${SESSION_ID}/messages`, (route) => {
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ messages: makeMessages(3) }),
+      });
+    });
+
+    await page.goto("/dashboard");
+    await page.waitForLoadState("networkidle");
+
+    // 開啟 Panel，確認有 3 則訊息
+    await page.keyboard.press("Meta+j");
+    const panel = page.getByTestId("copilot-panel");
+    await expect(panel).toBeVisible();
+    await expect(panel.getByTestId("copilot-message")).toHaveCount(3);
+
+    // 切換路由
+    await page.goto("/dashboard/library");
+    await page.waitForLoadState("networkidle");
+
+    // Panel 仍顯示，訊息保留
+    await expect(panel).toBeVisible();
+    await expect(panel.getByTestId("copilot-message")).toHaveCount(3);
+
+    await page.screenshot({ path: `../screenshots/${FEATURE}/cp3-panel-persists.png` });
+  });
+
+  // --- CP-4: 送出訊息 SSE streaming 顯示 ---
+
+  test("CP-4 送出訊息後 streaming 逐字顯示，TypingIndicator 在 message_done 後消失", async ({ page }) => {
+    test.skip(true, "skeleton：等 F-047 streaming UI + F-048 SSE backend 實作");
+
+    // Mock POST message → stream_ready
+    await page.route(`${API_BASE}/api/v1/copilot/message`, (route) => {
+      if (route.request().method() === "POST") {
+        route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify({ stream_ready: true, message_id: "msg-new" }),
+        });
+      } else {
+        route.continue();
+      }
+    });
+
+    // Mock SSE stream endpoint
+    await page.route(`${API_BASE}/api/v1/copilot/sessions/${SESSION_ID}/stream*`, (route) => {
+      route.fulfill({
+        status: 200,
+        contentType: "text/event-stream",
+        body: [
+          "data: {\"type\":\"message_start\",\"message_id\":\"msg-new\"}\n\n",
+          "data: {\"type\":\"token\",\"content\":\"Hello\"}\n\n",
+          "data: {\"type\":\"token\",\"content\":\" world\"}\n\n",
+          "data: {\"type\":\"message_done\",\"message_id\":\"msg-new\"}\n\n",
+        ].join(""),
+      });
+    });
+
+    await page.goto("/dashboard");
+    await page.waitForLoadState("networkidle");
+
+    await page.keyboard.press("Meta+j");
+    const panel = page.getByTestId("copilot-panel");
+    await expect(panel).toBeVisible();
+
+    // 輸入訊息並 Enter
+    const input = panel.getByTestId("copilot-input");
+    await input.fill("Hello copilot");
+    await input.press("Enter");
+
+    // user message 立即顯示
+    await expect(panel.getByText("Hello copilot")).toBeVisible();
+
+    // TypingIndicator 在 streaming 時顯示
+    const typingIndicator = panel.getByTestId("typing-indicator");
+    await expect(typingIndicator).toBeVisible();
+
+    // streaming 結束後 assistant message 出現，TypingIndicator 消失
+    await expect(panel.getByText("Hello world")).toBeVisible({ timeout: 10_000 });
+    await expect(typingIndicator).not.toBeVisible();
+
+    await page.screenshot({ path: `../screenshots/${FEATURE}/cp4-streaming-done.png` });
+  });
+
+  // --- CP-5: Clear session 清空 ---
+
+  test("CP-5 Clear session → messages 清空，顯示 welcome message", async ({ page }) => {
+    test.skip(true, "skeleton：等 F-047 Clear session 功能實作");
+
+    await page.route(`${API_BASE}/api/v1/copilot/sessions/${SESSION_ID}`, (route) => {
+      if (route.request().method() === "DELETE") {
+        route.fulfill({ status: 204 });
+      } else {
+        route.continue();
+      }
+    });
+
+    await page.route(`${API_BASE}/api/v1/copilot/sessions/${SESSION_ID}/messages`, (route) => {
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ messages: makeMessages(3) }),
+      });
+    });
+
+    await page.goto("/dashboard");
+    await page.waitForLoadState("networkidle");
+
+    await page.keyboard.press("Meta+j");
+    const panel = page.getByTestId("copilot-panel");
+    await expect(panel).toBeVisible();
+
+    // 點擊 Clear session
+    const clearButton = panel.getByRole("button", { name: /clear session/i });
+    await clearButton.click();
+
+    // 確認 messages 清空，welcome message 出現
+    await expect(panel.getByTestId("copilot-message")).toHaveCount(0);
+    await expect(panel.getByTestId("copilot-welcome")).toBeVisible();
+
+    await page.screenshot({ path: `../screenshots/${FEATURE}/cp5-session-cleared.png` });
+  });
+
+  // --- CP-6: resize Panel 寬度 ---
+
+  test("CP-6 拖拉 resize handle 可調整 Panel 寬度", async ({ page }) => {
+    test.skip(true, "skeleton：等 F-047 Panel resize 功能實作");
+
+    await page.goto("/dashboard");
+    await page.waitForLoadState("networkidle");
+
+    await page.keyboard.press("Meta+j");
+    const panel = page.getByTestId("copilot-panel");
+    await expect(panel).toBeVisible();
+
+    // 取得初始寬度
+    const initialWidth = await panel.evaluate((el) => el.getBoundingClientRect().width);
+
+    // 拖拉 resize handle 往左移動 100px（擴大 Panel）
+    const resizeHandle = page.getByTestId("copilot-resize-handle");
+    const handleBox = await resizeHandle.boundingBox();
+    if (handleBox) {
+      await page.mouse.move(handleBox.x + handleBox.width / 2, handleBox.y + handleBox.height / 2);
+      await page.mouse.down();
+      await page.mouse.move(handleBox.x - 100, handleBox.y + handleBox.height / 2);
+      await page.mouse.up();
+    }
+
+    // Panel 寬度應增加
+    const newWidth = await panel.evaluate((el) => el.getBoundingClientRect().width);
+    expect(newWidth).toBeGreaterThan(initialWidth);
+
+    await page.screenshot({ path: `../screenshots/${FEATURE}/cp6-panel-resized.png` });
+  });
+});

--- a/test/browser/specs/f048_copilot_backend.spec.ts
+++ b/test/browser/specs/f048_copilot_backend.spec.ts
@@ -1,0 +1,279 @@
+/**
+ * F-048: Copilot Backend SSE
+ *
+ * Spec: specs/features/f048-copilot-backend-sse.md
+ * Issue: #231
+ * QA Issue: #236
+ *
+ * 涵蓋 Sprint 16 QA scenarios（API 層）：
+ * CB-1  POST message → stream_ready + SSE token push
+ * CB-2  POST sessions → 建立 session，回傳 session_id (UUID)
+ * CB-3  GET sessions/:id/messages → 查詢歷史訊息（role + content）
+ * CB-4  LLM 不可用時回傳 503 + LLM_UNAVAILABLE
+ * CB-5  無效 session_id 回傳 404 + NOT_FOUND
+ */
+
+import { test, expect } from "@playwright/test";
+import { loginWithCookie } from "../helpers/cookie-auth";
+
+const FEATURE = "F-048";
+const API_BASE = process.env.API_BASE_URL || "http://localhost:8081";
+
+// UUID v4 pattern
+const UUID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+test.describe(`[${FEATURE}] Copilot Backend SSE`, () => {
+  test.beforeEach(async ({ context }) => {
+    await context.clearCookies();
+    const apiKey = process.env.AIBO_E2E_API_KEY!;
+    await loginWithCookie(context, apiKey);
+  });
+
+  // --- CB-1: POST message → stream_ready + SSE ---
+
+  test("CB-1 POST /api/v1/copilot/message → 200 stream_ready + SSE token push", async ({ page }) => {
+    test.skip(true, "skeleton：等 F-048 POST /copilot/message endpoint + SSE 推送實作");
+
+    const SESSION_ID = "session-cb1-uuid";
+
+    // Mock POST message
+    await page.route(`${API_BASE}/api/v1/copilot/message`, (route) => {
+      if (route.request().method() === "POST") {
+        route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify({
+            stream_ready: true,
+            message_id: "msg-cb1",
+            session_id: SESSION_ID,
+          }),
+        });
+      } else {
+        route.continue();
+      }
+    });
+
+    // Mock SSE stream
+    await page.route(`${API_BASE}/api/v1/copilot/sessions/${SESSION_ID}/stream*`, (route) => {
+      route.fulfill({
+        status: 200,
+        contentType: "text/event-stream",
+        headers: {
+          "Cache-Control": "no-cache",
+          Connection: "keep-alive",
+        },
+        body: [
+          `data: {"type":"message_start","message_id":"msg-cb1"}\n\n`,
+          `data: {"type":"token","content":"Hello"}\n\n`,
+          `data: {"type":"token","content":" world"}\n\n`,
+          `data: {"type":"message_done","message_id":"msg-cb1","total_tokens":10}\n\n`,
+        ].join(""),
+      });
+    });
+
+    await page.goto("/dashboard");
+    await page.waitForLoadState("networkidle");
+
+    // 直接呼叫 API via fetch in page context
+    const result = await page.evaluate(async (apiBase) => {
+      const resp = await fetch(`${apiBase}/api/v1/copilot/message`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          session_id: "session-cb1-uuid",
+          content: "Hello copilot",
+        }),
+        credentials: "include",
+      });
+      const body = await resp.json();
+      return { status: resp.status, body };
+    }, API_BASE);
+
+    expect(result.status).toBe(200);
+    expect(result.body.stream_ready).toBe(true);
+    expect(result.body.message_id).toBeDefined();
+
+    await page.screenshot({ path: `../screenshots/${FEATURE}/cb1-post-message.png` });
+  });
+
+  // --- CB-2: POST sessions → 建立 session ---
+
+  test("CB-2 POST /api/v1/copilot/sessions → 201 + session_id (UUID)", async ({ page }) => {
+    test.skip(true, "skeleton：等 F-048 POST /copilot/sessions endpoint 實作");
+
+    await page.route(`${API_BASE}/api/v1/copilot/sessions`, (route) => {
+      if (route.request().method() === "POST") {
+        route.fulfill({
+          status: 201,
+          contentType: "application/json",
+          body: JSON.stringify({
+            session_id: "550e8400-e29b-41d4-a716-446655440000",
+            created_at: "2026-04-28T10:00:00Z",
+          }),
+        });
+      } else {
+        route.continue();
+      }
+    });
+
+    await page.goto("/dashboard");
+    await page.waitForLoadState("networkidle");
+
+    const result = await page.evaluate(async (apiBase) => {
+      const resp = await fetch(`${apiBase}/api/v1/copilot/sessions`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({}),
+        credentials: "include",
+      });
+      const body = await resp.json();
+      return { status: resp.status, body };
+    }, API_BASE);
+
+    expect(result.status).toBe(201);
+    expect(result.body.session_id).toMatch(UUID_PATTERN);
+
+    await page.screenshot({ path: `../screenshots/${FEATURE}/cb2-create-session.png` });
+  });
+
+  // --- CB-3: GET sessions/:id/messages → 查詢歷史訊息 ---
+
+  test("CB-3 GET /api/v1/copilot/sessions/:id/messages → 200 含 role + content", async ({ page }) => {
+    test.skip(true, "skeleton：等 F-048 GET /copilot/sessions/:id/messages endpoint 實作");
+
+    const SESSION_ID = "session-cb3-uuid";
+
+    await page.route(`${API_BASE}/api/v1/copilot/sessions/${SESSION_ID}/messages`, (route) => {
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          messages: [
+            {
+              id: "msg-1",
+              session_id: SESSION_ID,
+              role: "user",
+              content: "What is aibo?",
+              created_at: "2026-04-28T10:00:00Z",
+            },
+            {
+              id: "msg-2",
+              session_id: SESSION_ID,
+              role: "assistant",
+              content: "Aibo is your AI-powered knowledge companion.",
+              created_at: "2026-04-28T10:00:01Z",
+            },
+          ],
+          total: 2,
+        }),
+      });
+    });
+
+    await page.goto("/dashboard");
+    await page.waitForLoadState("networkidle");
+
+    const result = await page.evaluate(
+      async ({ apiBase, sessionId }) => {
+        const resp = await fetch(`${apiBase}/api/v1/copilot/sessions/${sessionId}/messages`, {
+          credentials: "include",
+        });
+        const body = await resp.json();
+        return { status: resp.status, body };
+      },
+      { apiBase: API_BASE, sessionId: SESSION_ID },
+    );
+
+    expect(result.status).toBe(200);
+    expect(result.body.messages).toHaveLength(2);
+    expect(result.body.messages[0].role).toBe("user");
+    expect(result.body.messages[0].content).toBe("What is aibo?");
+    expect(result.body.messages[1].role).toBe("assistant");
+
+    await page.screenshot({ path: `../screenshots/${FEATURE}/cb3-get-messages.png` });
+  });
+
+  // --- CB-4: LLM 不可用時回傳 503 ---
+
+  test("CB-4 LLM 不可用時 POST /copilot/message → 503 + LLM_UNAVAILABLE", async ({ page }) => {
+    test.skip(true, "skeleton：等 F-048 LLM provider 健康檢查 + 503 回應實作");
+
+    await page.route(`${API_BASE}/api/v1/copilot/message`, (route) => {
+      if (route.request().method() === "POST") {
+        route.fulfill({
+          status: 503,
+          contentType: "application/json",
+          body: JSON.stringify({
+            code: "LLM_UNAVAILABLE",
+            message: "No active LLM provider available",
+          }),
+        });
+      } else {
+        route.continue();
+      }
+    });
+
+    await page.goto("/dashboard");
+    await page.waitForLoadState("networkidle");
+
+    const result = await page.evaluate(async (apiBase) => {
+      const resp = await fetch(`${apiBase}/api/v1/copilot/message`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ session_id: "any-session", content: "test" }),
+        credentials: "include",
+      });
+      const body = await resp.json();
+      return { status: resp.status, body };
+    }, API_BASE);
+
+    expect(result.status).toBe(503);
+    expect(result.body.code).toBe("LLM_UNAVAILABLE");
+
+    await page.screenshot({ path: `../screenshots/${FEATURE}/cb4-503-llm-unavailable.png` });
+  });
+
+  // --- CB-5: 無效 session_id → 404 ---
+
+  test("CB-5 無效 session_id → POST /copilot/message → 404 + NOT_FOUND", async ({ page }) => {
+    test.skip(true, "skeleton：等 F-048 session 驗證 + 404 回應實作");
+
+    const INVALID_SESSION = "nonexistent-session-id";
+
+    await page.route(`${API_BASE}/api/v1/copilot/message`, (route) => {
+      if (route.request().method() === "POST") {
+        route.fulfill({
+          status: 404,
+          contentType: "application/json",
+          body: JSON.stringify({
+            code: "NOT_FOUND",
+            message: `Session ${INVALID_SESSION} not found`,
+          }),
+        });
+      } else {
+        route.continue();
+      }
+    });
+
+    await page.goto("/dashboard");
+    await page.waitForLoadState("networkidle");
+
+    const result = await page.evaluate(
+      async ({ apiBase, sessionId }) => {
+        const resp = await fetch(`${apiBase}/api/v1/copilot/message`, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ session_id: sessionId, content: "test" }),
+          credentials: "include",
+        });
+        const body = await resp.json();
+        return { status: resp.status, body };
+      },
+      { apiBase: API_BASE, sessionId: INVALID_SESSION },
+    );
+
+    expect(result.status).toBe(404);
+    expect(result.body.code).toBe("NOT_FOUND");
+
+    await page.screenshot({ path: `../screenshots/${FEATURE}/cb5-404-not-found.png` });
+  });
+});

--- a/test/browser/specs/f049_cmdk_power.spec.ts
+++ b/test/browser/specs/f049_cmdk_power.spec.ts
@@ -1,0 +1,278 @@
+/**
+ * F-049: CmdK Power Actions
+ *
+ * Spec: specs/features/f049-cmdk-power-actions.md
+ * Issue: #233
+ * QA Issue: #236
+ *
+ * 涵蓋 Sprint 16 QA scenarios：
+ * CP-1  3+ 字元觸發搜尋（200ms debounce），結果分組出現
+ * CP-2  點擊搜尋結果開啟 EntryDetailSheet
+ * CP-3  QuickCreate：輸入 "new" → "New Entry" → QuickCreateModal → toast
+ * CP-4  > prefix AI mode：只顯示 AI Actions 分組
+ * CP-5  搜尋失敗 silent fail：Navigation 正常，Search Results 不顯示
+ * CP-6  grouped results：Navigation / Search / AI 分組標題顯示正確
+ */
+
+import { test, expect } from "@playwright/test";
+import { loginWithCookie } from "../helpers/cookie-auth";
+
+const FEATURE = "F-049";
+const API_BASE = process.env.API_BASE_URL || "http://localhost:8081";
+
+// --- Helpers ---
+
+function makeSearchResults(items?: Array<{ id: string; title: string; category: string }>) {
+  return {
+    items: items ?? [
+      { id: "entry-golang", title: "Golang Concurrency", category: "Programming" },
+      { id: "entry-go2", title: "Go Channels Explained", category: "Programming" },
+    ],
+    total: items?.length ?? 2,
+  };
+}
+
+test.describe(`[${FEATURE}] CmdK Power Actions`, () => {
+  test.beforeEach(async ({ context }) => {
+    await context.clearCookies();
+    const apiKey = process.env.AIBO_E2E_API_KEY!;
+    await loginWithCookie(context, apiKey);
+  });
+
+  // --- CP-1: 3+ 字元觸發搜尋 debounce ---
+
+  test("CP-1 輸入 3+ 字元後 200ms debounce 觸發搜尋，Search Results 分組出現", async ({ page }) => {
+    test.skip(true, "skeleton：等 F-049 CmdK 搜尋 debounce + Search Results 分組實作");
+
+    let searchCallCount = 0;
+
+    await page.route(`${API_BASE}/api/v1/entries/search*`, (route) => {
+      searchCallCount++;
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify(makeSearchResults()),
+      });
+    });
+
+    await page.goto("/dashboard");
+    await page.waitForLoadState("networkidle");
+
+    // 開啟 CmdK palette
+    await page.keyboard.press("Meta+k");
+    const palette = page.getByTestId("cmdk-palette");
+    await expect(palette).toBeVisible();
+
+    // 輸入 1 字元，不應觸發搜尋
+    await page.keyboard.type("c");
+    await page.waitForTimeout(250);
+    expect(searchCallCount).toBe(0);
+
+    // 繼續輸入到 3+ 字元
+    await page.keyboard.type("on");
+    // 等待 debounce（200ms）+ 緩衝
+    await page.waitForTimeout(400);
+
+    // 搜尋應已觸發
+    expect(searchCallCount).toBeGreaterThanOrEqual(1);
+
+    // "Search Results" 分組出現
+    const searchGroup = palette.getByTestId("cmdk-group-search");
+    await expect(searchGroup).toBeVisible();
+    await expect(searchGroup.getByText("Golang Concurrency")).toBeVisible();
+
+    await page.screenshot({ path: `../screenshots/${FEATURE}/cp1-search-results.png` });
+  });
+
+  // --- CP-2: 點擊搜尋結果開啟 EntryDetailSheet ---
+
+  test("CP-2 點擊搜尋結果 → EntryDetailSheet 開啟", async ({ page }) => {
+    test.skip(true, "skeleton：等 F-049 搜尋結果 → EntryDetailSheet 跳轉實作");
+
+    await page.route(`${API_BASE}/api/v1/entries/search*`, (route) => {
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify(makeSearchResults()),
+      });
+    });
+
+    await page.route(`${API_BASE}/api/v1/entries/entry-golang`, (route) => {
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          id: "entry-golang",
+          title: "Golang Concurrency",
+          content: "Goroutines and channels...",
+          category: "Programming",
+        }),
+      });
+    });
+
+    await page.goto("/dashboard");
+    await page.waitForLoadState("networkidle");
+
+    await page.keyboard.press("Meta+k");
+    const palette = page.getByTestId("cmdk-palette");
+    await expect(palette).toBeVisible();
+
+    await page.keyboard.type("conc");
+    await page.waitForTimeout(400);
+
+    // 點擊第一個搜尋結果
+    const firstResult = palette.getByTestId("cmdk-result-entry-golang");
+    await firstResult.click();
+
+    // EntryDetailSheet 開啟
+    const detailSheet = page.getByTestId("entry-detail-sheet");
+    await expect(detailSheet).toBeVisible();
+    await expect(detailSheet.getByText("Golang Concurrency")).toBeVisible();
+
+    // Palette 關閉
+    await expect(palette).not.toBeVisible();
+
+    await page.screenshot({ path: `../screenshots/${FEATURE}/cp2-entry-detail-sheet.png` });
+  });
+
+  // --- CP-3: QuickCreate entry ---
+
+  test("CP-3 ⌘K → 選 'New Entry' → QuickCreateModal → 建立後 toast", async ({ page }) => {
+    test.skip(true, "skeleton：等 F-049 QuickCreate flow + toast 實作");
+
+    await page.route(`${API_BASE}/api/v1/entries`, (route) => {
+      if (route.request().method() === "POST") {
+        route.fulfill({
+          status: 201,
+          contentType: "application/json",
+          body: JSON.stringify({
+            id: "entry-new-1",
+            title: "My New Draft Entry",
+            status: "draft",
+            created_at: "2026-04-28T10:00:00Z",
+          }),
+        });
+      } else {
+        route.continue();
+      }
+    });
+
+    await page.goto("/dashboard");
+    await page.waitForLoadState("networkidle");
+
+    await page.keyboard.press("Meta+k");
+    const palette = page.getByTestId("cmdk-palette");
+    await expect(palette).toBeVisible();
+
+    // 輸入 "new" 並選擇 "New Entry"
+    await page.keyboard.type("new");
+    await page.waitForTimeout(200);
+
+    const newEntryOption = palette.getByText(/new entry/i);
+    await newEntryOption.click();
+
+    // QuickCreateModal 出現
+    const modal = page.getByTestId("quick-create-modal");
+    await expect(modal).toBeVisible();
+
+    // 輸入 title 並選 "Create as Draft"
+    const titleInput = modal.getByTestId("quick-create-title");
+    await titleInput.fill("My New Draft Entry");
+    await modal.getByRole("button", { name: /create as draft/i }).click();
+
+    await page.waitForLoadState("networkidle");
+
+    // toast 出現
+    await expect(page.getByText(/entry created/i)).toBeVisible();
+    await expect(page.getByText(/open/i)).toBeVisible();
+
+    await page.screenshot({ path: `../screenshots/${FEATURE}/cp3-quick-create-toast.png` });
+  });
+
+  // --- CP-4: > prefix AI mode ---
+
+  test("CP-4 輸入 '>sum' → 只顯示 AI Actions（含 'summarize'），其他分組不顯示", async ({ page }) => {
+    test.skip(true, "skeleton：等 F-049 > prefix AI mode 分組過濾實作");
+
+    await page.goto("/dashboard");
+    await page.waitForLoadState("networkidle");
+
+    await page.keyboard.press("Meta+k");
+    const palette = page.getByTestId("cmdk-palette");
+    await expect(palette).toBeVisible();
+
+    // 輸入 > prefix
+    await page.keyboard.type(">sum");
+    await page.waitForTimeout(200);
+
+    // AI Actions 分組顯示，含 summarize
+    const aiGroup = palette.getByTestId("cmdk-group-ai-actions");
+    await expect(aiGroup).toBeVisible();
+    await expect(aiGroup.getByText(/summarize/i)).toBeVisible();
+
+    // Navigation 和 Search 分組不顯示
+    const navGroup = palette.getByTestId("cmdk-group-navigation");
+    await expect(navGroup).not.toBeVisible();
+
+    const searchGroup = palette.getByTestId("cmdk-group-search");
+    await expect(searchGroup).not.toBeVisible();
+
+    await page.screenshot({ path: `../screenshots/${FEATURE}/cp4-ai-mode.png` });
+  });
+
+  // --- CP-5: 搜尋失敗 silent fail ---
+
+  test("CP-5 搜尋 API 500 → Search Results 不顯示，Navigation 分組正常", async ({ page }) => {
+    test.skip(true, "skeleton：等 F-049 搜尋失敗 silent fail 實作");
+
+    await page.route(`${API_BASE}/api/v1/entries/search*`, (route) => {
+      route.fulfill({
+        status: 500,
+        contentType: "application/json",
+        body: JSON.stringify({ error: "Internal Server Error" }),
+      });
+    });
+
+    await page.goto("/dashboard");
+    await page.waitForLoadState("networkidle");
+
+    await page.keyboard.press("Meta+k");
+    const palette = page.getByTestId("cmdk-palette");
+    await expect(palette).toBeVisible();
+
+    await page.keyboard.type("conc");
+    await page.waitForTimeout(400);
+
+    // Search Results 不顯示（silent fail）
+    const searchGroup = palette.getByTestId("cmdk-group-search");
+    await expect(searchGroup).not.toBeVisible();
+
+    // Navigation 分組仍正常顯示
+    const navGroup = palette.getByTestId("cmdk-group-navigation");
+    await expect(navGroup).toBeVisible();
+
+    await page.screenshot({ path: `../screenshots/${FEATURE}/cp5-silent-fail.png` });
+  });
+
+  // --- CP-6: grouped results 分組標題 ---
+
+  test("CP-6 空白狀態下 CmdK 顯示 Navigation 分組與快捷操作", async ({ page }) => {
+    test.skip(true, "skeleton：等 F-049 CmdK 預設分組顯示實作");
+
+    await page.goto("/dashboard");
+    await page.waitForLoadState("networkidle");
+
+    await page.keyboard.press("Meta+k");
+    const palette = page.getByTestId("cmdk-palette");
+    await expect(palette).toBeVisible();
+
+    // 未輸入時顯示 Navigation 分組
+    const navGroup = palette.getByTestId("cmdk-group-navigation");
+    await expect(navGroup).toBeVisible();
+
+    // 應包含常見導航選項
+    await expect(palette.getByText(/inbox|library|settings/i)).toBeVisible();
+
+    await page.screenshot({ path: `../screenshots/${FEATURE}/cp6-default-groups.png` });
+  });
+});

--- a/test/browser/specs/f050_keyboard_shortcuts.spec.ts
+++ b/test/browser/specs/f050_keyboard_shortcuts.spec.ts
@@ -1,0 +1,255 @@
+/**
+ * F-050: Keyboard Shortcuts
+ *
+ * Spec: specs/features/f050-keyboard-shortcuts.md
+ * Issue: #234
+ * QA Issue: #236
+ *
+ * 涵蓋 Sprint 16 QA scenarios：
+ * KS-1  G+I sequential key → navigate to /dashboard/inbox
+ * KS-2  ? 開啟 ShortcutsModal（含全部 sections）
+ * KS-3  input focus 中按 J 不觸發 Library list 移動
+ * KS-4  Sequential key 超時重置（G → 600ms → I 不觸發）
+ * KS-5  ⌘S 儲存（Entry 編輯模式 → PATCH → toast "Saved"）
+ * KS-6  ⌘K 開啟 Command Palette
+ */
+
+import { test, expect } from "@playwright/test";
+import { loginWithCookie } from "../helpers/cookie-auth";
+
+const FEATURE = "F-050";
+const API_BASE = process.env.API_BASE_URL || "http://localhost:8081";
+const ENTRY_ID = "entry-ks-test";
+
+test.describe(`[${FEATURE}] Keyboard Shortcuts`, () => {
+  test.beforeEach(async ({ context }) => {
+    await context.clearCookies();
+    const apiKey = process.env.AIBO_E2E_API_KEY!;
+    await loginWithCookie(context, apiKey);
+  });
+
+  // --- KS-1: G+I sequential → /dashboard/inbox ---
+
+  test("KS-1 G+I sequential（500ms 內）→ navigate to /dashboard/inbox", async ({ page }) => {
+    test.skip(true, "skeleton：等 F-050 G+I sequential navigation 實作");
+
+    await page.goto("/dashboard/library");
+    await page.waitForLoadState("networkidle");
+
+    // 確認無 input focus
+    await page.keyboard.press("Escape");
+
+    // 按 G，500ms 內按 I
+    await page.keyboard.press("g");
+    await page.waitForTimeout(100);
+    await page.keyboard.press("i");
+
+    await page.waitForLoadState("networkidle");
+
+    expect(page.url()).toMatch(/\/dashboard\/inbox/);
+
+    await page.screenshot({ path: `../screenshots/${FEATURE}/ks1-g-i-navigation.png` });
+  });
+
+  // --- KS-2: ? 開啟 ShortcutsModal ---
+
+  test("KS-2 按 ? 開啟 ShortcutsModal，含全部 sections", async ({ page }) => {
+    test.skip(true, "skeleton：等 F-050 ShortcutsModal + ? 快捷鍵實作");
+
+    await page.goto("/dashboard");
+    await page.waitForLoadState("networkidle");
+
+    // 確認無 input focus
+    await page.keyboard.press("Escape");
+
+    // 按 ?
+    await page.keyboard.press("?");
+
+    // ShortcutsModal 出現
+    const modal = page.getByRole("dialog", { name: /keyboard shortcuts/i }).or(
+      page.getByTestId("shortcuts-modal"),
+    );
+    await expect(modal).toBeVisible();
+
+    // 包含必要 sections
+    await expect(modal.getByText(/navigation/i)).toBeVisible();
+    await expect(modal.getByText(/inbox/i)).toBeVisible();
+    await expect(modal.getByText(/library/i)).toBeVisible();
+    await expect(modal.getByText(/entry/i)).toBeVisible();
+    await expect(modal.getByText(/copilot/i)).toBeVisible();
+
+    await page.screenshot({ path: `../screenshots/${FEATURE}/ks2-shortcuts-modal.png`, fullPage: true });
+
+    // 按 Escape 關閉
+    await page.keyboard.press("Escape");
+    await expect(modal).not.toBeVisible();
+  });
+
+  // --- KS-3: input focus 中 J 不觸發 ---
+
+  test("KS-3 搜尋框 focused 時按 J 不觸發 Library list 移動", async ({ page }) => {
+    test.skip(true, "skeleton：等 F-050 input focus 防止快捷鍵觸發實作");
+
+    await page.route(`${API_BASE}/api/v1/entries/search*`, (route) => {
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ items: [], total: 0 }),
+      });
+    });
+
+    await page.goto("/dashboard/library");
+    await page.waitForLoadState("networkidle");
+
+    // 找到搜尋框並 focus
+    const searchInput = page.getByTestId("library-search-input").or(
+      page.locator('input[type="search"]'),
+    );
+    await searchInput.click();
+    await expect(searchInput).toBeFocused();
+
+    // 記錄當前選中的 list item（如果有）
+    const selectedItemBefore = await page
+      .getByTestId("library-list-item[data-selected='true']")
+      .count()
+      .catch(() => 0);
+
+    // 在 input focus 中輸入 j
+    await page.keyboard.press("j");
+
+    // Library list 選中項目不應改變
+    const selectedItemAfter = await page
+      .getByTestId("library-list-item[data-selected='true']")
+      .count()
+      .catch(() => 0);
+
+    expect(selectedItemAfter).toBe(selectedItemBefore);
+
+    // input 中應有字元 j（正常文字輸入）
+    await expect(searchInput).toHaveValue(/j/);
+
+    await page.screenshot({ path: `../screenshots/${FEATURE}/ks3-input-focus-no-shortcut.png` });
+  });
+
+  // --- KS-4: Sequential key 超時重置 ---
+
+  test("KS-4 按 G 後等待 600ms 再按 I → URL 不變（G+I 超時未觸發）", async ({ page }) => {
+    test.skip(true, "skeleton：等 F-050 sequential key timeout 重置實作");
+
+    await page.goto("/dashboard/library");
+    await page.waitForLoadState("networkidle");
+
+    // 確認無 input focus
+    await page.keyboard.press("Escape");
+
+    const urlBefore = page.url();
+
+    // 按 G
+    await page.keyboard.press("g");
+
+    // 等待超過 500ms timeout（600ms）
+    await page.waitForTimeout(600);
+
+    // 再按 I — 此時 G 已超時，不應觸發 G+I
+    await page.keyboard.press("i");
+    await page.waitForTimeout(200);
+
+    // URL 應不變
+    expect(page.url()).toBe(urlBefore);
+
+    await page.screenshot({ path: `../screenshots/${FEATURE}/ks4-sequential-timeout.png` });
+  });
+
+  // --- KS-5: ⌘S 儲存 ---
+
+  test("KS-5 Entry 編輯模式按 ⌘S → PATCH request 送出 + toast 'Saved'", async ({ page }) => {
+    test.skip(true, "skeleton：等 F-050 ⌘S 儲存快捷鍵 + Entry 編輯模式實作");
+
+    let patchCalled = false;
+
+    await page.route(`${API_BASE}/api/v1/entries/${ENTRY_ID}`, (route) => {
+      if (route.request().method() === "GET") {
+        route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify({
+            id: ENTRY_ID,
+            title: "Test Entry",
+            content: "Original content",
+            status: "draft",
+            updated_at: "2026-04-28T10:00:00Z",
+          }),
+        });
+      } else if (route.request().method() === "PATCH") {
+        patchCalled = true;
+        route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify({
+            id: ENTRY_ID,
+            title: "Test Entry",
+            content: "Original content",
+            updated_at: "2026-04-28T10:01:00Z",
+          }),
+        });
+      } else {
+        route.continue();
+      }
+    });
+
+    await page.goto(`/entries/${ENTRY_ID}`);
+    await page.waitForLoadState("networkidle");
+
+    // 進入編輯模式
+    const editButton = page.getByRole("button", { name: /edit/i });
+    await editButton.click();
+
+    // 確認在編輯模式
+    const editor = page.getByTestId("entry-editor").or(
+      page.locator("[contenteditable='true']"),
+    );
+    await expect(editor).toBeVisible();
+
+    // 按 ⌘S
+    await page.keyboard.press("Meta+s");
+    await page.waitForLoadState("networkidle");
+
+    // PATCH 應已送出
+    expect(patchCalled).toBe(true);
+
+    // toast "Saved" 出現
+    await expect(page.getByText(/saved/i)).toBeVisible();
+
+    await page.screenshot({ path: `../screenshots/${FEATURE}/ks5-cmd-s-saved.png` });
+  });
+
+  // --- KS-6: ⌘K 開啟 Command Palette ---
+
+  test("KS-6 ⌘K → Command Palette 開啟（F-049 CmdK 整合）", async ({ page }) => {
+    test.skip(true, "skeleton：等 F-050 ⌘K 快捷鍵 + F-049 CmdK 整合實作");
+
+    await page.goto("/dashboard");
+    await page.waitForLoadState("networkidle");
+
+    // Palette 初始應隱藏
+    const palette = page.getByTestId("cmdk-palette");
+    await expect(palette).not.toBeVisible();
+
+    // 按 ⌘K
+    await page.keyboard.press("Meta+k");
+    await expect(palette).toBeVisible();
+
+    // Palette 內有搜尋輸入框
+    const paletteInput = palette.getByRole("textbox").or(
+      palette.getByTestId("cmdk-input"),
+    );
+    await expect(paletteInput).toBeVisible();
+    await expect(paletteInput).toBeFocused();
+
+    // 按 Escape 關閉
+    await page.keyboard.press("Escape");
+    await expect(palette).not.toBeVisible();
+
+    await page.screenshot({ path: `../screenshots/${FEATURE}/ks6-cmdk-open-close.png` });
+  });
+});


### PR DESCRIPTION
## 摘要

Sprint 16 雙層 e2e test skeletons：Browser-level（Playwright）。

全部 scenarios 均為 `test.skip`，待 engineer PR 合併後逐步啟用。

## 測試覆蓋

| Feature | Issue | Scenarios | Browser Tests |
|---------|-------|-----------|---------------|
| F-047 Copilot Side Panel | #232 | CP-1~6 | 6 |
| F-048 Copilot Backend SSE | #231 | CB-1~5 | 5 |
| F-049 CmdK Power Actions | #233 | CP-1~6 | 6 |
| F-050 Keyboard Shortcuts | #234 | KS-1~6 | 6 |
| **合計** | | **24** | **24** |

## 新增檔案

- `test/browser/specs/f047_copilot_panel.spec.ts` — ⌘J toggle、跨路由保持、SSE streaming、Clear session、resize
- `test/browser/specs/f048_copilot_backend.spec.ts` — POST message/sessions、GET history、503/404 error codes
- `test/browser/specs/f049_cmdk_power.spec.ts` — debounce 搜尋、QuickCreate、> prefix AI mode、silent fail
- `test/browser/specs/f050_keyboard_shortcuts.spec.ts` — G+I sequential、ShortcutsModal、input focus 防觸發、⌘S 儲存

## 設計模式

- 所有測試使用 `page.route()` mock API，不依賴真實後端
- `loginWithCookie` 統一認證流程
- 失敗時自動截圖至 `test/screenshots/F-04{7-0}/`

待 engineer PR 全部合併後執行 Phase B 完整測試。

Refs #236