### PR TITLE
[Feature] F-049: CmdK Power Actions

### DIFF
--- a/dev/frontend/components/cmdk/command-palette.tsx
+++ b/dev/frontend/components/cmdk/command-palette.tsx
@@ -1,12 +1,17 @@
 "use client";
 
 /**
- * CommandPalette — 全域 ⌘K command palette 主元件
+ * CommandPalette — 全域 ⌘K command palette 主元件（F-037 + F-049 Power Actions）
  *
  * 結構：
  *   - Dialog overlay（cmdk CommandDialog）
  *   - search input（自動 focus）
- *   - 三個群組：Pages（Navigate）/ Recent Entries / Quick Actions
+ *   - AI mode（`>` prefix）：只顯示 AIActionsGroup
+ *   - 一般模式：
+ *       · Navigate（PagesGroup）
+ *       · Create（CreateActionsGroup）
+ *       · Search Results（EntriesSearchGroup，3+ chars debounce 200ms）
+ *       · Quick Actions（QuickActionsGroup）
  *
  * 生命週期：
  *   - open/close 由 CmdkProvider 管理
@@ -28,16 +33,23 @@ import { useCmdk } from "./cmdk-provider";
 import { useCommandPaletteShortcut } from "@/lib/hooks/use-cmdk-hotkey";
 import { useDebouncedValue } from "@/lib/hooks/use-debounced-value";
 import { PagesGroup } from "./groups/pages";
-import { RecentEntriesGroup } from "./groups/recent-entries";
 import { QuickActionsGroup } from "./groups/quick-actions";
+import { EntriesSearchGroup } from "./groups/entries-search";
+import { AIActionsGroup } from "./groups/ai-actions";
+import { CreateActionsGroup } from "./groups/create-actions";
+import { QuickCreateModal } from "./quick-create-modal";
 
 export function CommandPalette() {
   const { open, setOpen, toggle } = useCmdk();
   const [inputValue, setInputValue] = React.useState("");
   const debouncedQuery = useDebouncedValue(inputValue, 200);
+  const [quickCreateOpen, setQuickCreateOpen] = React.useState(false);
 
   // 全域 ⌘K / Ctrl+K 快捷鍵
   useCommandPaletteShortcut(toggle);
+
+  // `>` prefix → AI Actions 模式
+  const isAiMode = inputValue.startsWith(">");
 
   // 關閉時清空搜尋
   const handleOpenChange = (value: boolean) => {
@@ -49,45 +61,82 @@ export function CommandPalette() {
     handleOpenChange(false);
   };
 
+  // 開啟 QuickCreateModal（不關閉 CmdK，等 modal 完成後再關）
+  const handleNewEntry = () => {
+    setQuickCreateOpen(true);
+  };
+
+  // QuickCreateModal 完成 → 關閉 CmdK + modal
+  const handleQuickCreateDone = () => {
+    setQuickCreateOpen(false);
+    handleOpenChange(false);
+  };
+
   return (
-    <Dialog open={open} onOpenChange={handleOpenChange}>
-      <DialogContent
-        className="overflow-hidden p-0 shadow-2xl sm:max-w-[560px]"
-        aria-label="Command Palette"
-      >
-        <Command
-          className="[&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:font-medium [&_[cmdk-group-heading]]:text-[--fg-muted]"
-          shouldFilter={true}
-          onKeyDown={(e) => {
-            // 跳過 IME 組字中的 Enter
-            if ((e.nativeEvent as KeyboardEvent & { isComposing?: boolean }).isComposing) return;
-          }}
+    <>
+      <Dialog open={open} onOpenChange={handleOpenChange}>
+        <DialogContent
+          className="overflow-hidden p-0 shadow-2xl sm:max-w-[560px]"
+          aria-label="Command Palette"
         >
-          <CommandInput
-            placeholder="搜尋頁面、entries、動作..."
-            value={inputValue}
-            onValueChange={setInputValue}
-          />
-          <CommandList className="max-h-[400px]">
-            <CommandEmpty>找不到相關指令或 entry</CommandEmpty>
+          <Command
+            className="[&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:font-medium [&_[cmdk-group-heading]]:text-[--fg-muted]"
+            shouldFilter={!isAiMode}
+            onKeyDown={(e) => {
+              // 跳過 IME 組字中的 Enter
+              if ((e.nativeEvent as KeyboardEvent & { isComposing?: boolean }).isComposing) return;
+            }}
+          >
+            <CommandInput
+              placeholder="搜尋頁面、entries、動作... 或 > 輸入 AI 指令"
+              value={inputValue}
+              onValueChange={setInputValue}
+            />
+            <CommandList className="max-h-[400px]">
+              <CommandEmpty>找不到相關指令或 entry</CommandEmpty>
 
-            {/* Navigate 群組 — 靜態頁面 */}
-            <PagesGroup onSelect={handleSelect} />
+              {isAiMode ? (
+                /* AI Actions 模式：只顯示 AI 指令 */
+                <AIActionsGroup rawInput={inputValue} onSelect={handleSelect} />
+              ) : (
+                <>
+                  {/* Navigate 群組 — 靜態頁面 */}
+                  <PagesGroup onSelect={handleSelect} />
 
-            {/* Recent Entries 群組 — 查詢 API */}
-            {debouncedQuery.length >= 2 && (
-              <>
-                <CommandSeparator />
-                <RecentEntriesGroup query={debouncedQuery} onSelect={handleSelect} />
-              </>
-            )}
+                  {/* Create 群組 */}
+                  <CommandSeparator />
+                  <CreateActionsGroup
+                    onNewEntry={handleNewEntry}
+                    onSelect={handleSelect}
+                  />
 
-            {/* Quick Actions 群組 */}
-            <CommandSeparator />
-            <QuickActionsGroup onSelect={handleSelect} />
-          </CommandList>
-        </Command>
-      </DialogContent>
-    </Dialog>
+                  {/* Search Results 群組 — 3+ 字元才顯示 */}
+                  {debouncedQuery.length >= 3 && (
+                    <>
+                      <CommandSeparator />
+                      <EntriesSearchGroup
+                        query={debouncedQuery}
+                        onSelect={handleSelect}
+                      />
+                    </>
+                  )}
+
+                  {/* Quick Actions 群組 */}
+                  <CommandSeparator />
+                  <QuickActionsGroup onSelect={handleSelect} />
+                </>
+              )}
+            </CommandList>
+          </Command>
+        </DialogContent>
+      </Dialog>
+
+      {/* QuickCreateModal — 在 CmdK 之外 render 避免 Dialog 巢狀問題 */}
+      <QuickCreateModal
+        open={quickCreateOpen}
+        onOpenChange={setQuickCreateOpen}
+        onDone={handleQuickCreateDone}
+      />
+    </>
   );
 }

