### PR TITLE
feat(api): F-048 Copilot Backend SSE

### DIFF
--- a/dev/src/dto/copilot.go
+++ b/dev/src/dto/copilot.go
@@ -1,0 +1,68 @@
+package dto
+
+import (
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// CreateSessionResponse POST /api/v1/copilot/sessions 回應
+type CreateSessionResponse struct {
+	SessionID string    `json:"session_id"`
+	CreatedAt time.Time `json:"created_at"`
+}
+
+// SendMessageRequest POST /api/v1/copilot/message 請求
+type SendMessageRequest struct {
+	SessionID uuid.UUID `json:"session_id" binding:"required"`
+	Content   string    `json:"content"    binding:"required,min=1,max=4000"`
+}
+
+// SendMessageResponse POST /api/v1/copilot/message 回應
+type SendMessageResponse struct {
+	MsgID       string `json:"msg_id"`
+	StreamReady bool   `json:"stream_ready"`
+}
+
+// CopilotMessageItem 歷史訊息單筆
+type CopilotMessageItem struct {
+	ID        uuid.UUID `json:"id"`
+	Role      string    `json:"role"`
+	Content   string    `json:"content"`
+	Seq       int       `json:"seq"`
+	CreatedAt time.Time `json:"created_at"`
+}
+
+// ListMessagesResponse GET /api/v1/copilot/sessions/:id/messages 回應
+type ListMessagesResponse struct {
+	Messages []CopilotMessageItem `json:"messages"`
+}
+
+// SSE event data 結構
+type SSEPingData struct {
+	Ts    time.Time `json:"ts"`
+	MsgID string    `json:"msg_id"`
+	Seq   int       `json:"seq"`
+}
+
+type SSEMessageStartData struct {
+	MsgID     string `json:"msg_id"`
+	SessionID string `json:"session_id"`
+}
+
+type SSETokenData struct {
+	Token string `json:"token"`
+	MsgID string `json:"msg_id"`
+	Seq   int    `json:"seq"`
+}
+
+type SSEMessageDoneData struct {
+	MsgID        string `json:"msg_id"`
+	TotalTokens  int    `json:"total_tokens"`
+	FinishReason string `json:"finish_reason"`
+}
+
+type SSEErrorData struct {
+	Code  string `json:"code"`
+	MsgID string `json:"msg_id"`
+}

--- a/dev/src/handler/copilot.go
+++ b/dev/src/handler/copilot.go
@@ -1,0 +1,242 @@
+package handler
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"sync"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+
+	"github.com/gpwork4u/aibo/dto"
+	"github.com/gpwork4u/aibo/model"
+	"github.com/gpwork4u/aibo/service"
+)
+
+// pendingStream 等待 SSE 連線消費的 stream 資訊
+type pendingStream struct {
+	sessionID uuid.UUID
+	msgID     uuid.UUID
+	ch        chan service.StreamEvent
+}
+
+// CopilotHandler 完整 Copilot handler（含 REST + SSE）
+type CopilotHandler struct {
+	svc *service.CopilotService
+	mu  sync.Mutex
+	// 以 msgID 為 key，暫存待消費的 stream channel
+	pending map[uuid.UUID]*pendingStream
+}
+
+// NewCopilotHandler 建立新的 CopilotHandler
+func NewCopilotHandler(svc *service.CopilotService) *CopilotHandler {
+	return &CopilotHandler{
+		svc:     svc,
+		pending: make(map[uuid.UUID]*pendingStream),
+	}
+}
+
+// --- Session CRUD ---
+
+// CreateSession POST /api/v1/copilot/sessions
+func (h *CopilotHandler) CreateSession(c *gin.Context) {
+	sess, err := h.svc.CreateSession(c.Request.Context(), "admin")
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+	c.JSON(http.StatusCreated, dto.CreateSessionResponse{
+		SessionID: sess.ID.String(),
+		CreatedAt: sess.CreatedAt,
+	})
+}
+
+// DeleteSession DELETE /api/v1/copilot/sessions/:id
+func (h *CopilotHandler) DeleteSession(c *gin.Context) {
+	id, err := uuid.Parse(c.Param("id"))
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"code": "INVALID_INPUT", "error": "invalid session id"})
+		return
+	}
+	if err := h.svc.DeleteSession(c.Request.Context(), id); err != nil {
+		if errors.Is(err, service.ErrNotFound) {
+			c.JSON(http.StatusNotFound, gin.H{"code": "NOT_FOUND"})
+			return
+		}
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+	c.Status(http.StatusNoContent)
+}
+
+// ListMessages GET /api/v1/copilot/sessions/:id/messages
+func (h *CopilotHandler) ListMessages(c *gin.Context) {
+	id, err := uuid.Parse(c.Param("id"))
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"code": "INVALID_INPUT", "error": "invalid session id"})
+		return
+	}
+	msgs, err := h.svc.ListMessages(c.Request.Context(), id)
+	if err != nil {
+		if errors.Is(err, service.ErrNotFound) {
+			c.JSON(http.StatusNotFound, gin.H{"code": "NOT_FOUND"})
+			return
+		}
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+
+	items := make([]dto.CopilotMessageItem, 0, len(msgs))
+	for _, m := range msgs {
+		items = append(items, dto.CopilotMessageItem{
+			ID:        m.ID,
+			Role:      m.Role,
+			Content:   m.Content,
+			Seq:       m.Seq,
+			CreatedAt: m.CreatedAt,
+		})
+	}
+	c.JSON(http.StatusOK, dto.ListMessagesResponse{Messages: items})
+}
+
+// --- Message + SSE ---
+
+// SendMessage POST /api/v1/copilot/message
+// 儲存 user message，確認 LLM 可用，啟動 background streaming goroutine
+func (h *CopilotHandler) SendMessage(c *gin.Context) {
+	var req dto.SendMessageRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"code": "INVALID_INPUT", "error": err.Error()})
+		return
+	}
+
+	msgID, err := h.svc.StartStream(c.Request.Context(), req.SessionID, req.Content)
+	if err != nil {
+		if errors.Is(err, service.ErrNotFound) {
+			c.JSON(http.StatusNotFound, gin.H{"code": "NOT_FOUND"})
+			return
+		}
+		if errors.Is(err, service.ErrLLMUnavailable) {
+			c.JSON(http.StatusServiceUnavailable, gin.H{"code": "LLM_UNAVAILABLE"})
+			return
+		}
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+
+	ch := make(chan service.StreamEvent, 64)
+	ps := &pendingStream{
+		sessionID: req.SessionID,
+		msgID:     msgID,
+		ch:        ch,
+	}
+
+	h.mu.Lock()
+	h.pending[msgID] = ps
+	h.mu.Unlock()
+
+	// 背景 goroutine 執行 LLM streaming
+	go func() {
+		defer func() {
+			close(ch)
+			h.mu.Lock()
+			delete(h.pending, msgID)
+			h.mu.Unlock()
+		}()
+		// 使用 background context，不受 HTTP request context 影響
+		h.svc.StreamChat(context.Background(), req.SessionID, msgID, ch)
+	}()
+
+	c.JSON(http.StatusOK, dto.SendMessageResponse{
+		MsgID:       msgID.String(),
+		StreamReady: true,
+	})
+}
+
+// Stream GET /api/v1/copilot/stream?msg_id=<uuid>
+// SSE endpoint：消費 pending channel 並推送 token 事件
+func (h *CopilotHandler) Stream(c *gin.Context) {
+	msgIDStr := c.Query("msg_id")
+	if msgIDStr == "" {
+		c.JSON(http.StatusBadRequest, gin.H{"code": "INVALID_INPUT", "error": "msg_id required"})
+		return
+	}
+	msgID, err := uuid.Parse(msgIDStr)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"code": "INVALID_INPUT", "error": "invalid msg_id"})
+		return
+	}
+
+	// 等待 pending stream 最多 5 秒（POST /message 先觸發，GET /stream 後到達）
+	var ps *pendingStream
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		h.mu.Lock()
+		ps = h.pending[msgID]
+		h.mu.Unlock()
+		if ps != nil {
+			break
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	if ps == nil {
+		c.JSON(http.StatusNotFound, gin.H{"code": "NOT_FOUND", "error": "stream not found or already consumed"})
+		return
+	}
+
+	// 設定 SSE headers
+	c.Header("Content-Type", "text/event-stream")
+	c.Header("Cache-Control", "no-cache")
+	c.Header("Connection", "keep-alive")
+	c.Header("X-Accel-Buffering", "no")
+	c.Status(http.StatusOK)
+
+	// ping ticker（每 15 秒）
+	ticker := time.NewTicker(15 * time.Second)
+	defer ticker.Stop()
+
+	pingSeq := 0
+	reqCtx := c.Request.Context()
+
+	writeSSE := func(event, data string) {
+		fmt.Fprintf(c.Writer, "event: %s\ndata: %s\n\n", event, data)
+		c.Writer.Flush()
+	}
+
+	for {
+		select {
+		case <-reqCtx.Done():
+			// 客戶端斷線
+			return
+
+		case <-ticker.C:
+			pingSeq++
+			pingData, _ := json.Marshal(dto.SSEPingData{
+				Ts:    time.Now().UTC(),
+				MsgID: msgID.String(),
+				Seq:   pingSeq,
+			})
+			writeSSE("ping", string(pingData))
+
+		case evt, ok := <-ps.ch:
+			if !ok {
+				// channel 已關閉，streaming 結束
+				return
+			}
+			writeSSE(evt.Event, evt.Data)
+		}
+	}
+}
+
+// writeSSELine 是 Stream 中的本地輔助，已內嵌於 writeSSE closure，此函式保留以備測試用
+func writeSSELine(w io.Writer, event, data string) {
+	fmt.Fprintf(w, "event: %s\ndata: %s\n\n", event, data)
+}
+
+// compile-time interface checks
+var _ = (*model.CopilotSession)(nil)

