### PR TITLE
design(sprint-16): Copilot Panel + CmdK Power + ShortcutsModal UI Components

### DIFF
--- a/design/components/cmdk-power/example.tsx
+++ b/design/components/cmdk-power/example.tsx
@@ -1,0 +1,717 @@
+// CmdK Power Actions — 使用範例
+// 技術選型：Next.js 14 + cmdk ^1 + shadcn/ui Dialog + Tailwind CSS v4
+// 圖示套件：Lucide React
+
+import { useState, useEffect, useCallback, useRef } from "react";
+import {
+  Command,
+  CommandDialog,
+  CommandInput,
+  CommandList,
+  CommandEmpty,
+  CommandGroup,
+  CommandItem,
+  CommandSeparator,
+} from "cmdk";
+import {
+  FileText,
+  Plus,
+  Navigation,
+  Inbox,
+  BookOpen,
+  Calendar,
+  Network,
+  Settings,
+  Sparkles,
+  Search,
+  Loader2,
+  X,
+} from "lucide-react";
+import { cn } from "@/lib/utils";
+
+// ─── Types ───────────────────────────────────────────────────────────────────
+
+interface SearchEntry {
+  id: string;
+  title: string;
+  category?: string;
+  status?: string;
+}
+
+interface QuickCreateFormData {
+  title: string;
+  content: string;
+  tags: string[];
+}
+
+// ─── AIModePrefixIndicator ───────────────────────────────────────────────────
+
+function AIModePrefixIndicator({ visible }: { visible: boolean }) {
+  if (!visible) return null;
+  return (
+    <div
+      role="status"
+      aria-live="polite"
+      className={cn(
+        "flex items-center gap-1.5 px-3 py-1.5",
+        "bg-accent-subtle text-accent-default text-xs font-medium",
+        "animate-in fade-in duration-150"
+      )}
+    >
+      <Sparkles className="h-3 w-3" aria-hidden="true" />
+      AI Mode
+    </div>
+  );
+}
+
+// ─── SearchResultItem ─────────────────────────────────────────────────────────
+
+interface SearchResultItemProps {
+  icon: React.ReactNode;
+  title: string;
+  subtitle?: string;
+  badge?: string;
+  kbd?: string;
+  onSelect: () => void;
+}
+
+function SearchResultItem({
+  icon,
+  title,
+  subtitle,
+  badge,
+  kbd,
+  onSelect,
+}: SearchResultItemProps) {
+  return (
+    <CommandItem
+      onSelect={onSelect}
+      className={cn(
+        "flex h-[44px] items-center gap-3 px-3 py-2 rounded-md",
+        "cursor-pointer transition-colors duration-100",
+        "data-[selected=true]:bg-bg-subtle",
+        // 選中狀態左側 accent 線
+        "relative data-[selected=true]:before:absolute",
+        "data-[selected=true]:before:left-0 data-[selected=true]:before:top-1",
+        "data-[selected=true]:before:bottom-1 data-[selected=true]:before:w-[3px]",
+        "data-[selected=true]:before:rounded-full data-[selected=true]:before:bg-accent-default"
+      )}
+    >
+      <span className="text-fg-muted" aria-hidden="true">
+        {icon}
+      </span>
+      <span className="flex flex-1 flex-col min-w-0">
+        <span className="text-sm font-medium text-fg-default truncate">
+          {title}
+        </span>
+        {subtitle && (
+          <span className="text-xs text-fg-muted truncate">{subtitle}</span>
+        )}
+      </span>
+      {badge && (
+        <span
+          className={cn(
+            "rounded px-1.5 py-0.5",
+            "bg-secondary text-fg-muted text-xs shrink-0"
+          )}
+        >
+          {badge}
+        </span>
+      )}
+      {kbd && (
+        <kbd
+          className={cn(
+            "font-mono text-xs text-fg-muted shrink-0",
+            "border border-border rounded px-1.5 py-0.5",
+            "shadow-[0_1px_0_0_var(--border)]"
+          )}
+          aria-label={kbd}
+        >
+          {kbd}
+        </kbd>
+      )}
+    </CommandItem>
+  );
+}
+
+// ─── AIActionItem ─────────────────────────────────────────────────────────────
+
+interface AIActionItemProps {
+  action: string;
+  description: string;
+  onSelect: () => void;
+}
+
+function AIActionItem({ action, description, onSelect }: AIActionItemProps) {
+  return (
+    <CommandItem
+      onSelect={onSelect}
+      className={cn(
+        "flex h-[44px] items-center gap-3 px-3 py-2 rounded-md",
+        "cursor-pointer transition-colors duration-100",
+        "data-[selected=true]:bg-bg-subtle",
+        "relative data-[selected=true]:before:absolute",
+        "data-[selected=true]:before:left-0 data-[selected=true]:before:top-1",
+        "data-[selected=true]:before:bottom-1 data-[selected=true]:before:w-[3px]",
+        "data-[selected=true]:before:rounded-full data-[selected=true]:before:bg-accent-default"
+      )}
+    >
+      <Sparkles className="h-5 w-5 text-accent-default shrink-0" aria-hidden="true" />
+      <span className="flex flex-1 flex-col min-w-0">
+        <span className="text-sm font-medium text-fg-default">
+          <span className="text-accent-default">&gt;</span> {action}
+        </span>
+        <span className="text-xs text-fg-muted">{description}</span>
+      </span>
+      <kbd
+        className={cn(
+          "font-mono text-xs text-fg-muted shrink-0",
+          "border border-border rounded px-1.5 py-0.5",
+          "shadow-[0_1px_0_0_var(--border)]"
+        )}
+        aria-label="Enter 執行"
+      >
+        ↵
+      </kbd>
+    </CommandItem>
+  );
+}
+
+// ─── CommandFooter ────────────────────────────────────────────────────────────
+
+function CommandFooter({ isAIMode }: { isAIMode: boolean }) {
+  const hints = [
+    { kbd: "↑↓", label: "導航" },
+    { kbd: "↵", label: "選擇" },
+    { kbd: "Esc", label: "關閉" },
+    ...(!isAIMode ? [{ kbd: ">", label: "AI 模式" }] : []),
+  ];
+
+  return (
+    <div
+      className={cn(
+        "flex items-center gap-4 border-t border-border",
+        "bg-bg-subtle px-3 py-2"
+      )}
+      aria-hidden="true"
+    >
+      {hints.map(({ kbd, label }) => (
+        <span key={kbd} className="flex items-center gap-1.5 text-xs text-fg-muted">
+          <kbd
+            className={cn(
+              "font-mono text-xs",
+              "border border-border rounded px-1.5 py-0.5",
+              "shadow-[0_1px_0_0_var(--border)] bg-bg-muted"
+            )}
+          >
+            {kbd}
+          </kbd>
+          {label}
+        </span>
+      ))}
+    </div>
+  );
+}
+
+// ─── QuickCreateModal ─────────────────────────────────────────────────────────
+
+interface QuickCreateModalProps {
+  open: boolean;
+  onClose: () => void;
+  onCreated?: (entry: { id: string; title: string }) => void;
+}
+
+export function QuickCreateModal({
+  open,
+  onClose,
+  onCreated,
+}: QuickCreateModalProps) {
+  const [form, setForm] = useState<QuickCreateFormData>({
+    title: "",
+    content: "",
+    tags: [],
+  });
+  const [tagInput, setTagInput] = useState("");
+  const [titleError, setTitleError] = useState("");
+  const [isLoading, setIsLoading] = useState(false);
+  const titleRef = useRef<HTMLInputElement>(null);
+
+  // Auto focus title on open
+  useEffect(() => {
+    if (open) {
+      setTimeout(() => titleRef.current?.focus(), 50);
+      setForm({ title: "", content: "", tags: [] });
+      setTitleError("");
+    }
+  }, [open]);
+
+  const isDisabled = !form.title.trim() || isLoading;
+
+  const handleCreate = async (classify: boolean) => {
+    if (!form.title.trim()) {
+      setTitleError("Title is required");
+      titleRef.current?.focus();
+      return;
+    }
+    setIsLoading(true);
+    // engineer 在此實作 POST /api/v1/entries
+    // const result = await createEntry({ title: form.title, content: form.content, tags: form.tags, status: "inbox" });
+    // if (classify) await triggerClassify(result.id);
+    setIsLoading(false);
+    onClose();
+  };
+
+  const handleAddTag = () => {
+    const tag = tagInput.trim();
+    if (!tag || form.tags.includes(tag) || form.tags.length >= 10) return;
+    setForm((prev) => ({ ...prev, tags: [...prev.tags, tag] }));
+    setTagInput("");
+  };
+
+  const handleRemoveTag = (tag: string) => {
+    setForm((prev) => ({ ...prev, tags: prev.tags.filter((t) => t !== tag) }));
+  };
+
+  if (!open) return null;
+
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="quick-create-title"
+      className="fixed inset-0 z-50 flex items-center justify-center"
+    >
+      {/* Overlay */}
+      <div
+        className="absolute inset-0 bg-overlay backdrop-blur-sm"
+        onClick={onClose}
+        aria-hidden="true"
+      />
+
+      {/* Dialog */}
+      <div
+        className={cn(
+          "relative z-10 w-full max-w-lg rounded-xl",
+          "bg-card border border-border shadow-lg",
+          "p-6 flex flex-col gap-4",
+          "animate-in zoom-in-95 fade-in duration-150"
+        )}
+      >
+        {/* Header */}
+        <div className="flex items-center justify-between">
+          <h2
+            id="quick-create-title"
+            className="text-base font-semibold text-fg-default"
+          >
+            New Entry
+          </h2>
+          <button
+            onClick={onClose}
+            aria-label="關閉"
+            className={cn(
+              "flex h-[44px] w-[44px] items-center justify-center rounded-lg",
+              "text-fg-muted hover:text-fg-default hover:bg-secondary",
+              "transition-colors duration-150",
+              "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+            )}
+          >
+            <X className="h-4 w-4" aria-hidden="true" />
+          </button>
+        </div>
+
+        {/* Title */}
+        <div className="flex flex-col gap-1.5">
+          <label
+            htmlFor="qc-title"
+            className="text-sm font-medium text-fg-default"
+          >
+            Title <span className="text-danger-default" aria-label="必填">*</span>
+          </label>
+          <input
+            ref={titleRef}
+            id="qc-title"
+            type="text"
+            value={form.title}
+            onChange={(e) => {
+              setForm((prev) => ({ ...prev, title: e.target.value }));
+              if (e.target.value.trim()) setTitleError("");
+            }}
+            aria-required="true"
+            aria-invalid={!!titleError}
+            aria-describedby={titleError ? "qc-title-error" : undefined}
+            placeholder="Entry title..."
+            className={cn(
+              "w-full rounded-lg border px-4 py-2.5 text-sm",
+              "bg-bg-default placeholder:text-fg-subtle",
+              "focus:outline-none focus-visible:ring-2 focus-visible:ring-border-focus",
+              titleError ? "border-danger-default" : "border-border"
+            )}
+          />
+          {titleError && (
+            <p
+              id="qc-title-error"
+              role="alert"
+              className="text-xs text-danger-default mt-0.5"
+            >
+              {titleError}
+            </p>
+          )}
+        </div>
+
+        {/* Content */}
+        <div className="flex flex-col gap-1.5">
+          <label
+            htmlFor="qc-content"
+            className="text-sm font-medium text-fg-default"
+          >
+            Content <span className="text-fg-muted font-normal">(optional)</span>
+          </label>
+          <textarea
+            id="qc-content"
+            value={form.content}
+            onChange={(e) =>
+              setForm((prev) => ({ ...prev, content: e.target.value }))
+            }
+            placeholder="Add a note..."
+            rows={3}
+            className={cn(
+              "w-full resize-none rounded-lg border border-border px-4 py-2.5 text-sm",
+              "bg-bg-default placeholder:text-fg-subtle",
+              "focus:outline-none focus-visible:ring-2 focus-visible:ring-border-focus",
+              "min-h-[72px] max-h-[144px]"
+            )}
+          />
+        </div>
+
+        {/* Tags */}
+        <div className="flex flex-col gap-1.5">
+          <label
+            htmlFor="qc-tag-input"
+            className="text-sm font-medium text-fg-default"
+          >
+            Tags <span className="text-fg-muted font-normal">(optional)</span>
+          </label>
+          <div
+            className={cn(
+              "flex flex-wrap gap-1.5 min-h-[44px] rounded-lg border border-border",
+              "bg-bg-default px-3 py-2",
+              "focus-within:ring-2 focus-within:ring-border-focus"
+            )}
+          >
+            {form.tags.map((tag) => (
+              <span
+                key={tag}
+                className={cn(
+                  "flex items-center gap-1 rounded-full",
+                  "bg-secondary text-fg-default text-xs",
+                  "px-2.5 py-0.5"
+                )}
+              >
+                {tag}
+                <button
+                  onClick={() => handleRemoveTag(tag)}
+                  aria-label={`移除標籤 ${tag}`}
+                  className="text-fg-muted hover:text-fg-default"
+                >
+                  <X className="h-3 w-3" aria-hidden="true" />
+                </button>
+              </span>
+            ))}
+            <input
+              id="qc-tag-input"
+              type="text"
+              value={tagInput}
+              onChange={(e) => setTagInput(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === "Enter") {
+                  e.preventDefault();
+                  handleAddTag();
+                }
+              }}
+              placeholder={form.tags.length < 10 ? "Add tag..." : ""}
+              disabled={form.tags.length >= 10}
+              className={cn(
+                "flex-1 min-w-[80px] text-xs bg-transparent",
+                "focus:outline-none placeholder:text-fg-subtle"
+              )}
+            />
+          </div>
+        </div>
+
+        {/* CTAs */}
+        <div className="flex justify-end gap-3 pt-2">
+          <button
+            onClick={() => handleCreate(false)}
+            disabled={isDisabled}
+            className={cn(
+              "flex items-center gap-2 rounded-lg px-4 py-2.5 text-sm font-medium",
+              "border border-border bg-secondary text-fg-default",
+              "transition-colors duration-150",
+              "hover:bg-secondary-hover focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
+              isDisabled && "opacity-50 cursor-not-allowed"
+            )}
+          >
+            {isLoading && (
+              <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" />
+            )}
+            Create as Draft
+          </button>
+          <button
+            onClick={() => handleCreate(true)}
+            disabled={isDisabled}
+            className={cn(
+              "flex items-center gap-2 rounded-lg px-4 py-2.5 text-sm font-medium",
+              "bg-primary text-primary-fg",
+              "transition-colors duration-150",
+              "hover:bg-primary-hover focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
+              isDisabled && "opacity-50 cursor-not-allowed"
+            )}
+          >
+            {isLoading && (
+              <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" />
+            )}
+            Create & Classify
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// ─── CmdKPower（主元件）──────────────────────────────────────────────────────
+
+interface CmdKPowerProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+export function CmdKPower({ open, onOpenChange }: CmdKPowerProps) {
+  const [inputValue, setInputValue] = useState("");
+  const [searchResults, setSearchResults] = useState<SearchEntry[]>([]);
+  const [isSearching, setIsSearching] = useState(false);
+  const [showQuickCreate, setShowQuickCreate] = useState(false);
+  const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const isAIMode = inputValue.startsWith(">");
+  const trimmedInput = isAIMode ? inputValue.slice(1).trim() : inputValue;
+  const showSearch = !isAIMode && inputValue.length >= 3;
+
+  // Debounce 後端搜尋（200ms）
+  useEffect(() => {
+    if (!showSearch) {
+      setSearchResults([]);
+      return;
+    }
+    if (debounceRef.current) clearTimeout(debounceRef.current);
+    debounceRef.current = setTimeout(async () => {
+      setIsSearching(true);
+      try {
+        // engineer 在此實作 GET /api/v1/entries?q=...&per_page=5
+        // const res = await fetch(`/api/v1/entries?q=${encodeURIComponent(inputValue)}&per_page=5`);
+        // const data = await res.json();
+        // setSearchResults(data.entries);
+      } catch {
+        // silent fail：Search Results 分組不顯示
+        setSearchResults([]);
+      } finally {
+        setIsSearching(false);
+      }
+    }, 200);
+
+    return () => {
+      if (debounceRef.current) clearTimeout(debounceRef.current);
+    };
+  }, [inputValue, showSearch]);
+
+  // 清空 input 當 Dialog 關閉
+  useEffect(() => {
+    if (!open) {
+      setInputValue("");
+      setSearchResults([]);
+    }
+  }, [open]);
+
+  const navItems = [
+    { id: "inbox", icon: <Inbox className="h-5 w-5" />, title: "Go to Inbox", path: "/dashboard/inbox" },
+    { id: "library", icon: <BookOpen className="h-5 w-5" />, title: "Go to Library", path: "/dashboard/library" },
+    { id: "today", icon: <Calendar className="h-5 w-5" />, title: "Go to Today", path: "/dashboard/today" },
+    { id: "canvas", icon: <Network className="h-5 w-5" />, title: "Go to Canvas", path: "/dashboard/canvas" },
+    { id: "settings", icon: <Settings className="h-5 w-5" />, title: "Go to Settings", path: "/dashboard/settings" },
+  ];
+
+  const createItems = [
+    { id: "new-entry", icon: <Plus className="h-5 w-5" />, title: "New Entry", kbd: "⌘N" },
+    { id: "new-journal", icon: <FileText className="h-5 w-5" />, title: "New Journal Entry", subtitle: "journal, diary" },
+  ];
+
+  const aiActions = [
+    { action: "summarize", description: "摘要最近的 entries，開啟 Copilot" },
+    { action: "find duplicates", description: "找出重複筆記，開啟 Copilot" },
+    { action: "classify all inbox", description: "批次分類 Inbox 中的所有 entries" },
+    { action: "help", description: "查看所有鍵盤快捷鍵" },
+  ].filter((a) =>
+    trimmedInput === "" || a.action.includes(trimmedInput.toLowerCase())
+  );
+
+  return (
+    <>
+      <CommandDialog
+        open={open}
+        onOpenChange={onOpenChange}
+        aria-label="命令面板"
+      >
+        <div className="flex flex-col">
+          {/* AI Mode 提示列 */}
+          <AIModePrefixIndicator visible={isAIMode} />
+
+          {/* 搜尋框 */}
+          <CommandInput
+            value={inputValue}
+            onValueChange={setInputValue}
+            placeholder="搜尋或輸入指令..."
+            aria-label="搜尋或輸入指令"
+            aria-autocomplete="list"
+            className="h-12 px-4 text-sm"
+          />
+        </div>
+
+        <CommandList
+          aria-label="搜尋結果"
+          className="max-h-[60vh] overflow-y-auto"
+        >
+          <CommandEmpty>
+            <div className="flex flex-col items-center gap-3 py-8 text-center">
+              <Search className="h-8 w-8 text-fg-subtle" aria-hidden="true" />
+              <p className="text-sm text-fg-muted">
+                找不到「{inputValue}」的結果
+              </p>
+              <p className="text-xs text-fg-subtle">
+                試試建立新的 Entry，或輸入 &gt; 使用 AI 指令
+              </p>
+            </div>
+          </CommandEmpty>
+
+          {/* AI Actions（> prefix mode） */}
+          {isAIMode && (
+            <CommandGroup heading="AI Actions">
+              {aiActions.map((a) => (
+                <AIActionItem
+                  key={a.action}
+                  action={a.action}
+                  description={a.description}
+                  onSelect={() => {
+                    // engineer 在此實作各 AI 動作
+                    onOpenChange(false);
+                  }}
+                />
+              ))}
+            </CommandGroup>
+          )}
+
+          {/* 非 AI mode：Navigation + Create + Search Results */}
+          {!isAIMode && (
+            <>
+              <CommandGroup heading="Navigation">
+                {navItems.map((item) => (
+                  <SearchResultItem
+                    key={item.id}
+                    icon={item.icon}
+                    title={item.title}
+                    onSelect={() => {
+                      // router.push(item.path);
+                      onOpenChange(false);
+                    }}
+                  />
+                ))}
+              </CommandGroup>
+
+              <CommandSeparator />
+
+              <CommandGroup heading="Create">
+                {createItems.map((item) => (
+                  <SearchResultItem
+                    key={item.id}
+                    icon={item.icon}
+                    title={item.title}
+                    subtitle={item.subtitle}
+                    kbd={item.kbd}
+                    onSelect={() => {
+                      if (item.id === "new-entry") {
+                        setShowQuickCreate(true);
+                        onOpenChange(false);
+                      }
+                    }}
+                  />
+                ))}
+              </CommandGroup>
+
+              {/* Search Results（3+ chars） */}
+              {showSearch && (
+                <>
+                  <CommandSeparator />
+                  <CommandGroup heading="Search Results">
+                    {isSearching && (
+                      <div className="flex items-center gap-2 px-3 py-2 text-xs text-fg-muted">
+                        <Loader2 className="h-3 w-3 animate-spin" aria-hidden="true" />
+                        搜尋中...
+                      </div>
+                    )}
+                    {searchResults.map((entry) => (
+                      <SearchResultItem
+                        key={entry.id}
+                        icon={<FileText className="h-5 w-5" />}
+                        title={entry.title}
+                        badge={entry.category}
+                        onSelect={() => {
+                          // 開啟 EntryDetailSheet
+                          onOpenChange(false);
+                        }}
+                      />
+                    ))}
+                  </CommandGroup>
+                </>
+              )}
+            </>
+          )}
+        </CommandList>
+
+        {/* 底部 Kbd 提示列 */}
+        <CommandFooter isAIMode={isAIMode} />
+      </CommandDialog>
+
+      {/* QuickCreateModal（獨立 Dialog，CmdK 關閉後開啟） */}
+      <QuickCreateModal
+        open={showQuickCreate}
+        onClose={() => setShowQuickCreate(false)}
+      />
+    </>
+  );
+}
+
+// ─── 使用場景示範 ──────────────────────────────────────────────────────────────
+
+// 1. App Shell 中整合（已在 F-037 skeleton 建立）
+//
+// const [cmdkOpen, setCmdkOpen] = useState(false);
+//
+// useEffect(() => {
+//   const handler = (e: KeyboardEvent) => {
+//     if ((e.metaKey || e.ctrlKey) && e.key === "k") {
+//       e.preventDefault();
+//       setCmdkOpen((prev) => !prev);
+//     }
+//   };
+//   document.addEventListener("keydown", handler);
+//   return () => document.removeEventListener("keydown", handler);
+// }, []);
+//
+// <CmdKPower open={cmdkOpen} onOpenChange={setCmdkOpen} />
+
+// 2. > AI mode 觸發示範
+//   輸入 "> classify all inbox"
+//   → AI Actions 分組出現 "classify all inbox" 項目
+//   → 選中後觸發 POST /api/v1/entries/batch
+
+// 3. 搜尋 3+ chars 示範
+//   輸入 "go" (2 chars) → 無 Search Results
+//   輸入 "gol" (3 chars) → debounce 200ms 後觸發 GET /api/v1/entries?q=gol

--- a/design/components/cmdk-power/spec.md
+++ b/design/components/cmdk-power/spec.md
@@ -1,0 +1,242 @@
+# CmdK Power Actions
+
+## 用途
+延伸 F-037 Command Palette skeleton，加入分組動作架構、即時後端搜尋、AI Action mode（`>` prefix）、以及快速建立 Entry 的 QuickCreateModal。
+
+## 架構
+
+```
+CommandDialog（cmdk + shadcn Dialog）
+├── CommandInput（搜尋框 / AI mode prefix 偵測）
+├── AIModePrefixIndicator（`>` 前綴提示，AI mode 時顯示）
+├── CommandList（最大高度 60vh，overflow-y: auto）
+│   ├── CommandGroup "Navigation"
+│   │   └── SearchResultItem（navigation type）
+│   ├── CommandGroup "Create"
+│   │   └── SearchResultItem（create type）
+│   ├── CommandGroup "Search Results"（3+ chars 觸發）
+│   │   └── SearchResultItem（entry type，含 category badge）
+│   └── CommandGroup "AI Actions"（`>` prefix，隱藏其他分組）
+│       └── AIActionItem（含 magic wand icon）
+├── CommandEmpty（無結果提示）
+└── CommandFooter（Kbd 提示列）
+```
+
+---
+
+## SearchResultItem
+
+**視覺結構**
+```
+[icon 20px]  主文字                 [category badge]
+             副文字（entry 類型有）
+```
+
+**規格**
+- 高度：44px（觸控目標最小值）
+- Padding：`spacing.2 spacing.3`
+- Icon：`w-5 h-5`，`color.fg.muted`
+- 主文字：`font.size.sm`，`font.weight.medium`，`color.fg.default`
+- 副文字：`font.size.xs`，`color.fg.muted`（entry 的 category 或 status）
+- Category Badge：
+  - 背景：`color.secondary.default`
+  - 文字：`color.fg.muted`，`font.size.xs`
+  - Border-radius：`radius.sm`
+  - Padding：`spacing.0.5 spacing.1.5`
+- Hover / selected 背景：`color.bg.subtle`
+- 選中狀態：左側 3px accent 色條（`color.accent.default`）
+- Border-radius：`radius.md`
+
+**Types**
+| type | Icon（Lucide） | 說明 |
+|------|--------------|------|
+| navigation | `Navigation`（或對應頁面圖示） | 頁面導航 |
+| create | `Plus` | 建立動作 |
+| entry | `FileText` | 搜尋結果 entry |
+
+**Props**
+| Prop | Type | Default | 說明 |
+|------|------|---------|------|
+| icon | ReactNode | - | 左側圖示 |
+| title | string | - | 主文字 |
+| subtitle | string | - | 副文字（可選） |
+| badge | string | - | category badge 文字（可選） |
+| kbd | string | - | 右側鍵盤提示（可選） |
+| onSelect | () => void | - | 選中回調 |
+
+---
+
+## AIActionItem
+
+**視覺結構**
+```
+[Sparkles icon 20px]  > 動作名稱           [Enter 執行]
+                       動作描述文字
+```
+
+**規格**
+- 與 SearchResultItem 相同尺寸和 padding
+- Icon：Lucide `Sparkles`，`w-5 h-5`，`color.accent.default`（魔法棒效果）
+- 主文字：`> {action}`，`font.size.sm`，`font.weight.medium`，`color.fg.default`
+- 動作前綴 `>`：`color.accent.default`（強調 AI 模式）
+- 描述：`font.size.xs`，`color.fg.muted`
+- Kbd hint：`Enter 執行`
+
+**AI Actions 清單**
+| 指令 | 描述 | 行為 |
+|------|------|------|
+| `> summarize` | 摘要最近的 entries | 開啟 Copilot 並預填 prompt |
+| `> find duplicates` | 找出重複筆記 | 開啟 Copilot 並預填 prompt |
+| `> classify all inbox` | 批次分類 Inbox | POST /api/v1/entries/batch |
+| `> help` | 查看鍵盤快捷鍵 | 開啟 ShortcutsModal |
+
+---
+
+## AIModePrefixIndicator
+
+**視覺結構**
+```
+┌──────────────────────────────────────────────┐
+│  [Sparkles icon] AI Mode  ← 顯示在搜尋框上方  │
+└──────────────────────────────────────────────┘
+```
+
+**規格**
+- 顯示條件：輸入值以 `>` 開頭
+- 位置：CommandInput 上方，寬度 100%
+- 高度：28px
+- 背景：`color.accent.subtle`
+- 文字："AI Mode"，`font.size.xs`，`color.accent.default`，`font.weight.medium`
+- Icon：Lucide `Sparkles`，`w-3 h-3`，`color.accent.default`
+- Padding：`spacing.1.5 spacing.3`
+- 動畫：淡入 `opacity 0 → 1`，`150ms ease`
+
+---
+
+## QuickCreateModal
+
+**用途**
+從 CmdK 觸發的快速建立 Entry 表單，以 Dialog 方式呈現。
+
+**視覺結構**
+```
+┌────────────────────────────────────────┐
+│  New Entry                         [×] │
+├────────────────────────────────────────┤
+│  Title *                               │
+│  ┌────────────────────────────────────┐│
+│  │ Title（auto focus）                ││
+│  └────────────────────────────────────┘│
+│                                        │
+│  Content（optional）                   │
+│  ┌────────────────────────────────────┐│
+│  │ Add a note...                      ││
+│  │                                    ││
+│  └────────────────────────────────────┘│
+│                                        │
+│  Tags（optional）                      │
+│  ┌────────────────────────────────────┐│
+│  │ [tag1] [tag2] [+ add tag]          ││
+│  └────────────────────────────────────┘│
+│                                        │
+│     [Create as Draft]  [Create & Classify]│
+└────────────────────────────────────────┘
+```
+
+**規格**
+- Dialog 寬度：480px（`max-w-lg`）
+- 標題列：`font.size.base`，`font.weight.semibold`
+- 關閉按鈕：Lucide `X`，44×44px 觸控目標
+
+**TitleInput**
+- Auto focus（Dialog 開啟時）
+- Placeholder：`"Entry title..."`
+- 必填：空白時 CTA 按鈕 disabled
+- 驗證錯誤訊息（title 為空時點擊）："Title is required"，`color.danger.default`，`font.size.xs`，顯示在欄位正下方
+- Label：可見 `<label>` "Title"，加上 `*` 標示必填
+
+**ContentTextarea**
+- Label："Content（optional）"
+- Placeholder：`"Add a note..."`
+- Auto resize，min 3 行，max 6 行
+- Label 可見
+
+**TagInput**
+- Label："Tags（optional）"
+- Tag chip 樣式：
+  - 背景：`color.secondary.default`
+  - 文字：`color.fg.default`，`font.size.xs`
+  - 刪除按鈕：Lucide `X`，`w-3 h-3`
+  - Border-radius：`radius.full`
+- 輸入框 placeholder：`"Add tag..."`
+- Enter 鍵確認新增 tag
+- 最多 10 個 tag
+
+**CTA Buttons**
+| 按鈕 | Variant | 行為 |
+|------|---------|------|
+| Create as Draft | secondary | POST `{ status: "inbox" }` → toast "Entry created" → 關閉 |
+| Create & Classify | primary | POST `{ status: "inbox" }` → 觸發分類 API → toast "Entry created" → 關閉 |
+- Title 為空時兩個按鈕均 disabled
+
+**Loading 狀態**
+- 點擊後按鈕顯示 Lucide `Loader2` spinner（`animate-spin`），disabled
+- 文字："建立中..."
+
+**Accessibility**
+- `role="dialog"`，`aria-modal="true"`，`aria-labelledby="quick-create-title"`
+- TitleInput：`aria-required="true"`，`aria-invalid` 驗證失敗時
+- 錯誤訊息：`aria-describedby` 連結到錯誤文字 element
+- Focus trap in Dialog
+- Escape 關閉
+
+---
+
+## 模式切換行為
+
+| 輸入內容 | 顯示分組 |
+|---------|---------|
+| 空白 | Navigation + Create（預設動作） |
+| 1-2 字元 | Navigation + Create（過濾） |
+| 3+ 字元 | Navigation + Create + Search Results（debounce 200ms） |
+| `>` prefix | AI Actions 分組（隱藏其他） |
+
+---
+
+## 空結果狀態
+
+**CommandEmpty**
+- 文字：`找不到「{query}」的結果`
+- 副文字：`試試建立新的 Entry，或輸入 > 使用 AI 指令`
+- 居中對齊，`padding: spacing.8`
+- 圖示：Lucide `Search`，`w-8 h-8`，`color.fg.subtle`
+
+---
+
+## 底部 Kbd 提示列（CommandFooter）
+
+```
+[ ↑↓ 導航 ]  [ Enter 選擇 ]  [ Esc 關閉 ]  [ > AI 模式 ]
+```
+
+- 使用 `Kbd` 元件（`design/components/kbd/`）
+- 高度：36px
+- 頂部邊框：`color.border.default`
+- Padding：`spacing.2 spacing.3`
+- 背景：`color.bg.subtle`
+
+---
+
+## Accessibility
+
+- CommandDialog：`role="dialog"`，`aria-modal="true"`，`aria-label="命令面板"`
+- CommandInput：`aria-label="搜尋或輸入指令"`，`aria-autocomplete="list"`
+- CommandList：`role="listbox"`，`aria-label="搜尋結果"`
+- 每個 CommandItem：`role="option"`，`aria-selected`
+- CommandEmpty：`aria-live="polite"`
+- AIModePrefixIndicator：`role="status"`，`aria-live="polite"`
+- 開啟時 focus trap，Escape 關閉並 restore focus
+
+## 使用範例
+
+見 `example.tsx`

--- a/design/components/copilot-panel/example.tsx
+++ b/design/components/copilot-panel/example.tsx
@@ -1,0 +1,536 @@
+// CopilotPanel — 使用範例
+// 技術選型：Next.js 14 App Router + Tailwind CSS v4 + shadcn/ui + Zustand
+// 圖示套件：Lucide React
+
+import { useRef, useState, useCallback, useEffect } from "react";
+import { Bot, X, SendHorizontal, Trash2 } from "lucide-react";
+import { cn } from "@/lib/utils";
+
+// ─── Types ───────────────────────────────────────────────────────────────────
+
+type MessageRole = "user" | "assistant";
+
+interface Message {
+  id: string;
+  role: MessageRole;
+  content: string;
+  isStreaming?: boolean;
+  isTruncated?: boolean;
+}
+
+interface CopilotPanelProps {
+  isOpen: boolean;
+  onClose: () => void;
+  defaultWidth?: number;
+  minWidth?: number;
+  maxWidth?: number;
+}
+
+// ─── Kbd animation CSS（在 globals.css 中定義）────────────────────────────────
+// @keyframes blink {
+//   0%, 100% { opacity: 1; }
+//   50%       { opacity: 0; }
+// }
+// @keyframes typingBounce {
+//   0%, 80%, 100% { transform: translateY(0); }
+//   40%           { transform: translateY(-6px); }
+// }
+// .animate-blink { animation: blink 1s step-start infinite; }
+// @media (prefers-reduced-motion: reduce) {
+//   .animate-blink { animation: none; }
+//   .animate-typing-bounce { animation: none; }
+// }
+
+// ─── ResizeHandle ─────────────────────────────────────────────────────────────
+
+function ResizeHandle({
+  onResize,
+}: {
+  onResize: (delta: number) => void;
+}) {
+  const isDraggingRef = useRef(false);
+  const startXRef = useRef(0);
+
+  const handleMouseDown = useCallback(
+    (e: React.MouseEvent) => {
+      isDraggingRef.current = true;
+      startXRef.current = e.clientX;
+      document.body.style.userSelect = "none";
+      document.body.style.cursor = "col-resize";
+
+      const handleMouseMove = (e: MouseEvent) => {
+        if (!isDraggingRef.current) return;
+        const delta = startXRef.current - e.clientX; // 往左拖 = 增加寬度
+        onResize(delta);
+        startXRef.current = e.clientX;
+      };
+
+      const handleMouseUp = () => {
+        isDraggingRef.current = false;
+        document.body.style.userSelect = "";
+        document.body.style.cursor = "";
+        document.removeEventListener("mousemove", handleMouseMove);
+        document.removeEventListener("mouseup", handleMouseUp);
+      };
+
+      document.addEventListener("mousemove", handleMouseMove);
+      document.addEventListener("mouseup", handleMouseUp);
+    },
+    [onResize]
+  );
+
+  return (
+    <div
+      role="separator"
+      aria-orientation="vertical"
+      aria-label="調整面板寬度"
+      className={cn(
+        "absolute left-0 top-0 h-full w-2 cursor-col-resize",
+        "transition-colors duration-150",
+        "hover:bg-border-focus/40",
+        "active:bg-border-focus"
+      )}
+      onMouseDown={handleMouseDown}
+    />
+  );
+}
+
+// ─── CopilotHeader ────────────────────────────────────────────────────────────
+
+interface CopilotHeaderProps {
+  onClose: () => void;
+  onClearSession: () => void;
+}
+
+function CopilotHeader({ onClose, onClearSession }: CopilotHeaderProps) {
+  return (
+    <div className="flex h-[52px] items-center gap-2 border-b border-border px-4">
+      <Bot className="h-4 w-4 text-fg-muted" aria-hidden="true" />
+      <span className="flex-1 text-sm font-semibold text-fg-default">
+        Copilot
+      </span>
+      <button
+        onClick={onClearSession}
+        aria-label="清除對話記錄"
+        className={cn(
+          "text-xs text-fg-muted transition-colors duration-150",
+          "hover:text-fg-default focus-visible:outline-none",
+          "focus-visible:ring-2 focus-visible:ring-ring rounded"
+        )}
+      >
+        Clear session
+      </button>
+      <button
+        onClick={onClose}
+        aria-label="關閉 Copilot 面板"
+        className={cn(
+          "flex h-[44px] w-[44px] items-center justify-center rounded-lg",
+          "text-fg-muted transition-colors duration-150",
+          "hover:text-fg-default hover:bg-secondary",
+          "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+        )}
+      >
+        <X className="h-4 w-4" aria-hidden="true" />
+      </button>
+    </div>
+  );
+}
+
+// ─── UserMessage ──────────────────────────────────────────────────────────────
+
+function UserMessage({ content }: { content: string }) {
+  return (
+    <article
+      className="flex justify-end my-1"
+      aria-label={`你：${content}`}
+    >
+      <div
+        className={cn(
+          "max-w-[80%] rounded-lg rounded-br-sm",
+          "bg-primary text-primary-fg",
+          "px-4 py-3 text-sm leading-relaxed"
+        )}
+      >
+        {content}
+      </div>
+    </article>
+  );
+}
+
+// ─── AssistantMessage ─────────────────────────────────────────────────────────
+
+interface AssistantMessageProps {
+  content: string;
+  isStreaming?: boolean;
+  isTruncated?: boolean;
+}
+
+function AssistantMessage({
+  content,
+  isStreaming,
+  isTruncated,
+}: AssistantMessageProps) {
+  return (
+    <article
+      className="flex justify-start my-1"
+      aria-label={`Copilot：${content}`}
+      aria-busy={isStreaming ? "true" : undefined}
+    >
+      <div
+        className={cn(
+          "max-w-[85%] rounded-lg rounded-bl-sm",
+          "bg-card text-fg-default border border-border",
+          "px-4 py-3 text-sm leading-relaxed"
+        )}
+      >
+        {content}
+        {isTruncated && (
+          <span className="text-fg-muted" aria-hidden="true">
+            {" "}
+            …
+          </span>
+        )}
+        {isStreaming && !isTruncated && (
+          <span
+            className="inline-block w-[2px] h-[1em] ml-[1px] align-middle bg-current animate-blink"
+            aria-hidden="true"
+          />
+        )}
+      </div>
+    </article>
+  );
+}
+
+// ─── TypingIndicator ──────────────────────────────────────────────────────────
+
+function TypingIndicator() {
+  return (
+    <div
+      className="flex justify-start my-1"
+      aria-label="Copilot 正在輸入"
+      aria-live="assertive"
+    >
+      <div
+        className={cn(
+          "w-14 rounded-lg rounded-bl-sm",
+          "bg-card border border-border",
+          "px-4 py-3 flex items-center gap-1"
+        )}
+      >
+        {[0, 150, 300].map((delay, i) => (
+          <span
+            key={i}
+            className="h-2 w-2 rounded-full bg-fg-muted animate-typing-bounce"
+            style={{ animationDelay: `${delay}ms` }}
+            aria-hidden="true"
+          />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+// ─── SuggestionChip ──────────────────────────────────────────────────────────
+
+function SuggestionChip({
+  label,
+  onSelect,
+}: {
+  label: string;
+  onSelect: (label: string) => void;
+}) {
+  return (
+    <button
+      onClick={() => onSelect(label)}
+      className={cn(
+        "rounded-full border border-border",
+        "bg-secondary text-fg-default text-xs",
+        "px-3 py-1.5 transition-colors duration-150",
+        "hover:bg-secondary-hover focus-visible:outline-none",
+        "focus-visible:ring-2 focus-visible:ring-ring"
+      )}
+    >
+      &ldquo;{label}&rdquo;
+    </button>
+  );
+}
+
+// ─── WelcomeState ─────────────────────────────────────────────────────────────
+
+function WelcomeState({ onSuggestion }: { onSuggestion: (text: string) => void }) {
+  const suggestions = [
+    "Summarize recent entries",
+    "Find duplicate notes",
+    "What did I learn this week?",
+  ];
+
+  return (
+    <div className="flex flex-1 flex-col items-center justify-center gap-4 px-6 py-8">
+      <Bot className="h-12 w-12 text-fg-subtle" aria-hidden="true" />
+      <p className="text-center text-sm text-fg-muted leading-relaxed">
+        Ask me anything about your knowledge base.
+      </p>
+      <div className="flex flex-wrap justify-center gap-2">
+        {suggestions.map((s) => (
+          <SuggestionChip key={s} label={s} onSelect={onSuggestion} />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+// ─── CopilotInputArea ─────────────────────────────────────────────────────────
+
+interface CopilotInputAreaProps {
+  value: string;
+  onChange: (value: string) => void;
+  onSubmit: () => void;
+  isStreaming: boolean;
+}
+
+function CopilotInputArea({
+  value,
+  onChange,
+  onSubmit,
+  isStreaming,
+}: CopilotInputAreaProps) {
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
+  const isDisabled = isStreaming || value.trim() === "";
+
+  // Auto resize textarea
+  useEffect(() => {
+    const ta = textareaRef.current;
+    if (!ta) return;
+    ta.style.height = "auto";
+    ta.style.height = `${Math.min(ta.scrollHeight, 120)}px`;
+  }, [value]);
+
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+    if (e.key === "Enter" && !e.shiftKey) {
+      e.preventDefault();
+      if (!isDisabled) onSubmit();
+    }
+  };
+
+  return (
+    <div className="flex flex-col gap-2 border-t border-border bg-bg-subtle p-3">
+      <textarea
+        ref={textareaRef}
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        onKeyDown={handleKeyDown}
+        aria-label="輸入訊息"
+        aria-multiline="true"
+        placeholder="Ask me anything about your knowledge base."
+        rows={1}
+        className={cn(
+          "w-full resize-none rounded-lg border border-border",
+          "bg-bg-default px-4 py-3 text-sm leading-relaxed",
+          "placeholder:text-fg-subtle",
+          "focus:outline-none focus-visible:ring-2 focus-visible:ring-border-focus",
+          "transition-[height] duration-100",
+          "min-h-[44px] max-h-[120px]"
+        )}
+      />
+      <div className="flex justify-end">
+        <button
+          onClick={onSubmit}
+          disabled={isDisabled}
+          aria-label="送出訊息"
+          className={cn(
+            "flex h-[44px] w-[44px] items-center justify-center rounded-lg",
+            "transition-colors duration-150",
+            "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
+            isDisabled
+              ? "bg-secondary text-fg-muted opacity-50 cursor-not-allowed"
+              : "bg-primary text-primary-fg hover:bg-primary-hover active:bg-primary-active"
+          )}
+        >
+          <SendHorizontal className="h-4 w-4" aria-hidden="true" />
+        </button>
+      </div>
+    </div>
+  );
+}
+
+// ─── MessageList ──────────────────────────────────────────────────────────────
+
+interface MessageListProps {
+  messages: Message[];
+  isStreaming: boolean;
+}
+
+function MessageList({ messages, isStreaming }: MessageListProps) {
+  const bottomRef = useRef<HTMLDivElement>(null);
+  const containerRef = useRef<HTMLDivElement>(null);
+  const userScrolledUp = useRef(false);
+
+  // Detect manual scroll up
+  const handleScroll = () => {
+    const el = containerRef.current;
+    if (!el) return;
+    const isAtBottom = el.scrollHeight - el.scrollTop <= el.clientHeight + 48;
+    userScrolledUp.current = !isAtBottom;
+  };
+
+  // Auto scroll to bottom on new messages unless user scrolled up
+  useEffect(() => {
+    if (!userScrolledUp.current) {
+      bottomRef.current?.scrollIntoView({ behavior: "smooth" });
+    }
+  }, [messages.length, isStreaming]);
+
+  return (
+    <div
+      ref={containerRef}
+      role="log"
+      aria-label="對話記錄"
+      aria-live="polite"
+      onScroll={handleScroll}
+      className="flex flex-1 flex-col overflow-y-auto px-4 py-3"
+    >
+      {messages.map((msg) =>
+        msg.role === "user" ? (
+          <UserMessage key={msg.id} content={msg.content} />
+        ) : (
+          <AssistantMessage
+            key={msg.id}
+            content={msg.content}
+            isStreaming={msg.isStreaming}
+            isTruncated={msg.isTruncated}
+          />
+        )
+      )}
+      {isStreaming && (
+        <TypingIndicator />
+      )}
+      <div ref={bottomRef} />
+    </div>
+  );
+}
+
+// ─── CopilotPanel（主元件）────────────────────────────────────────────────────
+
+export function CopilotPanel({
+  isOpen,
+  onClose,
+  defaultWidth = 360,
+  minWidth = 240,
+  maxWidth = 600,
+}: CopilotPanelProps) {
+  const [width, setWidth] = useState(defaultWidth);
+  const [inputValue, setInputValue] = useState("");
+  const [messages, setMessages] = useState<Message[]>([]);
+  const [isStreaming, setIsStreaming] = useState(false);
+
+  // ResizeHandle callback
+  const handleResize = useCallback(
+    (delta: number) => {
+      setWidth((prev) => Math.min(maxWidth, Math.max(minWidth, prev + delta)));
+    },
+    [minWidth, maxWidth]
+  );
+
+  // Suggestion chip handler
+  const handleSuggestion = (text: string) => {
+    setInputValue(text);
+  };
+
+  // Send message
+  const handleSubmit = () => {
+    if (!inputValue.trim() || isStreaming) return;
+    const userMsg: Message = {
+      id: crypto.randomUUID(),
+      role: "user",
+      content: inputValue.trim(),
+    };
+    setMessages((prev) => [...prev, userMsg]);
+    setInputValue("");
+    setIsStreaming(true);
+    // engineer 在此實作 SSE 串流（POST + EventSource）
+  };
+
+  // Clear session
+  const handleClearSession = () => {
+    setMessages([]);
+    setIsStreaming(false);
+  };
+
+  return (
+    <>
+      {/* Panel 本體 */}
+      <aside
+        role="complementary"
+        aria-label="Copilot AI 助手"
+        aria-hidden={!isOpen}
+        style={{ width: isOpen ? width : 0 }}
+        className={cn(
+          "relative flex h-full flex-col",
+          "border-l border-border bg-bg-subtle",
+          "overflow-hidden",
+          // 開關動畫
+          "transition-[width,transform] duration-300 ease-out",
+          !isOpen && "transition-[width,transform] duration-200 ease-in"
+        )}
+      >
+        {/* ResizeHandle（面板左側） */}
+        <ResizeHandle onResize={handleResize} />
+
+        {/* Header */}
+        <CopilotHeader
+          onClose={onClose}
+          onClearSession={handleClearSession}
+        />
+
+        {/* Content */}
+        {messages.length === 0 && !isStreaming ? (
+          <WelcomeState onSuggestion={handleSuggestion} />
+        ) : (
+          <MessageList messages={messages} isStreaming={isStreaming} />
+        )}
+
+        {/* InputArea */}
+        <CopilotInputArea
+          value={inputValue}
+          onChange={setInputValue}
+          onSubmit={handleSubmit}
+          isStreaming={isStreaming}
+        />
+      </aside>
+    </>
+  );
+}
+
+// ─── 使用場景示範 ──────────────────────────────────────────────────────────────
+
+// 1. App Shell Layout（在 dev/src/app/(shell)/layout.tsx 中整合）
+//
+// import { useCopilotStore } from "@/stores/copilot";
+// import { CopilotPanel } from "@/components/copilot-panel";
+//
+// export default function ShellLayout({ children }) {
+//   const { isOpen, close } = useCopilotStore();
+//   return (
+//     <div className="flex h-screen">
+//       <Sidebar />
+//       <main className="flex-1 overflow-hidden">{children}</main>
+//       <CopilotPanel isOpen={isOpen} onClose={close} />
+//     </div>
+//   );
+// }
+
+// 2. 開啟面板（⌘J 快捷鍵由 useKeyboardShortcuts hook 觸發）
+//
+// const { open } = useCopilotStore();
+// open(); // → isOpen = true → CopilotPanel 滑入
+
+// 3. Streaming 訊息更新（SSE token 事件，由 engineer 實作）
+//
+// eventSource.addEventListener("token", (e) => {
+//   const { token } = JSON.parse(e.data);
+//   // 更新最後一則 AssistantMessage 的 content
+// });
+// eventSource.addEventListener("done", () => {
+//   setIsStreaming(false);
+//   // 移除 isStreaming flag from last message
+// });

--- a/design/components/copilot-panel/spec.md
+++ b/design/components/copilot-panel/spec.md
@@ -1,0 +1,264 @@
+# CopilotPanel
+
+## 用途
+App Shell 右側的 resizable AI 對話面板。使用者可透過 ⌘J 或 sidebar icon 開關，並與知識庫進行上下文對話。面板不遮蓋主內容區，而是將主內容擠縮。
+
+## 子元件
+
+### CopilotPanel（容器）
+
+**視覺結構**
+
+```
+┌─────────────────────┐
+│  CopilotHeader      │  高度 52px
+├─────────────────────┤
+│                     │
+│  MessageList        │  flex-1，overflow-y: auto
+│  （虛擬化捲動）     │
+│   ┌───────────────┐ │
+│   │ AssistantMsg  │ │  左對齊
+│   └───────────────┘ │
+│         ┌──────────┐│
+│         │ UserMsg  ││  右對齊
+│         └──────────┘│
+│   ┌───────────────┐ │
+│   │ TypingIndicator│ │  streaming 中顯示
+│   └───────────────┘ │
+│                     │
+├─────────────────────┤
+│  InputArea          │  min-height 68px
+└─────────────────────┘
+   ↑
+   ResizeHandle（左側，垂直線，可拖拽）
+```
+
+**尺寸**
+- 預設寬度：360px
+- 最小寬度：240px
+- 最大寬度：600px
+- 高度：100%（填滿 shell 高度，排除 Navbar）
+
+**色彩（Token）**
+- Panel 背景：`color.bg.subtle`（輕度區分主內容區）
+- 左側邊框：`color.border.default`（1px）
+- ResizeHandle 顏色：`color.border.strong`
+
+**動畫**
+- 開啟：右側滑入，`transform: translateX(100%) → translateX(0)`，`300ms ease-out`
+- 關閉：右側滑出，`transform: translateX(0) → translateX(100%)`，`200ms ease-in`
+- 尊重 `prefers-reduced-motion`（僅用 opacity 替代）
+
+**Props**
+| Prop | Type | Default | 說明 |
+|------|------|---------|------|
+| isOpen | boolean | false | 面板開關狀態 |
+| onClose | () => void | - | 關閉回調 |
+| defaultWidth | number | 360 | 初始寬度（px） |
+| minWidth | number | 240 | 最小寬度（px） |
+| maxWidth | number | 600 | 最大寬度（px） |
+
+---
+
+### CopilotHeader
+
+**視覺結構**
+```
+┌─────────────────────────────────────┐
+│ [BotIcon] Copilot   [clear] [×]     │
+└─────────────────────────────────────┘
+```
+
+**規格**
+- 高度：52px
+- 標題：`font.size.sm`，`font.weight.semibold`，`color.fg.default`
+- BotIcon：Lucide `Bot`，`w-4 h-4`，`color.fg.muted`
+- "Clear session" 連結：`font.size.xs`，`color.fg.muted`，hover 時 `color.fg.default`
+- 關閉按鈕：Lucide `X`，`w-4 h-4`，觸控目標 44×44px，hover `color.fg.default`
+- 底部邊框：`color.border.default`
+
+**Accessibility**
+- 關閉按鈕：`aria-label="關閉 Copilot 面板"`
+- Clear session 按鈕：`aria-label="清除對話記錄"`
+
+---
+
+### UserMessage
+
+**視覺結構**
+```
+                    ┌──────────────────┐
+                    │ 使用者訊息文字   │
+                    └──────────────────┘
+```
+
+**規格**
+- 對齊：右對齊（`justify-end`）
+- 氣泡背景：`color.primary.default`
+- 氣泡文字：`color.primary.fg`
+- Border-radius：`radius.lg radius.lg radius.sm radius.lg`（左下角小）
+- Padding：`spacing.3 spacing.4`
+- 最大寬度：80%
+- Font size：`font.size.sm`
+- Line height：`font.lineHeight.relaxed`
+- Margin：`spacing.1`（上下）
+
+---
+
+### AssistantMessage
+
+**視覺結構**
+```
+┌──────────────────┐
+│ AI 回應文字|     │  ← `|` 為游標（streaming 中 blink）
+└──────────────────┘
+```
+
+**規格**
+- 對齊：左對齊（`justify-start`）
+- 氣泡背景：`color.card.default`
+- 氣泡文字：`color.fg.default`
+- 氣泡邊框：`color.border.default`（1px）
+- Border-radius：`radius.lg radius.lg radius.lg radius.sm`（左下角小）
+- Padding：`spacing.3 spacing.4`
+- 最大寬度：85%
+- Font size：`font.size.sm`
+- Line height：`font.lineHeight.relaxed`
+
+**Streaming 游標**
+- 字元：`|`（U+007C vertical bar）
+- 動畫：CSS `@keyframes blink`，`opacity 1 → 0 → 1`，`1s step-start infinite`
+- 游標 class：`inline-block w-[2px] h-[1em] ml-[1px] align-middle bg-current animate-blink`
+- `prefers-reduced-motion`：游標靜止不動
+
+**狀態**
+| 狀態 | 外觀 |
+|------|------|
+| streaming | 尾端顯示 blink 游標 |
+| 截斷（Panel 關閉中斷） | 文字末尾顯示 "…"（`<span className="text-fg-muted">…</span>`） |
+| 完成 | 無游標 |
+
+---
+
+### TypingIndicator
+
+**視覺結構**
+```
+┌──────────────────┐
+│ • • •            │  三點以不同相位 bounce
+└──────────────────┘
+```
+
+**規格**
+- 氣泡大小：與 AssistantMessage 相同樣式
+- 寬度：56px（固定）
+- 三個點：`w-2 h-2`，`border-radius: full`，`color.fg.muted`
+- 動畫：`@keyframes typingBounce`，各點 delay 0ms / 150ms / 300ms
+  - `transform: translateY(0) → translateY(-6px) → translateY(0)`，`600ms ease-in-out infinite`
+- `prefers-reduced-motion`：靜止顯示三點（無動畫）
+- 顯示條件：`isStreaming === true`，以 `AnimatePresence`（framer-motion）或 CSS `transition` 淡入淡出
+
+---
+
+### CopilotInputArea
+
+**視覺結構**
+```
+┌─────────────────────────────────────┐
+│  ┌───────────────────────────────┐  │
+│  │ Textarea（Enter 送出）        │  │
+│  └───────────────────────────────┘  │
+│                         [SendButton]│
+└─────────────────────────────────────┘
+```
+
+**Textarea 規格**
+- 高度：min 44px，max 120px，auto resize
+- Font size：`font.size.sm`
+- Placeholder：`"Ask me anything about your knowledge base."`（顏色 `color.fg.subtle`）
+- Padding：`spacing.3 spacing.4`
+- Background：`color.bg.default`
+- Border：`color.border.default`（1px）
+- Border-radius：`radius.lg`
+- Focus ring：`color.border.focus`（2px）
+- 行為：Enter 送出，Shift+Enter 換行
+
+**SendButton 規格**
+- Icon：Lucide `SendHorizontal`，`w-4 h-4`
+- Size：44×44px（觸控目標）
+- 顏色（正常）：`color.primary.default` 背景，`color.primary.fg` icon
+- 顏色（disabled）：`color.secondary.default` 背景，`color.fg.muted` icon，`opacity-50`
+- Border-radius：`radius.lg`
+- 禁用條件：`isStreaming === true` 或 textarea 為空
+- `aria-label="送出訊息"`
+
+**區域整體**
+- 頂部邊框：`color.border.default`（1px）
+- Padding：`spacing.3`
+- Background：`color.bg.subtle`
+
+---
+
+### Empty / Welcome State
+
+**視覺結構**
+```
+┌─────────────────────────────────────┐
+│                                     │
+│      [BotIcon 48px]                 │
+│   Ask me anything about your        │
+│   knowledge base.                   │
+│                                     │
+│   ┌────────────────────────────┐    │
+│   │ "Summarize recent entries" │    │  ← 建議提示 chip
+│   └────────────────────────────┘    │
+└─────────────────────────────────────┘
+```
+
+**規格**
+- 垂直居中，`flex flex-col items-center gap-4`
+- Icon：Lucide `Bot`，`w-12 h-12`，`color.fg.subtle`
+- 主文字：`font.size.sm`，`color.fg.muted`，居中
+- Suggestion chips：
+  - 背景：`color.secondary.default`
+  - 文字：`color.fg.default`，`font.size.xs`
+  - Border：`color.border.default`
+  - Border-radius：`radius.full`
+  - Padding：`spacing.1.5 spacing.3`
+  - 點擊後填入 textarea
+
+## States
+
+| 狀態 | 外觀描述 |
+|------|---------|
+| 關閉 | Panel 不可見，translateX(100%) |
+| 開啟（空） | 顯示 Welcome state |
+| 對話中（正常） | MessageList 顯示訊息記錄 |
+| Streaming | TypingIndicator 可見，SendButton disabled |
+| SSE 連線失敗 | Toast 通知，InputArea 仍可操作（允許重試） |
+
+## Accessibility
+
+- Panel container：`role="complementary"`，`aria-label="Copilot AI 助手"`
+- MessageList：`role="log"`，`aria-live="polite"`，`aria-label="對話記錄"`
+- 每則訊息：`role="article"`
+- UserMessage：`aria-label="你：{content}"`
+- AssistantMessage：`aria-label="Copilot：{content}"`（streaming 中附加 `aria-busy="true"`）
+- TypingIndicator：`aria-label="Copilot 正在輸入"`，`aria-live="assertive"`
+- InputArea Textarea：`aria-label="輸入訊息"`，`aria-multiline="true"`
+- 面板開關：鍵盤 ⌘J，Escape 關閉
+- focus trap：面板開啟時 Tab 鍵限定在面板內
+
+## ResizeHandle
+
+**規格**
+- 位置：面板左邊緣
+- 寬度：8px 可拖拽熱區（視覺上 2px 線條）
+- 游標：`col-resize`
+- 顏色：透明背景，hover 時顯示 `color.border.focus`（2px 線）
+- 拖拽時：`user-select: none`，全域 `mousemove` + `mouseup` listener
+- `aria-label="調整面板寬度"`，`role="separator"`，`aria-orientation="vertical"`
+
+## 使用範例
+
+見 `example.tsx`

--- a/design/components/shortcuts-modal/example.tsx
+++ b/design/components/shortcuts-modal/example.tsx
@@ -1,0 +1,305 @@
+// ShortcutsModal — 使用範例
+// 技術選型：Next.js 14 + shadcn/ui Dialog + Tailwind CSS v4
+// 圖示套件：Lucide React
+
+import { useEffect } from "react";
+import { Keyboard, X } from "lucide-react";
+import { cn } from "@/lib/utils";
+
+// ─── Types ───────────────────────────────────────────────────────────────────
+
+interface ShortcutItem {
+  description: string;
+  keys: string[];
+  ariaLabels?: string[];
+}
+
+interface ShortcutSection {
+  id: string;
+  title: string;
+  shortcuts: ShortcutItem[];
+}
+
+// ─── 快捷鍵資料 ───────────────────────────────────────────────────────────────
+
+const SHORTCUT_SECTIONS: ShortcutSection[] = [
+  {
+    id: "navigation",
+    title: "Navigation",
+    shortcuts: [
+      { description: "Open Command Palette", keys: ["⌘", "K"], ariaLabels: ["Command", "K"] },
+      { description: "Open / Close Copilot", keys: ["⌘", "J"], ariaLabels: ["Command", "J"] },
+      { description: "Go to Inbox", keys: ["G", "I"] },
+      { description: "Go to Library", keys: ["G", "L"] },
+      { description: "Go to Today", keys: ["G", "T"] },
+      { description: "Go to Canvas", keys: ["G", "C"] },
+      { description: "Go to Settings", keys: ["G", "S"] },
+      { description: "Shortcuts Help", keys: ["?"] },
+      { description: "Close Overlay", keys: ["Esc"] },
+    ],
+  },
+  {
+    id: "inbox",
+    title: "Inbox",
+    shortcuts: [
+      { description: "Next item", keys: ["J"] },
+      { description: "Previous item", keys: ["K"] },
+      { description: "Expand / Edit", keys: ["Enter"] },
+      { description: "Archive", keys: ["A"] },
+      { description: "Delete", keys: ["D"] },
+      { description: "Quick edit title", keys: ["E"] },
+      { description: "Multi-select toggle", keys: ["Space"] },
+    ],
+  },
+  {
+    id: "library",
+    title: "Library",
+    shortcuts: [
+      { description: "Move up / down", keys: ["J", "/", "K"] },
+      { description: "Open detail", keys: ["Enter"] },
+      { description: "Focus search", keys: ["/"] },
+      { description: "Clear search / Close sheet", keys: ["Esc"] },
+    ],
+  },
+  {
+    id: "entry",
+    title: "Entry",
+    shortcuts: [
+      { description: "Enter edit mode", keys: ["E"] },
+      { description: "Save", keys: ["⌘", "S"], ariaLabels: ["Command", "S"] },
+      { description: "Close sheet", keys: ["Esc"] },
+    ],
+  },
+  {
+    id: "copilot",
+    title: "Copilot",
+    shortcuts: [
+      { description: "Send message", keys: ["Enter"] },
+      { description: "New line", keys: ["Shift", "Enter"] },
+      { description: "Open Command Palette", keys: ["⌘", "K"], ariaLabels: ["Command", "K"] },
+    ],
+  },
+];
+
+// ─── Kbd 元件（沿用 design/components/kbd/spec.md） ──────────────────────────
+
+interface KbdProps {
+  children: React.ReactNode;
+  ariaLabel?: string;
+}
+
+function Kbd({ children, ariaLabel }: KbdProps) {
+  return (
+    <kbd
+      aria-label={ariaLabel}
+      className={cn(
+        "font-mono text-xs text-fg-muted",
+        "bg-bg-muted border border-border rounded",
+        "px-1.5 py-0.5",
+        "shadow-[0_1px_0_0_var(--border)]",
+        "inline-flex items-center justify-center",
+        "min-w-[20px] h-[24px]"
+      )}
+    >
+      {children}
+    </kbd>
+  );
+}
+
+// ─── ShortcutRow ──────────────────────────────────────────────────────────────
+
+function ShortcutRow({ item }: { item: ShortcutItem }) {
+  return (
+    <div
+      className={cn(
+        "flex min-h-[40px] items-center gap-4",
+        "rounded-md px-2 py-1.5",
+        "transition-colors duration-100",
+        "hover:bg-bg-subtle"
+      )}
+    >
+      {/* 描述文字 */}
+      <span className="flex-1 text-sm text-fg-default">{item.description}</span>
+
+      {/* Kbd 組合 */}
+      <span className="flex items-center gap-1" aria-hidden="true">
+        {item.keys.map((key, i) => {
+          // "/" 在 Library section 用作分隔符，不渲染為 Kbd
+          if (key === "/" && item.keys.length === 3 && i === 1) {
+            return (
+              <span key={i} className="text-xs text-fg-muted mx-0.5">
+                /
+              </span>
+            );
+          }
+          return (
+            <Kbd key={i} ariaLabel={item.ariaLabels?.[i]}>
+              {key}
+            </Kbd>
+          );
+        })}
+      </span>
+
+      {/* screen reader 用完整描述（可選） */}
+      <span className="sr-only">
+        {item.description}: {item.keys.join(" + ")}
+      </span>
+    </div>
+  );
+}
+
+// ─── ShortcutSection ──────────────────────────────────────────────────────────
+
+function ShortcutSectionBlock({ section }: { section: ShortcutSection }) {
+  return (
+    <section aria-labelledby={`shortcuts-section-${section.id}`}>
+      <h3
+        id={`shortcuts-section-${section.id}`}
+        className={cn(
+          "mb-2 pb-1 border-b border-border",
+          "text-xs font-semibold uppercase tracking-wider text-fg-subtle"
+        )}
+      >
+        {section.title}
+      </h3>
+      <div className="flex flex-col">
+        {section.shortcuts.map((item, i) => (
+          <ShortcutRow key={i} item={item} />
+        ))}
+      </div>
+    </section>
+  );
+}
+
+// ─── ShortcutsModal ───────────────────────────────────────────────────────────
+
+interface ShortcutsModalProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+export function ShortcutsModal({ open, onOpenChange }: ShortcutsModalProps) {
+  // Keyboard close（Escape）
+  useEffect(() => {
+    if (!open) return;
+    const handler = (e: KeyboardEvent) => {
+      if (e.key === "Escape") {
+        e.preventDefault();
+        onOpenChange(false);
+      }
+    };
+    document.addEventListener("keydown", handler);
+    return () => document.removeEventListener("keydown", handler);
+  }, [open, onOpenChange]);
+
+  if (!open) return null;
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center">
+      {/* Overlay */}
+      <div
+        className="absolute inset-0 bg-overlay backdrop-blur-sm"
+        onClick={() => onOpenChange(false)}
+        aria-hidden="true"
+      />
+
+      {/* Dialog */}
+      <div
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="shortcuts-modal-title"
+        className={cn(
+          "relative z-10 w-full max-w-xl rounded-xl",
+          "bg-card border border-border shadow-lg",
+          "flex flex-col max-h-[80vh]",
+          "animate-in zoom-in-95 fade-in duration-150",
+          "@media (prefers-reduced-motion: reduce) animate-in:opacity-0 animate-in:fade-in"
+        )}
+      >
+        {/* Header */}
+        <div
+          className={cn(
+            "flex h-[56px] items-center gap-2 border-b border-border px-6",
+            "shrink-0"
+          )}
+        >
+          <Keyboard className="h-4 w-4 text-fg-muted" aria-hidden="true" />
+          <h2
+            id="shortcuts-modal-title"
+            className="flex-1 text-base font-semibold text-fg-default"
+          >
+            Keyboard Shortcuts
+          </h2>
+          <button
+            onClick={() => onOpenChange(false)}
+            aria-label="關閉快捷鍵說明"
+            className={cn(
+              "flex h-[44px] w-[44px] items-center justify-center rounded-lg",
+              "text-fg-muted transition-colors duration-150",
+              "hover:text-fg-default hover:bg-secondary",
+              "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+            )}
+          >
+            <X className="h-4 w-4" aria-hidden="true" />
+          </button>
+        </div>
+
+        {/* Content */}
+        <div className="flex flex-col gap-6 overflow-y-auto px-6 py-5">
+          {SHORTCUT_SECTIONS.map((section) => (
+            <ShortcutSectionBlock key={section.id} section={section} />
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// ─── 使用場景示範 ──────────────────────────────────────────────────────────────
+
+// 1. App Shell 中整合（useKeyboardShortcuts hook 觸發）
+//
+// const [shortcutsOpen, setShortcutsOpen] = useState(false);
+//
+// // ? 鍵觸發（非 input focus 狀態）
+// useEffect(() => {
+//   const handler = (e: KeyboardEvent) => {
+//     if (e.key === "?" && !isInputFocused()) {
+//       e.preventDefault();
+//       setShortcutsOpen(true);
+//     }
+//   };
+//   document.addEventListener("keydown", handler);
+//   return () => document.removeEventListener("keydown", handler);
+// }, []);
+//
+// <ShortcutsModal open={shortcutsOpen} onOpenChange={setShortcutsOpen} />
+
+// 2. CmdK "> help" 觸發
+//   選中 AI Actions 中的 "help"
+//   → setShortcutsOpen(true)
+
+// 3. 自訂 sections（新增 feature 後擴充）
+//   在 SHORTCUT_SECTIONS 陣列新增 section 即可自動渲染
+//   不需修改元件本體
+
+// ─── Kbd 單獨使用示範 ─────────────────────────────────────────────────────────
+
+// 在任何元件中引入 Kbd：
+// <Kbd ariaLabel="Command K">⌘</Kbd>
+// <Kbd>K</Kbd>
+
+// 組合快捷鍵：
+// <span className="flex items-center gap-1">
+//   <Kbd ariaLabel="Command">⌘</Kbd>
+//   <Kbd>K</Kbd>
+// </span>
+
+// 在 Tooltip 中使用：
+// <TooltipContent>
+//   Open Command Palette
+//   <span className="flex items-center gap-1 ml-2">
+//     <Kbd ariaLabel="Command">⌘</Kbd>
+//     <Kbd>K</Kbd>
+//   </span>
+// </TooltipContent>

--- a/design/components/shortcuts-modal/spec.md
+++ b/design/components/shortcuts-modal/spec.md
@@ -1,0 +1,230 @@
+# ShortcutsModal
+
+## 用途
+以 Dialog 呈現 App 所有鍵盤快捷鍵的視覺總覽。`?` 鍵觸發，Escape 或 × 按鈕關閉。快捷鍵以 `Kbd` 元件渲染，依功能分為 5 個 Section。
+
+## 觸發方式
+- 鍵盤：`?`（全域，非 input focus 狀態）
+- CmdK 中輸入 `> help`
+- AI Action "help" 選項
+
+## 視覺結構
+
+```
+┌──────────────────────────────────────────────────┐
+│  Keyboard Shortcuts                          [×]  │  ← Dialog header，height 56px
+├──────────────────────────────────────────────────┤
+│                                                  │
+│  Navigation                                      │  ← Section heading
+│  ┌────────────────────────────────────────────┐  │
+│  │ Open Command Palette      [⌘] [K]          │  │  ← ShortcutRow
+│  │ Open/Close Copilot        [⌘] [J]          │  │
+│  │ Go to Inbox               [G] [I]          │  │
+│  │ Go to Library             [G] [L]          │  │
+│  │ Go to Today               [G] [T]          │  │
+│  │ Go to Canvas              [G] [C]          │  │
+│  │ Go to Settings            [G] [S]          │  │
+│  │ Shortcuts Help            [?]              │  │
+│  │ Close Overlay             [Esc]            │  │
+│  └────────────────────────────────────────────┘  │
+│                                                  │
+│  Inbox                                           │
+│  ┌────────────────────────────────────────────┐  │
+│  │ Next item                 [J]              │  │
+│  │ Previous item             [K]              │  │
+│  │ Expand/Edit               [Enter]          │  │
+│  │ Archive                   [A]              │  │
+│  │ Delete                    [D]              │  │
+│  │ Quick edit title          [E]              │  │
+│  │ Multi-select toggle       [Space]          │  │
+│  └────────────────────────────────────────────┘  │
+│                                                  │
+│  Library                                         │
+│  ┌────────────────────────────────────────────┐  │
+│  │ Move up/down              [J] / [K]        │  │
+│  │ Open detail               [Enter]          │  │
+│  │ Focus search              [/]              │  │
+│  │ Clear search / Close sheet [Esc]           │  │
+│  └────────────────────────────────────────────┘  │
+│                                                  │
+│  Entry                                           │
+│  ┌────────────────────────────────────────────┐  │
+│  │ Enter edit mode           [E]              │  │
+│  │ Save                      [⌘] [S]          │  │
+│  │ Close sheet               [Esc]            │  │
+│  └────────────────────────────────────────────┘  │
+│                                                  │
+│  Copilot                                         │
+│  ┌────────────────────────────────────────────┐  │
+│  │ Send message              [Enter]          │  │
+│  │ New line                  [Shift] [Enter]  │  │
+│  │ Open Command Palette      [⌘] [K]          │  │
+│  └────────────────────────────────────────────┘  │
+│                                                  │
+└──────────────────────────────────────────────────┘
+```
+
+## 尺寸
+
+- Dialog 寬度：`560px`（`max-w-xl`）
+- 最大高度：`80vh`，內容區 `overflow-y: auto`
+- Section 間距：`spacing.6`（24px）
+
+## ShortcutRow
+
+**視覺結構**
+```
+描述文字                     [Kbd] [Kbd]
+```
+
+**規格**
+- 高度：40px（min-height）
+- 描述文字：`font.size.sm`，`color.fg.default`，`flex-1`
+- Kbd 組合：`flex gap-1`，右側對齊
+- 偶數行背景：無差異（統一 `color.bg.default`）
+- Hover：`color.bg.subtle`，`border-radius: radius.md`
+- Padding：`spacing.1.5 spacing.2`
+
+## Kbd 元件規格（沿用 design/components/kbd/spec.md）
+
+| 屬性 | 值 |
+|------|-----|
+| 標籤 | 語義化 `<kbd>` HTML element |
+| 字型 | `font.family.mono` |
+| 字級 | `font.size.xs`（12px） |
+| 顏色 | `color.fg.muted` |
+| 背景 | `color.bg.muted` |
+| 邊框 | `color.border.default`（1px） |
+| 底部陰影 | `0 1px 0 0 color.border.default`（立體感） |
+| Border-radius | `radius.sm`（4px） |
+| Padding | `px-1.5 py-0.5` |
+
+**特殊 Kbd 字元對照**
+
+| 按鍵 | 顯示字元 | aria-label |
+|------|---------|------------|
+| Command（macOS） | `⌘` | "Command" |
+| Shift | `Shift` | "Shift" |
+| Enter | `↵` 或 `Enter` | "Enter" |
+| Escape | `Esc` | "Escape" |
+| Space | `Space` | "Space" |
+| Slash | `/` | "Slash" |
+| Question mark | `?` | "Question mark" |
+| Arrow keys | `↑` `↓` `←` `→` | "Up / Down / Left / Right arrow" |
+| Sequential G | `G` 後加 `→` 符號則用兩個 Kbd | - |
+
+## Section Heading
+
+- Font：`font.size.xs`，`font.weight.semibold`，`letter-spacing: wider`，uppercase
+- Color：`color.fg.subtle`
+- Margin-bottom：`spacing.2`
+- Padding-bottom：`spacing.1`
+- 底部邊框：`color.border.default`（1px）
+
+## Dialog Header
+
+- 高度：56px
+- 標題：Lucide `Keyboard`（`w-4 h-4`，`color.fg.muted`）+ "Keyboard Shortcuts"，`font.size.base`，`font.weight.semibold`
+- 關閉按鈕：Lucide `X`，44×44px 觸控目標，`aria-label="關閉快捷鍵說明"`
+- 底部邊框：`color.border.default`
+
+## 動畫
+
+- Dialog open：`scale(0.96) opacity 0 → scale(1) opacity 1`，`150ms ease`
+- Dialog close：反向，`100ms ease`
+- 尊重 `prefers-reduced-motion`（只用 opacity）
+
+## Props
+
+| Prop | Type | Default | 說明 |
+|------|------|---------|------|
+| open | boolean | false | 控制開關 |
+| onOpenChange | (open: boolean) => void | - | 狀態回調 |
+
+## Accessibility
+
+- `role="dialog"`，`aria-modal="true"`，`aria-labelledby="shortcuts-modal-title"`
+- 開啟時 focus trap，第一個 focusable 元素為關閉按鈕
+- Escape 鍵關閉
+- 每個 `<kbd>` 元素包含 `aria-label` 說明完整按鍵名稱
+- Section heading 以 `<h3>` 語義標籤
+- 複合快捷鍵（如 ⌘K）：`aria-label="Command K"`
+
+## 快捷鍵資料結構
+
+```typescript
+interface ShortcutSection {
+  id: string;
+  title: string;
+  shortcuts: ShortcutItem[];
+}
+
+interface ShortcutItem {
+  description: string;
+  keys: string[];         // 顯示在 Kbd 中的字串陣列
+  ariaLabels?: string[];  // 對應每個 key 的 aria-label
+}
+
+const SHORTCUT_SECTIONS: ShortcutSection[] = [
+  {
+    id: "navigation",
+    title: "Navigation",
+    shortcuts: [
+      { description: "Open Command Palette", keys: ["⌘", "K"], ariaLabels: ["Command", "K"] },
+      { description: "Open/Close Copilot", keys: ["⌘", "J"], ariaLabels: ["Command", "J"] },
+      { description: "Go to Inbox", keys: ["G", "I"] },
+      { description: "Go to Library", keys: ["G", "L"] },
+      { description: "Go to Today", keys: ["G", "T"] },
+      { description: "Go to Canvas", keys: ["G", "C"] },
+      { description: "Go to Settings", keys: ["G", "S"] },
+      { description: "Shortcuts Help", keys: ["?"] },
+      { description: "Close Overlay", keys: ["Esc"] },
+    ],
+  },
+  {
+    id: "inbox",
+    title: "Inbox",
+    shortcuts: [
+      { description: "Next item", keys: ["J"] },
+      { description: "Previous item", keys: ["K"] },
+      { description: "Expand / Edit", keys: ["Enter"] },
+      { description: "Archive", keys: ["A"] },
+      { description: "Delete", keys: ["D"] },
+      { description: "Quick edit title", keys: ["E"] },
+      { description: "Multi-select toggle", keys: ["Space"] },
+    ],
+  },
+  {
+    id: "library",
+    title: "Library",
+    shortcuts: [
+      { description: "Move up / down", keys: ["J", "/", "K"] },
+      { description: "Open detail", keys: ["Enter"] },
+      { description: "Focus search", keys: ["/"] },
+      { description: "Clear search / Close sheet", keys: ["Esc"] },
+    ],
+  },
+  {
+    id: "entry",
+    title: "Entry",
+    shortcuts: [
+      { description: "Enter edit mode", keys: ["E"] },
+      { description: "Save", keys: ["⌘", "S"], ariaLabels: ["Command", "S"] },
+      { description: "Close sheet", keys: ["Esc"] },
+    ],
+  },
+  {
+    id: "copilot",
+    title: "Copilot",
+    shortcuts: [
+      { description: "Send message", keys: ["Enter"] },
+      { description: "New line", keys: ["Shift", "Enter"] },
+      { description: "Open Command Palette", keys: ["⌘", "K"], ariaLabels: ["Command", "K"] },
+    ],
+  },
+];
+```
+
+## 使用範例
+
+見 `example.tsx`

--- a/design/pages/f047-copilot.md
+++ b/design/pages/f047-copilot.md
@@ -1,0 +1,198 @@
+# F-047 Copilot 整合 Layout
+
+## 對應 Feature
+#232 F-047: Copilot Side Panel
+
+## 概述
+Copilot Panel 整合於 App Shell 的右側 slot，與 Sidebar + 主內容區並排。Panel 開啟時，主內容區縮小（不遮蓋）。CmdK Power Actions 和 ShortcutsModal 以 Portal 方式覆蓋在所有層級之上。
+
+---
+
+## 全局 Layout（Panel 關閉）
+
+```
+┌─────────────────────────────────────────────────────────┐
+│  Navbar（height: 64px，full width）                      │
+├──────────┬──────────────────────────────────────────────┤
+│ Sidebar  │  Main Content Area                          │
+│ (240px   │  （flex-1，overflow hidden）                 │
+│  fixed)  │                                             │
+│          │   ┌─────────────────────────────────────┐  │
+│ - Inbox  │   │ Page Content                        │  │
+│ - Library│   │（各 feature 頁面在此渲染）           │  │
+│ - Today  │   └─────────────────────────────────────┘  │
+│ - Canvas │                                             │
+│ ──────── │                                             │
+│ [Copilot]│                                             │  ← Copilot icon（Lucide Bot）
+│ [Settings]                                             │
+└──────────┴──────────────────────────────────────────────┘
+```
+
+---
+
+## 全局 Layout（Panel 開啟，預設 360px）
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│  Navbar（height: 64px，full width）                              │
+├──────────┬───────────────────────────────┬─────────────────────┤
+│ Sidebar  │  Main Content Area            │  CopilotPanel       │
+│ (240px)  │  （flex-1，縮小）              │  (360px，預設)      │
+│          │                               │  ← ResizeHandle     │
+│          │  ┌─────────────────────────┐  │                     │
+│          │  │ Page Content            │  │  CopilotHeader      │
+│          │  └─────────────────────────┘  │  ─────────────────  │
+│          │                               │  MessageList        │
+│          │                               │  （scroll area）    │
+│          │                               │  ─────────────────  │
+│          │                               │  InputArea          │
+└──────────┴───────────────────────────────┴─────────────────────┘
+```
+
+---
+
+## 響應式行為
+
+| 斷點 | Sidebar | Main Content | CopilotPanel |
+|------|---------|-------------|-------------|
+| >= 1280px (xl) | 固定 240px | flex-1 | 固定 360px（預設），可 resize |
+| 1024-1279px (lg) | 固定 240px | flex-1 | 固定 360px，可能擠壓 main content |
+| 768-1023px (md) | 收合（icon only 64px）或漢堡選單 | flex-1 | 360px（覆蓋模式，overlay） |
+| < 768px (sm) | 隱藏，漢堡選單 | 全寬 | 全屏 bottom sheet 模式（100vw × 75vh）|
+
+**Mobile（< 768px）Copilot 模式**：
+- Panel 以 bottom sheet 方式從底部滑入，`height: 75vh`
+- ResizeHandle 改為 drag handle bar（水平，置頂）
+- 主內容區完全被遮蓋（不縮小）
+
+---
+
+## Z-index 層級
+
+| 元素 | z-index |
+|------|---------|
+| Navbar | 40 |
+| Sidebar（mobile overlay） | 50 |
+| CopilotPanel（desktop） | 30（inline，不需 z-index） |
+| CopilotPanel（mobile bottom sheet） | 60 |
+| CmdK Dialog | 70 |
+| QuickCreateModal | 75 |
+| ShortcutsModal | 70 |
+| Toast | 80 |
+
+---
+
+## Sidebar Copilot Icon
+
+**位置**：Sidebar 底部，Settings icon 上方
+
+**規格**：
+- Icon：Lucide `Bot`，`w-5 h-5`
+- 標籤：`"Copilot"`
+- 觸控目標：44×44px（最小）
+- 激活狀態（Panel 開啟）：`color.sidebar.active-bg`，`color.sidebar.active-fg`
+- Keyboard shortcut hint：Tooltip 顯示 `⌘J`
+- `aria-label="開啟 Copilot AI 助手"`，`aria-pressed="true/false"`（反映 Panel 狀態）
+
+---
+
+## CmdK（⌘K）覆蓋層
+
+**覆蓋所有內容**（包含 Sidebar、Navbar、CopilotPanel）：
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│                                                                 │
+│              ┌──────────────────────────────────┐              │
+│              │ CommandDialog（640px）            │              │
+│              │  [AIModePrefixIndicator]          │              │
+│              │  [CommandInput]                  │              │
+│              │  [CommandList]                   │              │
+│              │  [CommandFooter]                 │              │
+│              └──────────────────────────────────┘              │
+│                                                                 │
+│  [backdrop: bg-overlay backdrop-blur-sm]                       │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+---
+
+## ShortcutsModal 覆蓋層
+
+與 CmdK 相同的覆蓋方式，Dialog 居中：
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│                                                                 │
+│            ┌────────────────────────────────────┐              │
+│            │ ShortcutsModal（560px）             │              │
+│            │  [Header: Keyboard Shortcuts]      │              │
+│            │  [Section: Navigation]             │              │
+│            │  [Section: Inbox]                  │              │
+│            │  ...                               │              │
+│            └────────────────────────────────────┘              │
+│                                                                 │
+│  [backdrop: bg-overlay backdrop-blur-sm]                       │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+---
+
+## 狀態管理（zustand store）
+
+```typescript
+// useCopilotStore（跨路由持久化）
+interface CopilotStore {
+  isOpen: boolean;
+  panelWidth: number;          // 記憶 resize 寬度
+  open(): void;
+  close(): void;
+  toggle(): void;
+  setPanelWidth(w: number): void;
+}
+```
+
+**⌘J 觸發流程**：
+```
+useKeyboardShortcuts（global）
+  → e.key === "j" && e.metaKey
+  → useCopilotStore.toggle()
+  → isOpen 切換
+  → CopilotPanel CSS transition 觸發
+```
+
+---
+
+## 使用到的元件
+
+| 元件 | 路徑 | 說明 |
+|------|------|------|
+| CopilotPanel | `design/components/copilot-panel/` | 右側面板（含所有子元件） |
+| CmdKPower | `design/components/cmdk-power/` | 命令面板（延伸 F-037） |
+| ShortcutsModal | `design/components/shortcuts-modal/` | 快捷鍵總覽 |
+| Sidebar | `design/components/layout-shell/` | 現有 Sidebar（新增 Copilot icon） |
+| Kbd | `design/components/kbd/` | 鍵盤按鍵 badge（ShortcutsModal 中使用） |
+
+---
+
+## 頁面切換時的狀態保持
+
+- CopilotPanel 位於 `app/(shell)/layout.tsx`，路由切換時 **不重新 mount**
+- `useCopilotStore` zustand store 跨路由持久化（`isOpen`、`messages`、`sessionId`）
+- SSE EventSource 連線：Panel 開啟時建立，**路由切換不中斷**，Panel 關閉時才 `es.close()`
+
+---
+
+## Pre-delivery Checklist（此頁面）
+
+| 類別 | 項目 | 狀態 |
+|------|------|------|
+| Accessibility | Copilot Panel `role="complementary"` | 已定義 |
+| Accessibility | MessageList `role="log"` + `aria-live` | 已定義 |
+| Accessibility | Sidebar Copilot icon `aria-pressed` | 已定義 |
+| Interaction | ResizeHandle 44px+ 熱區 | 已定義（8px 視覺，drag area） |
+| Interaction | Panel 開關 300ms ease-out 動畫 | 已定義 |
+| Interaction | Mobile bottom sheet 模式 | 已定義 |
+| Layout | Desktop 並排（Sidebar + Main + Panel） | 已定義 |
+| Layout | Mobile 全屏 bottom sheet | 已定義 |
+| Z-index | CmdK > CopilotPanel > Sidebar | 已定義 |


### PR DESCRIPTION
## Summary

Sprint 16 的 UI component dataset，供前端 engineer 開發 F-047 / F-049 / F-050 使用。

- **CopilotPanel**：右側 resizable drawer 完整規格，包含 ResizeHandle（240-600px 範圍）、CopilotHeader（Clear session + 關閉按鈕）、UserMessage / AssistantMessage 氣泡（blink cursor streaming 動畫）、TypingIndicator（三點 bounce）、CopilotInputArea（Enter 送出 / Shift+Enter 換行 / streaming disabled）、Welcome state（suggestion chips）
- **CmdKPower**：延伸 F-037，分組架構（Navigation / Create / Search Results / AI Actions）、SearchResultItem（icon + title + category badge）、AIActionItem（Sparkles icon + `>` prefix）、AIModePrefixIndicator、QuickCreateModal（TitleInput + ContentTextarea + TagInput + Draft/Classify CTA）
- **ShortcutsModal**：`?` 鍵觸發，5 section Kbd badge grid（Navigation / Inbox / Library / Entry / Copilot），ShortcutRow + Kbd 元件，資料驅動設計

## 檔案

| 元件 | Spec | Example |
|------|------|---------|
| CopilotPanel | `design/components/copilot-panel/spec.md` | `example.tsx` |
| CmdKPower | `design/components/cmdk-power/spec.md` | `example.tsx` |
| ShortcutsModal | `design/components/shortcuts-modal/spec.md` | `example.tsx` |
| Copilot 整合 Layout | `design/pages/f047-copilot.md` | - |

## 設計決策

- 沿用 Sprint 13 editorial paper theme（OKLCH tokens）
- CopilotPanel 背景使用 `color.bg.subtle` 輕度區分主內容區
- Streaming 游標以純 CSS `@keyframes blink`（step-start）實作，尊重 `prefers-reduced-motion`
- QuickCreateModal 獨立 Dialog，CmdK 關閉後再開啟（避免 Dialog 巢狀複雜度）
- ShortcutsModal 資料以 `SHORTCUT_SECTIONS` 常數管理，新增快捷鍵只需修改資料，不動元件本體
- Mobile < 768px CopilotPanel 改為 bottom sheet（full-width，75vh）

Refs #235

🤖 Generated with [Claude Code](https://claude.com/claude-code)