--- a/dev/frontend/components/cmdk/groups/ai-actions.tsx
+++ b/dev/frontend/components/cmdk/groups/ai-actions.tsx
@@ -1,0 +1,167 @@
+"use client";
+
+/**
+ * AIActionsGroup — `>` prefix AI 指令模式群組（F-049）
+ *
+ * 業務規則：
+ *   - 只有輸入值以 `>` 開頭時才顯示此群組（其他群組隱藏）
+ *   - `> summarize` / `> find duplicates` → 導向 copilot 頁並預填 prompt（query param）
+ *   - `> classify all inbox` → 批次分類 POST /api/v1/entries/batch
+ *   - `> help` → 顯示 ShortcutsModal（toast 提示）
+ *   - 以 `>` 後的文字過濾動作清單
+ */
+
+import { useRouter } from "next/navigation";
+import { Sparkles, Copy, Tag, HelpCircle } from "lucide-react";
+import { toast } from "sonner";
+import {
+  CommandGroup,
+  CommandItem,
+} from "@/components/ui/command";
+import { apiClient } from "@/lib/api/client";
+import type { ListEntriesResponse } from "@/lib/api/entries";
+
+interface AiActionsGroupProps {
+  /** 完整輸入值，應以 `>` 開頭 */
+  rawInput: string;
+  onSelect: () => void;
+}
+
+interface AiAction {
+  id: string;
+  label: string;
+  description: string;
+  keywords: string[];
+  icon: React.ComponentType<{ className?: string }>;
+}
+
+const AI_ACTIONS: AiAction[] = [
+  {
+    id: "summarize",
+    label: "Summarize recent entries",
+    description: "讓 Copilot 摘要最近的 entries",
+    keywords: ["summarize", "summary", "摘要"],
+    icon: Sparkles,
+  },
+  {
+    id: "find-duplicates",
+    label: "Find duplicate entries",
+    description: "讓 Copilot 找出重複的 entries",
+    keywords: ["find duplicates", "duplicate", "重複"],
+    icon: Copy,
+  },
+  {
+    id: "classify-inbox",
+    label: "Classify all inbox entries",
+    description: "批次分類所有 inbox entries",
+    keywords: ["classify", "classify all inbox", "分類"],
+    icon: Tag,
+  },
+  {
+    id: "help",
+    label: "Help — keyboard shortcuts",
+    description: "顯示鍵盤快捷鍵總覽",
+    keywords: ["help", "shortcuts", "說明", "快捷鍵"],
+    icon: HelpCircle,
+  },
+];
+
+async function classifyAllInbox(onSelect: () => void) {
+  onSelect();
+  const toastId = toast.loading("正在取得 inbox entries...");
+
+  try {
+    const res = await apiClient.get<ListEntriesResponse>(
+      "/api/v1/entries?status=inbox&per_page=100",
+    );
+    const ids = (res.data ?? []).map((e) => e.id);
+
+    if (ids.length === 0) {
+      toast.dismiss(toastId);
+      toast.info("Inbox 中沒有 entries");
+      return;
+    }
+
+    toast.loading(`Classifying ${ids.length} entries...`, { id: toastId });
+
+    await apiClient.post("/api/v1/entries/batch", {
+      action: "classify",
+      ids,
+    });
+
+    toast.success("Classification complete", { id: toastId });
+  } catch {
+    toast.error("分類失敗，請稍後再試", { id: toastId });
+  }
+}
+
+export function AIActionsGroup({ rawInput, onSelect }: AiActionsGroupProps) {
+  const router = useRouter();
+
+  // 只在 `>` prefix 模式下顯示
+  if (!rawInput.startsWith(">")) return null;
+
+  // `>` 後的文字作為 filter（去頭空格）
+  const filterText = rawInput.slice(1).trim().toLowerCase();
+
+  const filtered = AI_ACTIONS.filter((action) => {
+    if (!filterText) return true;
+    return action.keywords.some((kw) => kw.toLowerCase().includes(filterText));
+  });
+
+  if (filtered.length === 0) return null;
+
+  const handleSelect = (action: AiAction) => {
+    switch (action.id) {
+      case "summarize":
+        router.push(
+          "/dashboard?copilot=1&prompt=" +
+            encodeURIComponent("Summarize my recent entries"),
+        );
+        onSelect();
+        break;
+
+      case "find-duplicates":
+        router.push(
+          "/dashboard?copilot=1&prompt=" +
+            encodeURIComponent(
+              "Find duplicate entries in my knowledge base and list them",
+            ),
+        );
+        onSelect();
+        break;
+
+      case "classify-inbox":
+        void classifyAllInbox(onSelect);
+        break;
+
+      case "help":
+        toast.info("快捷鍵：⌘K 開啟 Command Palette，⌘/ 開啟說明", {
+          duration: 5000,
+        });
+        onSelect();
+        break;
+    }
+  };
+
+  return (
+    <CommandGroup heading="AI Actions">
+      {filtered.map((action) => {
+        const Icon = action.icon;
+        return (
+          <CommandItem
+            key={action.id}
+            value={`ai-${action.id}-${action.label}`}
+            onSelect={() => handleSelect(action)}
+          >
+            <Icon className="mr-2 h-4 w-4 text-[--fg-subtle]" />
+            <div className="flex flex-col">
+              <span>{action.label}</span>
+              <span className="text-xs text-[--fg-muted]">{action.description}</span>
+            </div>
+          </CommandItem>
+        );
+      })}
+    </CommandGroup>
+  );
+}