--- a/dev/src/handler/copilot_stream_handler.go
+++ b/dev/src/handler/copilot_stream_handler.go
@@ -1,48 +1,12 @@
 package handler
 
-import (
-	"fmt"
-	"net/http"
-	"time"
-
-	"github.com/gin-gonic/gin"
-)
-
-// CopilotStreamHandler SSE 串流 handler（F-039 skeleton，完整實作屬於 F-048）
+// CopilotStreamHandler F-039 SSE skeleton（已被 F-048 CopilotHandler 取代）
+// 保留此檔案以避免破壞任何現有 import；實際路由請使用 CopilotHandler。
+//
+// Deprecated: 請改用 NewCopilotHandler + CopilotHandler.Stream。
 type CopilotStreamHandler struct{}
 
-// NewCopilotStreamHandler 建立新的 CopilotStreamHandler
+// NewCopilotStreamHandler 建立 CopilotStreamHandler（deprecated skeleton）
 func NewCopilotStreamHandler() *CopilotStreamHandler {
 	return &CopilotStreamHandler{}
-}
-
-// Stream SSE skeleton：每 15s 送 ping，並送出一個 demo event
-// GET /api/v1/copilot/stream
-func (h *CopilotStreamHandler) Stream(c *gin.Context) {
-	c.Header("Content-Type", "text/event-stream")
-	c.Header("Cache-Control", "no-cache")
-	c.Header("Connection", "keep-alive")
-	c.Header("X-Accel-Buffering", "no")
-	c.Status(http.StatusOK)
-
-	// demo event（寫死 hello）
-	msgID := "demo-001"
-	seq := 1
-	eventID := fmt.Sprintf("%s:%d", msgID, seq)
-	c.Writer.WriteString(fmt.Sprintf("id: %s\nevent: message\ndata: hello\n\n", eventID))
-	c.Writer.Flush()
-
-	ticker := time.NewTicker(15 * time.Second)
-	defer ticker.Stop()
-
-	ctx := c.Request.Context()
-	for {
-		select {
-		case <-ctx.Done():
-			return
-		case <-ticker.C:
-			c.Writer.WriteString("event: ping\ndata: {}\n\n")
-			c.Writer.Flush()
-		}
-	}
 }