--- a/dev/frontend/components/cmdk/groups/create-actions.tsx
+++ b/dev/frontend/components/cmdk/groups/create-actions.tsx
@@ -1,0 +1,49 @@
+"use client";
+
+/**
+ * CreateActionsGroup — 建立動作群組（F-049）
+ *
+ * 包含：
+ *   - New Entry → 開啟 QuickCreateModal
+ *   - New Journal Entry → 導向 /today/journal
+ */
+
+import { useRouter } from "next/navigation";
+import { PlusCircle, BookOpenCheck } from "lucide-react";
+import {
+  CommandGroup,
+  CommandItem,
+} from "@/components/ui/command";
+
+interface CreateActionsGroupProps {
+  onNewEntry: () => void;
+  onSelect: () => void;
+}
+
+export function CreateActionsGroup({ onNewEntry, onSelect }: CreateActionsGroupProps) {
+  const router = useRouter();
+
+  return (
+    <CommandGroup heading="Create">
+      <CommandItem
+        value="new entry create add 建立 新增"
+        onSelect={() => {
+          onNewEntry();
+        }}
+      >
+        <PlusCircle className="mr-2 h-4 w-4 text-[--fg-subtle]" />
+        New Entry
+      </CommandItem>
+      <CommandItem
+        value="new journal entry diary 日記 日誌"
+        onSelect={() => {
+          router.push("/today/journal");
+          onSelect();
+        }}
+      >
+        <BookOpenCheck className="mr-2 h-4 w-4 text-[--fg-subtle]" />
+        New Journal Entry
+      </CommandItem>
+    </CommandGroup>
+  );
+}

--- a/dev/frontend/components/cmdk/groups/entries-search.tsx
+++ b/dev/frontend/components/cmdk/groups/entries-search.tsx
@@ -1,0 +1,77 @@
+"use client";
+
+/**
+ * EntriesSearchGroup — 即時後端搜尋結果群組（F-049）
+ *
+ * 業務規則：
+ *   - query 3+ 字元才顯示（debounce 已在上層處理，此元件直接接收 debouncedQuery）
+ *   - GET /api/v1/entries?q=...&status=library&per_page=5
+ *   - API 失敗 → silent fail（不顯示此群組，不影響其他群組）
+ *   - 點選結果 → 開啟 EntryDetailSheet（router.push to /library/:id）
+ */
+
+import { useQuery } from "@tanstack/react-query";
+import { FileText } from "lucide-react";
+import { useRouter } from "next/navigation";
+import {
+  CommandGroup,
+  CommandItem,
+} from "@/components/ui/command";
+import { apiClient } from "@/lib/api/client";
+import type { ListEntriesResponse, EntryListItem } from "@/lib/api/entries";
+
+interface EntriesSearchGroupProps {
+  /** debounce 後的搜尋字串，父層負責 debounce 200ms */
+  query: string;
+  onSelect: () => void;
+}
+
+const MAX_RESULTS = 5;
+
+export function EntriesSearchGroup({ query, onSelect }: EntriesSearchGroupProps) {
+  const router = useRouter();
+
+  const { data, isError, isFetching } = useQuery<ListEntriesResponse>({
+    queryKey: ["cmdk-entries-search", query],
+    queryFn: () =>
+      apiClient.get<ListEntriesResponse>(
+        `/api/v1/entries?q=${encodeURIComponent(query)}&status=library&per_page=5`,
+      ),
+    enabled: query.length >= 3,
+    staleTime: 15_000,
+    retry: false,
+  });
+
+  // 3 字元以下或 API 錯誤時不顯示群組（silent fail）
+  if (query.length < 3 || isError) return null;
+
+  const entries: EntryListItem[] = (data?.data ?? []).slice(0, MAX_RESULTS);
+
+  // 還在 fetching 且沒有舊資料時顯示空 group（避免 layout shift）
+  if (isFetching && entries.length === 0) return null;
+
+  if (entries.length === 0) return null;
+
+  return (
+    <CommandGroup heading="Search Results">
+      {entries.map((entry) => (
+        <CommandItem
+          key={entry.id}
+          value={`search-${entry.id}-${entry.title ?? entry.id}`}
+          onSelect={() => {
+            router.push(`/library/${entry.id}`);
+            onSelect();
+          }}
+        >
+          <FileText className="mr-2 h-4 w-4 text-[--fg-subtle]" />
+          <span className="truncate">{entry.title ?? "(無標題)"}</span>
+          {entry.content_preview && (
+            <span className="ml-2 truncate text-xs text-[--fg-muted]">
+              {entry.content_preview}
+            </span>
+          )}
+        </CommandItem>
+      ))}
+    </CommandGroup>
+  );
+}