--- a/dev/src/main.go
+++ b/dev/src/main.go
@@ -171,8 +171,13 @@ func main() {
 	entryLinksRepo := repository.NewEntryLinksRepository(pool)
 	entryLinksHandler := handler.NewEntryLinksHandler(entryLinksRepo)
 
+	// 初始化 Copilot 服務（F-048）
+	copilotRepo := repository.NewCopilotRepository(pool)
+	copilotSvc := service.NewCopilotService(copilotRepo, entryRepo, llmSvc)
+	copilotHandler := handler.NewCopilotHandler(copilotSvc)
+
 	// 設定路由
-	r := router.Setup(pool, apiKeySvc, apiKeyHandler, categoryHandler, llmProviderHandler, entryHandler, classifyHandler, searchHandler, gitImportHandler, gcalHandler, confidenceHandler, statsHandler, systemHandler, lifecycleHandler, calendarConvertHandler, calendarHandler, journalHandler, journalDraftHandler, journalAutoHandler, projectHandler, taskHandler, githubIntegrationHandler, githubCommitsHandler, viewHandler, entryLinksHandler)
+	r := router.Setup(pool, apiKeySvc, apiKeyHandler, categoryHandler, llmProviderHandler, entryHandler, classifyHandler, searchHandler, gitImportHandler, gcalHandler, confidenceHandler, statsHandler, systemHandler, lifecycleHandler, calendarConvertHandler, calendarHandler, journalHandler, journalDraftHandler, journalAutoHandler, projectHandler, taskHandler, githubIntegrationHandler, githubCommitsHandler, viewHandler, entryLinksHandler, copilotHandler)
 
 	// 啟動 HTTP server（graceful shutdown）
 	srv := &http.Server{

--- a/dev/src/migration/020_copilot_sessions.down.sql
+++ b/dev/src/migration/020_copilot_sessions.down.sql
@@ -1,0 +1,2 @@
+DROP TABLE IF EXISTS copilot_messages;
+DROP TABLE IF EXISTS copilot_sessions;

--- a/dev/src/migration/020_copilot_sessions.up.sql
+++ b/dev/src/migration/020_copilot_sessions.up.sql
@@ -1,0 +1,18 @@
+CREATE TABLE copilot_sessions (
+  id          UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id     VARCHAR(64) NOT NULL DEFAULT 'admin',
+  created_at  TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  last_active TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE TABLE copilot_messages (
+  id          UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  session_id  UUID NOT NULL REFERENCES copilot_sessions(id) ON DELETE CASCADE,
+  role        VARCHAR(20) NOT NULL CHECK (role IN ('user', 'assistant', 'system')),
+  content     TEXT NOT NULL,
+  seq         INTEGER NOT NULL,
+  created_at  TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  UNIQUE (session_id, seq)
+);
+
+CREATE INDEX ON copilot_messages(session_id, seq);

--- a/dev/src/model/copilot.go
+++ b/dev/src/model/copilot.go
@@ -1,0 +1,25 @@
+package model
+
+import (
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// CopilotSession Copilot 對話 session
+type CopilotSession struct {
+	ID         uuid.UUID `json:"id"`
+	UserID     string    `json:"user_id"`
+	CreatedAt  time.Time `json:"created_at"`
+	LastActive time.Time `json:"last_active"`
+}
+
+// CopilotMessage Copilot 對話訊息
+type CopilotMessage struct {
+	ID        uuid.UUID `json:"id"`
+	SessionID uuid.UUID `json:"session_id"`
+	Role      string    `json:"role"` // user | assistant | system
+	Content   string    `json:"content"`
+	Seq       int       `json:"seq"`
+	CreatedAt time.Time `json:"created_at"`
+}

--- a/dev/src/repository/copilot.go
+++ b/dev/src/repository/copilot.go
@@ -1,0 +1,156 @@
+package repository
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/google/uuid"
+	"github.com/gpwork4u/aibo/model"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+// CopilotRepository Copilot session + message CRUD
+type CopilotRepository struct {
+	pool *pgxpool.Pool
+}
+
+// NewCopilotRepository 建立新的 CopilotRepository
+func NewCopilotRepository(pool *pgxpool.Pool) *CopilotRepository {
+	return &CopilotRepository{pool: pool}
+}
+
+// CreateSession 建立新的 copilot session
+func (r *CopilotRepository) CreateSession(ctx context.Context, userID string) (*model.CopilotSession, error) {
+	row := r.pool.QueryRow(ctx,
+		`INSERT INTO copilot_sessions (user_id) VALUES ($1)
+		 RETURNING id, user_id, created_at, last_active`,
+		userID,
+	)
+	var s model.CopilotSession
+	if err := row.Scan(&s.ID, &s.UserID, &s.CreatedAt, &s.LastActive); err != nil {
+		return nil, fmt.Errorf("建立 copilot session 失敗: %w", err)
+	}
+	return &s, nil
+}
+
+// GetSession 依 ID 取得 session
+func (r *CopilotRepository) GetSession(ctx context.Context, id uuid.UUID) (*model.CopilotSession, error) {
+	row := r.pool.QueryRow(ctx,
+		`SELECT id, user_id, created_at, last_active
+		 FROM copilot_sessions WHERE id = $1`,
+		id,
+	)
+	var s model.CopilotSession
+	if err := row.Scan(&s.ID, &s.UserID, &s.CreatedAt, &s.LastActive); err != nil {
+		return nil, fmt.Errorf("取得 copilot session 失敗: %w", err)
+	}
+	return &s, nil
+}
+
+// DeleteSession 刪除 session（cascade 刪除 messages）
+func (r *CopilotRepository) DeleteSession(ctx context.Context, id uuid.UUID) error {
+	tag, err := r.pool.Exec(ctx, `DELETE FROM copilot_sessions WHERE id = $1`, id)
+	if err != nil {
+		return fmt.Errorf("刪除 copilot session 失敗: %w", err)
+	}
+	if tag.RowsAffected() == 0 {
+		return fmt.Errorf("session 不存在")
+	}
+	return nil
+}
+
+// TouchSession 更新 last_active 時間戳
+func (r *CopilotRepository) TouchSession(ctx context.Context, id uuid.UUID) error {
+	_, err := r.pool.Exec(ctx,
+		`UPDATE copilot_sessions SET last_active = NOW() WHERE id = $1`,
+		id,
+	)
+	return err
+}
+
+// NextSeq 取得 session 下一個 seq 編號（MAX(seq)+1，若無訊息則為 1）
+func (r *CopilotRepository) NextSeq(ctx context.Context, sessionID uuid.UUID) (int, error) {
+	var max *int
+	err := r.pool.QueryRow(ctx,
+		`SELECT MAX(seq) FROM copilot_messages WHERE session_id = $1`,
+		sessionID,
+	).Scan(&max)
+	if err != nil {
+		return 0, fmt.Errorf("查詢 max seq 失敗: %w", err)
+	}
+	if max == nil {
+		return 1, nil
+	}
+	return *max + 1, nil
+}
+
+// CreateMessage 儲存一則訊息
+func (r *CopilotRepository) CreateMessage(ctx context.Context, msg *model.CopilotMessage) error {
+	return r.pool.QueryRow(ctx,
+		`INSERT INTO copilot_messages (session_id, role, content, seq)
+		 VALUES ($1, $2, $3, $4)
+		 RETURNING id, created_at`,
+		msg.SessionID, msg.Role, msg.Content, msg.Seq,
+	).Scan(&msg.ID, &msg.CreatedAt)
+}
+
+// ListMessages 取得 session 所有訊息（依 seq 升冪）
+func (r *CopilotRepository) ListMessages(ctx context.Context, sessionID uuid.UUID) ([]model.CopilotMessage, error) {
+	rows, err := r.pool.Query(ctx,
+		`SELECT id, session_id, role, content, seq, created_at
+		 FROM copilot_messages
+		 WHERE session_id = $1
+		 ORDER BY seq ASC`,
+		sessionID,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("查詢訊息失敗: %w", err)
+	}
+	defer rows.Close()
+
+	var msgs []model.CopilotMessage
+	for rows.Next() {
+		var m model.CopilotMessage
+		if err := rows.Scan(&m.ID, &m.SessionID, &m.Role, &m.Content, &m.Seq, &m.CreatedAt); err != nil {
+			return nil, fmt.Errorf("掃描訊息失敗: %w", err)
+		}
+		msgs = append(msgs, m)
+	}
+	return msgs, rows.Err()
+}
+
+// ListRecentMessages 取得最近 N 輪（2N 則）訊息，用於 context 組裝
+// 回傳依 seq 升冪排序（最舊在前，便於組裝 LLM messages slice）
+func (r *CopilotRepository) ListRecentMessages(ctx context.Context, sessionID uuid.UUID, maxRounds int) ([]model.CopilotMessage, error) {
+	limit := maxRounds * 2
+	rows, err := r.pool.Query(ctx,
+		`SELECT id, session_id, role, content, seq, created_at
+		 FROM copilot_messages
+		 WHERE session_id = $1
+		 ORDER BY seq DESC
+		 LIMIT $2`,
+		sessionID, limit,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("查詢最近訊息失敗: %w", err)
+	}
+	defer rows.Close()
+
+	var msgs []model.CopilotMessage
+	for rows.Next() {
+		var m model.CopilotMessage
+		if err := rows.Scan(&m.ID, &m.SessionID, &m.Role, &m.Content, &m.Seq, &m.CreatedAt); err != nil {
+			return nil, fmt.Errorf("掃描訊息失敗: %w", err)
+		}
+		msgs = append(msgs, m)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+
+	// 反轉為升冪（seq 小 → 大）
+	for i, j := 0, len(msgs)-1; i < j; i, j = i+1, j-1 {
+		msgs[i], msgs[j] = msgs[j], msgs[i]
+	}
+	return msgs, nil
+}

--- a/dev/src/router/router.go
+++ b/dev/src/router/router.go
@@ -12,7 +12,7 @@ import (
 )
 
 // Setup 設定路由
-func Setup(pool *pgxpool.Pool, apiKeySvc *service.ApiKeyService, apiKeyHandler *handler.ApiKeyHandler, categoryHandler *handler.CategoryHandler, llmProviderHandler *handler.LlmProviderHandler, entryHandler *handler.EntryHandler, classifyHandler *handler.ClassifyHandler, searchHandler *handler.SearchHandler, gitImportHandler *handler.GitImportHandler, gcalHandler *handler.GcalHandler, confidenceHandler *handler.ConfidenceHandler, statsHandler *handler.StatsHandler, systemHandler *handler.SystemHandler, lifecycleHandler *handler.LifecycleHandler, calendarConvertHandler *handler.CalendarConvertHandler, calendarHandler *handler.CalendarHandler, journalHandler *handler.JournalHandler, journalDraftHandler *handler.JournalDraftHandler, journalAutoHandler *handler.JournalAutoHandler, projectHandler *handler.ProjectHandler, taskHandler *handler.TaskHandler, githubIntegrationHandler *handler.GitHubIntegrationHandler, githubCommitsHandler *handler.GitHubCommitsHandler, viewHandler *handler.ViewHandler, entryLinksHandler *handler.EntryLinksHandler) *gin.Engine {
+func Setup(pool *pgxpool.Pool, apiKeySvc *service.ApiKeyService, apiKeyHandler *handler.ApiKeyHandler, categoryHandler *handler.CategoryHandler, llmProviderHandler *handler.LlmProviderHandler, entryHandler *handler.EntryHandler, classifyHandler *handler.ClassifyHandler, searchHandler *handler.SearchHandler, gitImportHandler *handler.GitImportHandler, gcalHandler *handler.GcalHandler, confidenceHandler *handler.ConfidenceHandler, statsHandler *handler.StatsHandler, systemHandler *handler.SystemHandler, lifecycleHandler *handler.LifecycleHandler, calendarConvertHandler *handler.CalendarConvertHandler, calendarHandler *handler.CalendarHandler, journalHandler *handler.JournalHandler, journalDraftHandler *handler.JournalDraftHandler, journalAutoHandler *handler.JournalAutoHandler, projectHandler *handler.ProjectHandler, taskHandler *handler.TaskHandler, githubIntegrationHandler *handler.GitHubIntegrationHandler, githubCommitsHandler *handler.GitHubCommitsHandler, viewHandler *handler.ViewHandler, entryLinksHandler *handler.EntryLinksHandler, copilotHandler *handler.CopilotHandler) *gin.Engine {
 	r := gin.Default()
 
 	// CORS middleware — 允許跨網域（前端 localhost:3000 呼叫 API localhost:8080）
@@ -207,6 +207,16 @@ func Setup(pool *pgxpool.Pool, apiKeySvc *service.ApiKeyService, apiKeyHandler *
 
 		// Knowledge Graph（F-044）
 		v1.GET("/graph", entryLinksHandler.GetGraph)
+
+		// Copilot（F-048）
+		copilot := v1.Group("/copilot")
+		{
+			copilot.POST("/sessions", copilotHandler.CreateSession)
+			copilot.DELETE("/sessions/:id", copilotHandler.DeleteSession)
+			copilot.GET("/sessions/:id/messages", copilotHandler.ListMessages)
+			copilot.POST("/message", copilotHandler.SendMessage)
+			copilot.GET("/stream", copilotHandler.Stream)
+		}
 	}
 
 	return r

--- a/dev/src/service/copilot.go
+++ b/dev/src/service/copilot.go
@@ -1,0 +1,345 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+	openai "github.com/sashabaranov/go-openai"
+
+	"github.com/gpwork4u/aibo/model"
+	"github.com/gpwork4u/aibo/repository"
+)
+
+// CopilotRepo 定義 CopilotService 需要的資料存取介面
+type CopilotRepo interface {
+	CreateSession(ctx context.Context, userID string) (*model.CopilotSession, error)
+	GetSession(ctx context.Context, id uuid.UUID) (*model.CopilotSession, error)
+	DeleteSession(ctx context.Context, id uuid.UUID) error
+	TouchSession(ctx context.Context, id uuid.UUID) error
+	NextSeq(ctx context.Context, sessionID uuid.UUID) (int, error)
+	CreateMessage(ctx context.Context, msg *model.CopilotMessage) error
+	ListMessages(ctx context.Context, sessionID uuid.UUID) ([]model.CopilotMessage, error)
+	ListRecentMessages(ctx context.Context, sessionID uuid.UUID, maxRounds int) ([]model.CopilotMessage, error)
+}
+
+// copilotEntryRepo 只使用 EntryRepository 的 List 方法子集
+type copilotEntryRepo interface {
+	List(ctx context.Context, filter model.EntryFilter) (*model.EntryListResult, error)
+}
+
+// StreamEvent SSE 事件型別
+type StreamEvent struct {
+	Event string
+	Data  string
+}
+
+// CopilotService Copilot 業務邏輯服務
+type CopilotService struct {
+	repo      CopilotRepo
+	entryRepo copilotEntryRepo
+	llmSvc    *LlmService
+}
+
+// NewCopilotService 建立新的 CopilotService
+func NewCopilotService(repo CopilotRepo, entryRepo copilotEntryRepo, llmSvc *LlmService) *CopilotService {
+	return &CopilotService{
+		repo:      repo,
+		entryRepo: entryRepo,
+		llmSvc:    llmSvc,
+	}
+}
+
+// CreateSession 建立新 session
+func (s *CopilotService) CreateSession(ctx context.Context, userID string) (*model.CopilotSession, error) {
+	return s.repo.CreateSession(ctx, userID)
+}
+
+// GetSession 取得 session（不存在回傳 ErrNotFound）
+func (s *CopilotService) GetSession(ctx context.Context, id uuid.UUID) (*model.CopilotSession, error) {
+	sess, err := s.repo.GetSession(ctx, id)
+	if err != nil {
+		return nil, fmt.Errorf("session 不存在: %w", ErrNotFound)
+	}
+	return sess, nil
+}
+
+// DeleteSession 刪除 session
+func (s *CopilotService) DeleteSession(ctx context.Context, id uuid.UUID) error {
+	if err := s.repo.DeleteSession(ctx, id); err != nil {
+		return fmt.Errorf("session 不存在: %w", ErrNotFound)
+	}
+	return nil
+}
+
+// ListMessages 列出 session 所有歷史訊息
+func (s *CopilotService) ListMessages(ctx context.Context, sessionID uuid.UUID) ([]model.CopilotMessage, error) {
+	// 確認 session 存在
+	if _, err := s.repo.GetSession(ctx, sessionID); err != nil {
+		return nil, fmt.Errorf("session 不存在: %w", ErrNotFound)
+	}
+	return s.repo.ListMessages(ctx, sessionID)
+}
+
+// StartStream 儲存 user message，組裝 context，並回傳 msgID 供 SSE handler 使用
+// 真正的 streaming 在 StreamChat 中執行
+func (s *CopilotService) StartStream(ctx context.Context, sessionID uuid.UUID, content string) (uuid.UUID, error) {
+	// 確認 session 存在
+	if _, err := s.repo.GetSession(ctx, sessionID); err != nil {
+		return uuid.Nil, fmt.Errorf("session 不存在: %w", ErrNotFound)
+	}
+
+	// 確認 LLM provider 可用
+	if _, err := s.llmSvc.providerSvc.GetActiveProvider(ctx); err != nil {
+		return uuid.Nil, ErrLLMUnavailable
+	}
+
+	// 取得下個 seq 並儲存 user message
+	seq, err := s.repo.NextSeq(ctx, sessionID)
+	if err != nil {
+		return uuid.Nil, fmt.Errorf("取得 seq 失敗: %w", err)
+	}
+
+	userMsg := &model.CopilotMessage{
+		SessionID: sessionID,
+		Role:      "user",
+		Content:   content,
+		Seq:       seq,
+	}
+	if err := s.repo.CreateMessage(ctx, userMsg); err != nil {
+		return uuid.Nil, fmt.Errorf("儲存 user message 失敗: %w", err)
+	}
+
+	// 更新 session last_active
+	_ = s.repo.TouchSession(ctx, sessionID)
+
+	return userMsg.ID, nil
+}
+
+// StreamChat 對指定 session + msgID 執行 LLM streaming，將 SSE 事件逐一送到 ch
+// 呼叫者負責關閉 ch（defer close(ch)）後等待本函式回傳
+func (s *CopilotService) StreamChat(ctx context.Context, sessionID uuid.UUID, msgID uuid.UUID, ch chan<- StreamEvent) {
+	// 取得 provider
+	provider, err := s.llmSvc.providerSvc.GetActiveProvider(ctx)
+	if err != nil {
+		ch <- StreamEvent{Event: "error", Data: fmt.Sprintf(`{"code":"LLM_UNAVAILABLE","msg_id":"%s"}`, msgID)}
+		return
+	}
+
+	// 解密 API key
+	apiKey := ""
+	if provider.ApiKey != nil && *provider.ApiKey != "" {
+		decrypted, err := s.llmSvc.crypto.Decrypt(*provider.ApiKey)
+		if err != nil {
+			ch <- StreamEvent{Event: "error", Data: fmt.Sprintf(`{"code":"LLM_UNAVAILABLE","msg_id":"%s"}`, msgID)}
+			return
+		}
+		apiKey = decrypted
+	}
+	cached := s.llmSvc.getOrCreateClient(provider, apiKey)
+
+	// 組裝 LLM messages（system prompt + history + user message）
+	messages, err := s.buildMessages(ctx, sessionID)
+	if err != nil {
+		ch <- StreamEvent{Event: "error", Data: fmt.Sprintf(`{"code":"INTERNAL_ERROR","msg_id":"%s"}`, msgID)}
+		return
+	}
+
+	// 推送 message_start
+	ch <- StreamEvent{
+		Event: "message_start",
+		Data:  fmt.Sprintf(`{"msg_id":"%s","session_id":"%s"}`, msgID, sessionID),
+	}
+
+	// 90 秒 streaming timeout
+	streamCtx, cancel := context.WithTimeout(ctx, 90*time.Second)
+	defer cancel()
+
+	stream, err := cached.client.CreateChatCompletionStream(streamCtx, openai.ChatCompletionRequest{
+		Model:    provider.ModelName,
+		Messages: messages,
+		Stream:   true,
+	})
+	if err != nil {
+		ch <- StreamEvent{Event: "error", Data: fmt.Sprintf(`{"code":"LLM_UNAVAILABLE","msg_id":"%s"}`, msgID)}
+		return
+	}
+	defer stream.Close()
+
+	var (
+		seq         = 1
+		totalTokens = 0
+		fullContent strings.Builder
+		finishReason = "stop"
+	)
+
+	for {
+		resp, err := stream.Recv()
+		if err != nil {
+			// 檢查是否為正常結束
+			if isEOF(err) {
+				break
+			}
+			// 檢查是否 timeout
+			if errors.Is(streamCtx.Err(), context.DeadlineExceeded) {
+				ch <- StreamEvent{Event: "error", Data: fmt.Sprintf(`{"code":"STREAM_TIMEOUT","msg_id":"%s"}`, msgID)}
+				return
+			}
+			ch <- StreamEvent{Event: "error", Data: fmt.Sprintf(`{"code":"STREAM_ERROR","msg_id":"%s"}`, msgID)}
+			return
+		}
+
+		if len(resp.Choices) == 0 {
+			continue
+		}
+
+		delta := resp.Choices[0].Delta.Content
+		if delta == "" {
+			// 取得 finish_reason（若存在）
+			if resp.Choices[0].FinishReason != "" {
+				finishReason = string(resp.Choices[0].FinishReason)
+			}
+			continue
+		}
+
+		fullContent.WriteString(delta)
+		totalTokens++
+
+		// 推送 token，JSON 手動組裝避免轉義問題
+		tokenJSON := buildTokenJSON(delta, msgID.String(), seq)
+		ch <- StreamEvent{Event: "token", Data: tokenJSON}
+		seq++
+	}
+
+	// 儲存 assistant message
+	assistantContent := fullContent.String()
+	if assistantContent != "" {
+		nextSeq, err := s.repo.NextSeq(ctx, sessionID)
+		if err == nil {
+			assistantMsg := &model.CopilotMessage{
+				SessionID: sessionID,
+				Role:      "assistant",
+				Content:   assistantContent,
+				Seq:       nextSeq,
+			}
+			if err := s.repo.CreateMessage(ctx, assistantMsg); err != nil {
+				slog.Error("儲存 assistant message 失敗", "error", err, "session_id", sessionID)
+			}
+		}
+	}
+
+	// 推送 message_done
+	ch <- StreamEvent{
+		Event: "message_done",
+		Data:  fmt.Sprintf(`{"msg_id":"%s","total_tokens":%d,"finish_reason":"%s"}`, msgID, totalTokens, finishReason),
+	}
+}
+
+// buildMessages 組裝 LLM 的完整 messages（system prompt + history + user message）
+func (s *CopilotService) buildMessages(ctx context.Context, sessionID uuid.UUID) ([]openai.ChatCompletionMessage, error) {
+	// 取得最近 10 輪對話（含剛儲存的 user message）
+	history, err := s.repo.ListRecentMessages(ctx, sessionID, 10)
+	if err != nil {
+		return nil, fmt.Errorf("取得歷史訊息失敗: %w", err)
+	}
+
+	// 取得最後一則 user message 作為搜尋查詢
+	query := ""
+	for i := len(history) - 1; i >= 0; i-- {
+		if history[i].Role == "user" {
+			query = history[i].Content
+			break
+		}
+	}
+
+	// 語意搜尋 top-5 entries 組裝 system prompt
+	systemPrompt := buildSystemPrompt(ctx, s.entryRepo, query)
+
+	var messages []openai.ChatCompletionMessage
+	messages = append(messages, openai.ChatCompletionMessage{
+		Role:    openai.ChatMessageRoleSystem,
+		Content: systemPrompt,
+	})
+
+	for _, msg := range history {
+		role := openai.ChatMessageRoleUser
+		if msg.Role == "assistant" {
+			role = openai.ChatMessageRoleAssistant
+		}
+		messages = append(messages, openai.ChatCompletionMessage{
+			Role:    role,
+			Content: msg.Content,
+		})
+	}
+
+	return messages, nil
+}
+
+// buildSystemPrompt 組裝包含知識庫 entries 的 system prompt
+func buildSystemPrompt(ctx context.Context, entryRepo copilotEntryRepo, query string) string {
+	const basePrompt = "You are a knowledge assistant for the user's personal knowledge base."
+
+	if query == "" || entryRepo == nil {
+		return basePrompt
+	}
+
+	result, err := entryRepo.List(ctx, model.EntryFilter{
+		Search:  query,
+		Page:    1,
+		PerPage: 5,
+	})
+	if err != nil || result == nil || len(result.Data) == 0 {
+		return basePrompt
+	}
+
+	var sb strings.Builder
+	sb.WriteString(basePrompt)
+	sb.WriteString("\n\nRelevant entries from the knowledge base:\n")
+	for _, e := range result.Data {
+		if e.Title != nil {
+			sb.WriteString("- ")
+			sb.WriteString(*e.Title)
+			if e.Summary != nil {
+				sb.WriteString(": ")
+				sb.WriteString(*e.Summary)
+			}
+			sb.WriteString("\n")
+		}
+	}
+	sb.WriteString("\nUse these entries to provide accurate, context-aware responses.")
+	return sb.String()
+}
+
+// buildTokenJSON 手動組裝 token SSE data JSON（避免特殊字元轉義問題）
+func buildTokenJSON(token, msgID string, seq int) string {
+	// 對 token 做基本 JSON 字串轉義
+	escaped := strings.NewReplacer(
+		`\`, `\\`,
+		`"`, `\"`,
+		"\n", `\n`,
+		"\r", `\r`,
+		"\t", `\t`,
+	).Replace(token)
+	return fmt.Sprintf(`{"token":"%s","msg_id":"%s","seq":%d}`, escaped, msgID, seq)
+}
+
+// isEOF 判斷是否為正常的 stream 結束
+func isEOF(err error) bool {
+	if err == nil {
+		return false
+	}
+	return err.Error() == "EOF" || strings.Contains(err.Error(), "EOF")
+}
+
+// ErrNotFound session/message 不存在
+var ErrNotFound = errors.New("not_found")
+
+// ErrLLMUnavailable 無可用 LLM provider
+var ErrLLMUnavailable = errors.New("LLM_UNAVAILABLE")
+
+// compile-time check
+var _ CopilotRepo = (*repository.CopilotRepository)(nil)

--- a/dev/src/service/copilot_test.go
+++ b/dev/src/service/copilot_test.go
@@ -1,0 +1,244 @@
+package service
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/gpwork4u/aibo/model"
+)
+
+// --- mock CopilotRepo ---
+
+type mockCopilotRepo struct {
+	sessions map[uuid.UUID]*model.CopilotSession
+	messages []model.CopilotMessage
+	nextSeq  int
+}
+
+func newMockCopilotRepo() *mockCopilotRepo {
+	return &mockCopilotRepo{
+		sessions: make(map[uuid.UUID]*model.CopilotSession),
+		nextSeq:  1,
+	}
+}
+
+func (m *mockCopilotRepo) CreateSession(_ context.Context, userID string) (*model.CopilotSession, error) {
+	s := &model.CopilotSession{
+		ID:         uuid.New(),
+		UserID:     userID,
+		CreatedAt:  time.Now(),
+		LastActive: time.Now(),
+	}
+	m.sessions[s.ID] = s
+	return s, nil
+}
+
+func (m *mockCopilotRepo) GetSession(_ context.Context, id uuid.UUID) (*model.CopilotSession, error) {
+	s, ok := m.sessions[id]
+	if !ok {
+		return nil, errors.New("not found")
+	}
+	return s, nil
+}
+
+func (m *mockCopilotRepo) DeleteSession(_ context.Context, id uuid.UUID) error {
+	if _, ok := m.sessions[id]; !ok {
+		return errors.New("not found")
+	}
+	delete(m.sessions, id)
+	return nil
+}
+
+func (m *mockCopilotRepo) TouchSession(_ context.Context, _ uuid.UUID) error {
+	return nil
+}
+
+func (m *mockCopilotRepo) NextSeq(_ context.Context, _ uuid.UUID) (int, error) {
+	seq := m.nextSeq
+	m.nextSeq++
+	return seq, nil
+}
+
+func (m *mockCopilotRepo) CreateMessage(_ context.Context, msg *model.CopilotMessage) error {
+	msg.ID = uuid.New()
+	msg.CreatedAt = time.Now()
+	m.messages = append(m.messages, *msg)
+	return nil
+}
+
+func (m *mockCopilotRepo) ListMessages(_ context.Context, sessionID uuid.UUID) ([]model.CopilotMessage, error) {
+	var result []model.CopilotMessage
+	for _, msg := range m.messages {
+		if msg.SessionID == sessionID {
+			result = append(result, msg)
+		}
+	}
+	return result, nil
+}
+
+func (m *mockCopilotRepo) ListRecentMessages(_ context.Context, sessionID uuid.UUID, maxRounds int) ([]model.CopilotMessage, error) {
+	var all []model.CopilotMessage
+	for _, msg := range m.messages {
+		if msg.SessionID == sessionID {
+			all = append(all, msg)
+		}
+	}
+	limit := maxRounds * 2
+	if len(all) > limit {
+		all = all[len(all)-limit:]
+	}
+	return all, nil
+}
+
+// --- mock entryRepo ---
+
+type mockEntryRepo struct {
+	data []model.EntryListItem
+}
+
+func (m *mockEntryRepo) List(_ context.Context, _ model.EntryFilter) (*model.EntryListResult, error) {
+	return &model.EntryListResult{Data: m.data}, nil
+}
+
+// --- Tests ---
+
+func TestCopilotService_CreateSession(t *testing.T) {
+	repo := newMockCopilotRepo()
+	svc := NewCopilotService(repo, nil, nil)
+
+	sess, err := svc.CreateSession(context.Background(), "admin")
+	if err != nil {
+		t.Fatalf("建立 session 失敗: %v", err)
+	}
+	if sess.ID == uuid.Nil {
+		t.Error("session ID 不應為空")
+	}
+	if sess.UserID != "admin" {
+		t.Errorf("user_id 期望 admin，得到 %s", sess.UserID)
+	}
+}
+
+func TestCopilotService_DeleteSession_NotFound(t *testing.T) {
+	repo := newMockCopilotRepo()
+	svc := NewCopilotService(repo, nil, nil)
+
+	err := svc.DeleteSession(context.Background(), uuid.New())
+	if !errors.Is(err, ErrNotFound) {
+		t.Errorf("期望 ErrNotFound，得到 %v", err)
+	}
+}
+
+func TestCopilotService_ListMessages_NotFound(t *testing.T) {
+	repo := newMockCopilotRepo()
+	svc := NewCopilotService(repo, nil, nil)
+
+	_, err := svc.ListMessages(context.Background(), uuid.New())
+	if !errors.Is(err, ErrNotFound) {
+		t.Errorf("期望 ErrNotFound，得到 %v", err)
+	}
+}
+
+func TestCopilotService_ListMessages_Success(t *testing.T) {
+	repo := newMockCopilotRepo()
+	svc := NewCopilotService(repo, nil, nil)
+
+	sess, _ := svc.CreateSession(context.Background(), "admin")
+
+	// 插入 4 則訊息
+	for i := 0; i < 4; i++ {
+		msg := &model.CopilotMessage{
+			SessionID: sess.ID,
+			Role:      "user",
+			Content:   "msg",
+			Seq:       i + 1,
+		}
+		_ = repo.CreateMessage(context.Background(), msg)
+	}
+
+	msgs, err := svc.ListMessages(context.Background(), sess.ID)
+	if err != nil {
+		t.Fatalf("ListMessages 失敗: %v", err)
+	}
+	if len(msgs) != 4 {
+		t.Errorf("期望 4 則訊息，得到 %d", len(msgs))
+	}
+}
+
+// TestBuildSystemPrompt_WithEntries 驗證 context 注入邏輯
+func TestBuildSystemPrompt_WithEntries(t *testing.T) {
+	title := "Test Driven Development Basics"
+	summary := "TDD 是一種開發流程"
+	entryRepo := &mockEntryRepo{
+		data: []model.EntryListItem{
+			{Title: &title, Summary: &summary},
+		},
+	}
+
+	prompt := buildSystemPrompt(context.Background(), entryRepo, "Explain TDD")
+
+	if !strings.Contains(prompt, title) {
+		t.Errorf("system prompt 應包含 entry title：%s", title)
+	}
+	if !strings.Contains(prompt, summary) {
+		t.Errorf("system prompt 應包含 entry summary：%s", summary)
+	}
+}
+
+// TestBuildSystemPrompt_EmptyQuery 查詢為空時回傳基本 prompt
+func TestBuildSystemPrompt_EmptyQuery(t *testing.T) {
+	prompt := buildSystemPrompt(context.Background(), nil, "")
+	if prompt == "" {
+		t.Error("prompt 不應為空")
+	}
+	if strings.Contains(prompt, "Relevant entries") {
+		t.Error("空查詢不應包含 entries 段落")
+	}
+}
+
+// TestListRecentMessages_TruncatesTo10Rounds 驗證 10 輪截斷邏輯
+func TestListRecentMessages_TruncatesTo10Rounds(t *testing.T) {
+	repo := newMockCopilotRepo()
+	sessID := uuid.New()
+
+	// 插入 22 則訊息（11 輪）
+	for i := 1; i <= 22; i++ {
+		role := "user"
+		if i%2 == 0 {
+			role = "assistant"
+		}
+		msg := &model.CopilotMessage{
+			SessionID: sessID,
+			Role:      role,
+			Content:   "msg",
+			Seq:       i,
+		}
+		_ = repo.CreateMessage(context.Background(), msg)
+	}
+
+	// ListRecentMessages 最多 10 輪 = 20 則
+	msgs, err := repo.ListRecentMessages(context.Background(), sessID, 10)
+	if err != nil {
+		t.Fatalf("ListRecentMessages 失敗: %v", err)
+	}
+	if len(msgs) > 20 {
+		t.Errorf("期望最多 20 則，得到 %d", len(msgs))
+	}
+
+	// 驗證 DB 仍保留全部 22 則
+	allMsgs, _ := repo.ListMessages(context.Background(), sessID)
+	if len(allMsgs) != 22 {
+		t.Errorf("DB 應保留 22 則，得到 %d", len(allMsgs))
+	}
+}
+
+// TestBuildTokenJSON_EscapesQuotes 驗證特殊字元轉義
+func TestBuildTokenJSON_EscapesQuotes(t *testing.T) {
+	json := buildTokenJSON(`say "hello"`, "msg-001", 1)
+	if !strings.Contains(json, `\"hello\"`) {
+		t.Errorf("雙引號應被轉義，JSON: %s", json)
+	}
+}


### PR DESCRIPTION
Closes #231

## 實作
- migration 020：copilot_sessions + copilot_messages 表
- model.Copilot* / dto.Copilot* / repository.CopilotRepository
- service.CopilotService：context 注入（最近 entries）+ LLM streaming
- handler.CopilotHandler：POST /copilot/messages、GET /copilot/stream、sessions CRUD
- 取代 F-039 skeleton CopilotStreamHandler
- router.go + main.go DI 初始化