--- a/dev/frontend/components/cmdk/quick-create-modal.tsx
+++ b/dev/frontend/components/cmdk/quick-create-modal.tsx
@@ -1,0 +1,213 @@
+"use client";
+
+/**
+ * QuickCreateModal — 快速建立 Entry 的 Dialog（F-049）
+ *
+ * 行為：
+ *   - TitleInput（auto focus）：必填
+ *   - ContentTextarea（optional）
+ *   - TagInput（optional，逗號分隔）
+ *   - [Create as Draft]：status=inbox，source_type=manual
+ *   - [Create & Classify]：同上，建立後呼叫 classify
+ *   - Title 為空時按鈕 disabled，顯示 "Title is required"
+ *   - 建立成功後：toast "Entry created — Open" + 關閉 Modal + 關閉 CmdK
+ */
+
+import * as React from "react";
+import { useMutation } from "@tanstack/react-query";
+import { toast } from "sonner";
+import { useRouter } from "next/navigation";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogFooter,
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
+import { Label } from "@/components/ui/label";
+import { apiClient } from "@/lib/api/client";
+import type { Entry } from "@/lib/api/entries";
+
+interface QuickCreateModalProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  /** 關閉時同時關閉 CmdK */
+  onDone: () => void;
+}
+
+interface CreateEntryPayload {
+  title: string;
+  content?: string;
+  tags?: string[];
+  status: "inbox";
+  source_type: "manual";
+}
+
+interface CreateEntryResponse {
+  data: Entry;
+}
+
+export function QuickCreateModal({ open, onOpenChange, onDone }: QuickCreateModalProps) {
+  const router = useRouter();
+  const [title, setTitle] = React.useState("");
+  const [content, setContent] = React.useState("");
+  const [tagsRaw, setTagsRaw] = React.useState("");
+  const [touched, setTouched] = React.useState(false);
+
+  const titleEmpty = title.trim().length === 0;
+  const showError = touched && titleEmpty;
+
+  // 重置 form 狀態
+  const resetForm = () => {
+    setTitle("");
+    setContent("");
+    setTagsRaw("");
+    setTouched(false);
+  };
+
+  const handleClose = (value: boolean) => {
+    if (!value) resetForm();
+    onOpenChange(value);
+  };
+
+  const parseTags = (): string[] =>
+    tagsRaw
+      .split(",")
+      .map((t) => t.trim())
+      .filter(Boolean);
+
+  const mutation = useMutation<CreateEntryResponse, Error, { classify: boolean }>({
+    mutationFn: async ({ classify }) => {
+      const payload: CreateEntryPayload = {
+        title: title.trim(),
+        status: "inbox",
+        source_type: "manual",
+      };
+      if (content.trim()) payload.content = content.trim();
+      const tags = parseTags();
+      if (tags.length > 0) payload.tags = tags;
+
+      const res = await apiClient.post<CreateEntryPayload, CreateEntryResponse>(
+        "/api/v1/entries",
+        payload,
+      );
+
+      if (classify && res.data?.id) {
+        await apiClient.post("/api/v1/entries/batch", {
+          action: "classify",
+          ids: [res.data.id],
+        });
+      }
+
+      return res;
+    },
+    onSuccess: (res) => {
+      const entryId = res.data?.id;
+      toast.success("Entry created", {
+        action: entryId
+          ? {
+              label: "Open",
+              onClick: () => router.push(`/library/${entryId}`),
+            }
+          : undefined,
+      });
+      handleClose(false);
+      onDone();
+    },
+    onError: () => {
+      toast.error("建立失敗，請稍後再試");
+    },
+  });
+
+  const handleCreate = (classify: boolean) => {
+    setTouched(true);
+    if (titleEmpty) return;
+    mutation.mutate({ classify });
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={handleClose}>
+      <DialogContent
+        className="sm:max-w-[480px]"
+        aria-label="Quick Create Entry"
+      >
+        <DialogHeader>
+          <DialogTitle>建立新 Entry</DialogTitle>
+        </DialogHeader>
+
+        <div className="space-y-4 py-2">
+          {/* Title */}
+          <div className="space-y-1.5">
+            <Label htmlFor="qc-title">
+              標題 <span className="text-destructive">*</span>
+            </Label>
+            <Input
+              id="qc-title"
+              autoFocus
+              placeholder="輸入標題..."
+              value={title}
+              onChange={(e) => setTitle(e.target.value)}
+              onBlur={() => setTouched(true)}
+              aria-invalid={showError}
+              aria-describedby={showError ? "qc-title-error" : undefined}
+            />
+            {showError && (
+              <p id="qc-title-error" className="text-xs text-destructive">
+                Title is required
+              </p>
+            )}
+          </div>
+
+          {/* Content */}
+          <div className="space-y-1.5">
+            <Label htmlFor="qc-content">內容（選填）</Label>
+            <Textarea
+              id="qc-content"
+              placeholder="輸入內容..."
+              rows={3}
+              value={content}
+              onChange={(e) => setContent(e.target.value)}
+            />
+          </div>
+
+          {/* Tags */}
+          <div className="space-y-1.5">
+            <Label htmlFor="qc-tags">標籤（選填，逗號分隔）</Label>
+            <Input
+              id="qc-tags"
+              placeholder="例：rust, concurrency, notes"
+              value={tagsRaw}
+              onChange={(e) => setTagsRaw(e.target.value)}
+            />
+          </div>
+        </div>
+
+        <DialogFooter className="gap-2">
+          <Button
+            variant="outline"
+            onClick={() => handleClose(false)}
+            disabled={mutation.isPending}
+          >
+            取消
+          </Button>
+          <Button
+            variant="secondary"
+            onClick={() => handleCreate(true)}
+            disabled={titleEmpty || mutation.isPending}
+          >
+            Create &amp; Classify
+          </Button>
+          <Button
+            onClick={() => handleCreate(false)}
+            disabled={titleEmpty || mutation.isPending}
+          >
+            Create as Draft
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/dev/frontend/components/cmdk/quick-create-modal.tsx
+++ b/dev/frontend/components/cmdk/quick-create-modal.tsx
@@ -90,7 +90,7 @@ export function QuickCreateModal({ open, onOpenChange, onDone }: QuickCreateModa
       const tags = parseTags();
       if (tags.length > 0) payload.tags = tags;
 
-      const res = await apiClient.post<CreateEntryPayload, CreateEntryResponse>(
+      const res = await apiClient.post<CreateEntryResponse>(
         "/api/v1/entries",
         payload,
       );


### PR DESCRIPTION
## Summary

延伸 F-037 Command Palette skeleton，加入 Power Actions 四大群組。

## Changes

- `dev/frontend/components/cmdk/groups/entries-search.tsx` — 即時後端搜尋分組，3+ 字元 debounce 200ms，呼叫 GET /api/v1/entries?q=...&status=library&per_page=5；API 失敗 silent fail
- `dev/frontend/components/cmdk/groups/ai-actions.tsx` — `>` prefix AI 指令模式：summarize / find duplicates / classify all inbox / help；classify all inbox 呼叫 GET /api/v1/entries?status=inbox + POST /api/v1/entries/batch
- `dev/frontend/components/cmdk/groups/create-actions.tsx` — Create 群組：New Entry（開啟 QuickCreateModal）/ New Journal Entry（導向 /today/journal）
- `dev/frontend/components/cmdk/quick-create-modal.tsx` — 快速建立 Entry Dialog，TitleInput auto focus，title 為空時按鈕 disabled，建立成功 toast "Entry created — Open"
- `dev/frontend/components/cmdk/command-palette.tsx` — 整合所有新群組；`>` prefix 時 shouldFilter=false 改為手動過濾；QuickCreateModal 在 CmdK Dialog 外 render 避免巢狀

## Scenario 覆蓋

- [x] Scenario: 快速搜尋並跳轉 entry — EntriesSearchGroup debounce 200ms，3+ chars 觸發
- [x] Scenario: 快速建立 Entry — QuickCreateModal + POST /api/v1/entries + toast
- [x] Scenario: AI Action > classify all inbox — GET inbox + POST batch + progress toast
- [x] Scenario: 搜尋 API 失敗時降級 — isError 時 return null，silent fail
- [x] Scenario: 快速建立 title 為空 — titleEmpty disabled + "Title is required"
- [x] Scenario: `>` prefix 切換 AI mode — isAiMode 判斷，隱藏其他群組
- [x] Scenario: 多次快速輸入 debounce — useDebouncedValue(inputValue, 200)

## Related Issues

Closes #233