### PR TITLE
[Feature] F-047: Copilot Side Panel

### DIFF
--- a/dev/frontend/__tests__/lib/hooks/use-copilot-sse.test.ts
+++ b/dev/frontend/__tests__/lib/hooks/use-copilot-sse.test.ts
@@ -1,0 +1,157 @@
+/**
+ * Unit tests for useCopilotSSE
+ *
+ * 使用 mock EventSource 驗證：
+ * - Panel 開啟時建立連線
+ * - Panel 關閉時 close() 呼叫
+ * - message / done / error events 觸發正確 store action
+ * - 連線錯誤時觸發指數退避重連（最多 3 次）
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import { useCopilotSSE } from "@/lib/hooks/use-copilot-sse";
+import { useCopilotStore } from "@/lib/stores/copilot-store";
+
+// ──────────────────────────────────────────────────────────────────
+// Mock EventSource
+// ──────────────────────────────────────────────────────────────────
+
+type EventHandler = (e: { data?: string }) => void;
+
+class MockEventSource {
+  static instances: MockEventSource[] = [];
+  url: string;
+  withCredentials: boolean;
+  onerror: (() => void) | null = null;
+  private listeners: Record<string, EventHandler[]> = {};
+  closed = false;
+
+  constructor(url: string, opts?: { withCredentials?: boolean }) {
+    this.url = url;
+    this.withCredentials = opts?.withCredentials ?? false;
+    MockEventSource.instances.push(this);
+  }
+
+  addEventListener(event: string, handler: EventHandler) {
+    if (!this.listeners[event]) this.listeners[event] = [];
+    this.listeners[event].push(handler);
+  }
+
+  /** 測試輔助：模擬 server-sent event */
+  emit(event: string, data?: string) {
+    const handlers = this.listeners[event] ?? [];
+    handlers.forEach((h) => h({ data }));
+  }
+
+  /** 模擬連線錯誤 */
+  triggerError() {
+    this.onerror?.();
+  }
+
+  close() {
+    this.closed = true;
+  }
+}
+
+vi.stubGlobal("EventSource", MockEventSource);
+
+// ──────────────────────────────────────────────────────────────────
+
+function resetStore() {
+  useCopilotStore.setState({
+    isOpen: false,
+    sessionId: null,
+    messages: [],
+    isStreaming: false,
+    error: null,
+  });
+}
+
+describe("useCopilotSSE", () => {
+  beforeEach(() => {
+    MockEventSource.instances = [];
+    resetStore();
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.clearAllTimers();
+  });
+
+  it("Panel 開啟時建立 EventSource 連線", () => {
+    act(() => useCopilotStore.setState({ isOpen: true }));
+    renderHook(() => useCopilotSSE());
+    expect(MockEventSource.instances.length).toBe(1);
+    expect(MockEventSource.instances[0].url).toContain("/api/v1/copilot/stream");
+  });
+
+  it("Panel 關閉時 EventSource.close() 被呼叫", () => {
+    act(() => useCopilotStore.setState({ isOpen: true }));
+    const { rerender } = renderHook(() => useCopilotSSE());
+    const es = MockEventSource.instances[0];
+
+    act(() => useCopilotStore.getState().close());
+    rerender();
+
+    expect(es.closed).toBe(true);
+  });
+
+  it("message event 觸發 appendStreamToken", () => {
+    const appendStreamToken = vi.spyOn(
+      useCopilotStore.getState(),
+      "appendStreamToken",
+    );
+    // 加入 streaming assistant 訊息
+    useCopilotStore.setState({
+      isOpen: true,
+      isStreaming: true,
+      messages: [{ id: "a1", role: "assistant", content: "", isStreaming: true }],
+    });
+
+    renderHook(() => useCopilotSSE());
+    const es = MockEventSource.instances[0];
+
+    act(() => es.emit("message", "hello"));
+    // appendStreamToken 在 store 中直接更新 state，驗證 content
+    const msgs = useCopilotStore.getState().messages;
+    expect(msgs[0].content).toBe("hello");
+  });
+
+  it("done event 觸發 finishStreaming", () => {
+    useCopilotStore.setState({ isOpen: true, isStreaming: true });
+    renderHook(() => useCopilotSSE());
+    const es = MockEventSource.instances[0];
+
+    act(() => es.emit("done"));
+    expect(useCopilotStore.getState().isStreaming).toBe(false);
+  });
+
+  it("連線錯誤時最多重試 3 次（指數退避）", () => {
+    useCopilotStore.setState({ isOpen: true });
+    renderHook(() => useCopilotSSE());
+
+    // 第一次錯誤 → retry 1（1s delay）
+    act(() => MockEventSource.instances.at(-1)!.triggerError());
+    expect(MockEventSource.instances.length).toBe(1); // 尚未重連
+
+    act(() => vi.advanceTimersByTime(1000));
+    expect(MockEventSource.instances.length).toBe(2);
+
+    // 第二次錯誤 → retry 2（2s delay）
+    act(() => MockEventSource.instances.at(-1)!.triggerError());
+    act(() => vi.advanceTimersByTime(2000));
+    expect(MockEventSource.instances.length).toBe(3);
+
+    // 第三次錯誤 → retry 3（4s delay）
+    act(() => MockEventSource.instances.at(-1)!.triggerError());
+    act(() => vi.advanceTimersByTime(4000));
+    expect(MockEventSource.instances.length).toBe(4);
+
+    // 第四次錯誤 → 超過 max retries，不再重連
+    act(() => MockEventSource.instances.at(-1)!.triggerError());
+    act(() => vi.advanceTimersByTime(10000));
+    expect(MockEventSource.instances.length).toBe(4); // 沒有新連線
+  });
+});

--- a/dev/frontend/__tests__/lib/stores/copilot-store.test.ts
+++ b/dev/frontend/__tests__/lib/stores/copilot-store.test.ts
@@ -1,0 +1,138 @@
+/**
+ * Unit tests for copilot-store
+ *
+ * 測試 zustand store 的核心行為：
+ * - open/close/clearSession
+ * - appendStreamToken / finishStreaming / abortStreaming
+ * - close 時截斷 streaming 訊息
+ */
+
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+// Mock API calls
+vi.mock("@/lib/api/copilot", () => ({
+  createSession: vi.fn().mockResolvedValue({ id: "session-1", created_at: "" }),
+  postMessage: vi.fn().mockResolvedValue({
+    id: "msg-1",
+    session_id: "session-1",
+    role: "user",
+    content: "hello",
+    created_at: "",
+  }),
+}));
+
+import { useCopilotStore } from "@/lib/stores/copilot-store";
+
+function getStore() {
+  return useCopilotStore.getState();
+}
+
+function resetStore() {
+  useCopilotStore.setState({
+    isOpen: false,
+    sessionId: null,
+    messages: [],
+    isStreaming: false,
+    error: null,
+  });
+}
+
+describe("CopilotStore", () => {
+  beforeEach(() => {
+    resetStore();
+  });
+
+  it("初始狀態正確", () => {
+    const s = getStore();
+    expect(s.isOpen).toBe(false);
+    expect(s.sessionId).toBeNull();
+    expect(s.messages).toEqual([]);
+    expect(s.isStreaming).toBe(false);
+    expect(s.error).toBeNull();
+  });
+
+  it("open() 設定 isOpen = true", () => {
+    getStore().open();
+    expect(useCopilotStore.getState().isOpen).toBe(true);
+  });
+
+  it("close() 設定 isOpen = false（無 streaming）", () => {
+    getStore().open();
+    getStore().close();
+    expect(useCopilotStore.getState().isOpen).toBe(false);
+  });
+
+  it("close() 截斷 streaming 中的訊息並加 '...'", () => {
+    useCopilotStore.setState({
+      isOpen: true,
+      isStreaming: true,
+      messages: [
+        { id: "1", role: "user", content: "hi" },
+        { id: "2", role: "assistant", content: "hell", isStreaming: true },
+      ],
+    });
+    getStore().close();
+    const s = useCopilotStore.getState();
+    expect(s.isOpen).toBe(false);
+    expect(s.isStreaming).toBe(false);
+    expect(s.messages[1].content).toBe("hell...");
+    expect(s.messages[1].isStreaming).toBe(false);
+  });
+
+  it("clearSession() 清空訊息和 sessionId", () => {
+    useCopilotStore.setState({
+      sessionId: "abc",
+      messages: [{ id: "1", role: "user", content: "x" }],
+      isStreaming: true,
+    });
+    getStore().clearSession();
+    const s = useCopilotStore.getState();
+    expect(s.messages).toEqual([]);
+    expect(s.sessionId).toBeNull();
+    expect(s.isStreaming).toBe(false);
+  });
+
+  it("appendStreamToken() 追加 token 到最後一個 streaming assistant message", () => {
+    useCopilotStore.setState({
+      messages: [
+        { id: "1", role: "user", content: "hi" },
+        { id: "2", role: "assistant", content: "hell", isStreaming: true },
+      ],
+    });
+    getStore().appendStreamToken("o");
+    const msgs = useCopilotStore.getState().messages;
+    expect(msgs[1].content).toBe("hello");
+  });
+
+  it("finishStreaming() 結束所有 isStreaming 狀態", () => {
+    useCopilotStore.setState({
+      isStreaming: true,
+      messages: [
+        { id: "2", role: "assistant", content: "hello", isStreaming: true },
+      ],
+    });
+    getStore().finishStreaming();
+    const s = useCopilotStore.getState();
+    expect(s.isStreaming).toBe(false);
+    expect(s.messages[0].isStreaming).toBe(false);
+  });
+
+  it("abortStreaming() 截斷並加 '...'", () => {
+    useCopilotStore.setState({
+      isStreaming: true,
+      messages: [
+        { id: "1", role: "assistant", content: "partial", isStreaming: true },
+      ],
+    });
+    getStore().abortStreaming();
+    const s = useCopilotStore.getState();
+    expect(s.isStreaming).toBe(false);
+    expect(s.messages[0].content).toBe("partial...");
+  });
+
+  it("clearError() 清除錯誤", () => {
+    useCopilotStore.setState({ error: "some error" });
+    getStore().clearError();
+    expect(useCopilotStore.getState().error).toBeNull();
+  });
+});

--- a/dev/frontend/app/(shell)/layout.tsx
+++ b/dev/frontend/app/(shell)/layout.tsx
@@ -4,11 +4,12 @@ import { useState } from "react";
 import { Sidebar } from "@/components/shell/sidebar";
 import { TopBar } from "@/components/shell/top-bar";
 import { MainArea } from "@/components/shell/main-area";
-import { CopilotSlot } from "@/components/shell/copilot-slot";
+import { CopilotPanel } from "@/components/copilot/copilot-panel";
 import { CmdkProvider } from "@/components/cmdk/cmdk-provider";
 import { CommandPalette } from "@/components/cmdk/command-palette";
 import { ShortcutsModal } from "@/components/shortcuts/shortcuts-modal";
 import { useKeyboardShortcuts } from "@/lib/hooks/use-keyboard-shortcuts";
+import { useCopilotStore } from "@/lib/stores/copilot-store";
 import { useQuery } from "@tanstack/react-query";
 import { apiClient } from "@/lib/api/client";
 import { useApiKey } from "@/lib/hooks/use-api-key";
@@ -23,7 +24,22 @@ interface InboxCountResponse {
 
 function ShellContent({ children }: { children: React.ReactNode }) {
   const [shortcutsOpen, setShortcutsOpen] = useState(false);
-  useKeyboardShortcuts({ onOpenShortcutsModal: () => setShortcutsOpen(true) });
+  const copilotOpen = useCopilotStore((s) => s.isOpen);
+  const openCopilot = useCopilotStore((s) => s.open);
+  const closeCopilot = useCopilotStore((s) => s.close);
+
+  const handleToggleCopilot = () => {
+    if (copilotOpen) {
+      closeCopilot();
+    } else {
+      openCopilot();
+    }
+  };
+
+  useKeyboardShortcuts({
+    onOpenShortcutsModal: () => setShortcutsOpen(true),
+    onToggleCopilot: handleToggleCopilot,
+  });
 
   return (
     <>
@@ -40,7 +56,6 @@ export default function ShellLayout({
 }) {
   const router = useRouter();
   const { apiKey, hydrated } = useApiKey();
-  const [copilotOpen, setCopilotOpen] = useState(false);
 
   useEffect(() => {
     if (hydrated && !apiKey) {
@@ -84,8 +99,8 @@ export default function ShellLayout({
           </MainArea>
         </div>
 
-        {/* 右側 Copilot 佔位 */}
-        <CopilotSlot open={copilotOpen} onClose={() => setCopilotOpen(false)} />
+        {/* 右側 Copilot Panel（zustand 管理開關狀態，跨路由保持） */}
+        <CopilotPanel />
 
         {/* 全域 Command Palette overlay */}
         <CommandPalette />

--- a/dev/frontend/components/copilot/copilot-panel.tsx
+++ b/dev/frontend/components/copilot/copilot-panel.tsx
@@ -1,0 +1,169 @@
+"use client";
+
+/**
+ * CopilotPanel — 右側 resizable side panel
+ *
+ * - 寬度預設 360px，可 resize 至 240-600px（拖曳左側 handle）
+ * - 從右側滑入動畫（300ms ease-out）
+ * - 整合 useCopilotSSE hook
+ * - Header：標題 + 關閉 + 清除 Session
+ * - MessageList + TypingIndicator + MessageInput
+ */
+
+import { useCallback, useRef, useState } from "react";
+import { Bot, X, Trash2 } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+import { useCopilotStore } from "@/lib/stores/copilot-store";
+import { useCopilotSSE } from "@/lib/hooks/use-copilot-sse";
+import { MessageList } from "./message-list";
+import { MessageInput } from "./message-input";
+
+const MIN_WIDTH = 240;
+const MAX_WIDTH = 600;
+const DEFAULT_WIDTH = 360;
+
+export function CopilotPanel() {
+  const isOpen = useCopilotStore((s) => s.isOpen);
+  const close = useCopilotStore((s) => s.close);
+  const clearSession = useCopilotStore((s) => s.clearSession);
+  const messages = useCopilotStore((s) => s.messages);
+  const isStreaming = useCopilotStore((s) => s.isStreaming);
+  const sendMessage = useCopilotStore((s) => s.sendMessage);
+  const error = useCopilotStore((s) => s.error);
+  const clearError = useCopilotStore((s) => s.clearError);
+
+  // SSE 連線
+  useCopilotSSE();
+
+  // resize handle
+  const [panelWidth, setPanelWidth] = useState(DEFAULT_WIDTH);
+  const isDraggingRef = useRef(false);
+  const startXRef = useRef(0);
+  const startWidthRef = useRef(DEFAULT_WIDTH);
+
+  const onMouseDown = useCallback((e: React.MouseEvent) => {
+    e.preventDefault();
+    isDraggingRef.current = true;
+    startXRef.current = e.clientX;
+    startWidthRef.current = panelWidth;
+
+    const onMouseMove = (me: MouseEvent) => {
+      if (!isDraggingRef.current) return;
+      const delta = startXRef.current - me.clientX; // 往左拖 = 加寬
+      const newWidth = Math.min(
+        MAX_WIDTH,
+        Math.max(MIN_WIDTH, startWidthRef.current + delta),
+      );
+      setPanelWidth(newWidth);
+    };
+
+    const onMouseUp = () => {
+      isDraggingRef.current = false;
+      window.removeEventListener("mousemove", onMouseMove);
+      window.removeEventListener("mouseup", onMouseUp);
+    };
+
+    window.addEventListener("mousemove", onMouseMove);
+    window.addEventListener("mouseup", onMouseUp);
+  }, [panelWidth]);
+
+  return (
+    <aside
+      data-testid="copilot-panel"
+      aria-label="Copilot 助手"
+      style={{ width: isOpen ? panelWidth : 0 }}
+      className={cn(
+        "sticky top-0 h-screen flex-col border-l border-border bg-background overflow-hidden",
+        "transition-[width] duration-300 ease-out",
+        isOpen ? "flex" : "hidden",
+      )}
+    >
+      {/* Resize handle（左側拖曳條） */}
+      <div
+        role="separator"
+        aria-orientation="vertical"
+        aria-label="調整 Copilot 寬度"
+        data-testid="copilot-resize-handle"
+        className={cn(
+          "absolute left-0 top-0 h-full w-1 cursor-col-resize",
+          "hover:bg-primary/30 active:bg-primary/50 transition-colors",
+          "z-10",
+        )}
+        onMouseDown={onMouseDown}
+      />
+
+      {/* Header */}
+      <div className="flex h-14 items-center justify-between border-b border-border px-4 shrink-0">
+        <div className="flex items-center gap-2">
+          <Bot className="h-4 w-4 text-muted-foreground" />
+          <span className="text-sm font-semibold">Copilot</span>
+        </div>
+        <div className="flex items-center gap-1">
+          <Button
+            variant="ghost"
+            size="icon"
+            className="h-7 w-7"
+            onClick={clearSession}
+            aria-label="清除對話"
+            data-testid="copilot-clear-btn"
+            title="Clear session"
+          >
+            <Trash2 className="h-3.5 w-3.5" />
+          </Button>
+          <Button
+            variant="ghost"
+            size="icon"
+            className="h-7 w-7"
+            onClick={close}
+            aria-label="關閉 Copilot"
+            data-testid="copilot-close-btn"
+          >
+            <X className="h-4 w-4" />
+          </Button>
+        </div>
+      </div>
+
+      {/* Message List */}
+      <div className="flex flex-1 flex-col overflow-hidden">
+        <MessageList messages={messages} />
+
+        {/* Typing Indicator */}
+        {isStreaming && (
+          <div
+            className="px-4 pb-2 flex items-center gap-1.5"
+            data-testid="copilot-typing-indicator"
+            aria-label="Copilot 正在回應"
+          >
+            <span className="h-1.5 w-1.5 rounded-full bg-muted-foreground/60 animate-bounce [animation-delay:-0.3s]" />
+            <span className="h-1.5 w-1.5 rounded-full bg-muted-foreground/60 animate-bounce [animation-delay:-0.15s]" />
+            <span className="h-1.5 w-1.5 rounded-full bg-muted-foreground/60 animate-bounce" />
+          </div>
+        )}
+
+        {/* Error toast inline */}
+        {error && (
+          <div
+            className="mx-3 mb-2 flex items-center justify-between rounded-md border border-destructive/30 bg-destructive/10 px-3 py-2 text-xs text-destructive"
+            data-testid="copilot-error"
+          >
+            <span>{error}</span>
+            <button
+              onClick={clearError}
+              className="ml-2 shrink-0 opacity-70 hover:opacity-100"
+              aria-label="關閉錯誤提示"
+            >
+              <X className="h-3 w-3" />
+            </button>
+          </div>
+        )}
+
+        {/* Input */}
+        <MessageInput
+          onSend={sendMessage}
+          disabled={isStreaming}
+        />
+      </div>
+    </aside>
+  );
+}

--- a/dev/frontend/components/copilot/message-input.tsx
+++ b/dev/frontend/components/copilot/message-input.tsx
@@ -1,0 +1,89 @@
+"use client";
+
+/**
+ * MessageInput — 訊息輸入框
+ *
+ * - Enter 送出；Shift+Enter 換行
+ * - Streaming 中 SendButton disabled，防止重複送出
+ * - 送出後清空輸入框
+ */
+
+import { useRef, useState, KeyboardEvent } from "react";
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+import { SendHorizontal } from "lucide-react";
+
+interface MessageInputProps {
+  onSend: (content: string) => void;
+  disabled?: boolean;
+}
+
+export function MessageInput({ onSend, disabled = false }: MessageInputProps) {
+  const [value, setValue] = useState("");
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
+
+  const handleSend = () => {
+    const trimmed = value.trim();
+    if (!trimmed || disabled) return;
+    onSend(trimmed);
+    setValue("");
+    // 還原 textarea 高度
+    if (textareaRef.current) {
+      textareaRef.current.style.height = "auto";
+    }
+  };
+
+  const handleKeyDown = (e: KeyboardEvent<HTMLTextAreaElement>) => {
+    if (e.key === "Enter" && !e.shiftKey) {
+      e.preventDefault();
+      handleSend();
+    }
+  };
+
+  // 自動調整高度（最多 120px）
+  const handleChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
+    setValue(e.target.value);
+    const el = e.target;
+    el.style.height = "auto";
+    el.style.height = Math.min(el.scrollHeight, 120) + "px";
+  };
+
+  return (
+    <div
+      className="border-t border-border bg-background px-3 py-2"
+      data-testid="copilot-input-area"
+    >
+      <div className="flex items-end gap-2">
+        <textarea
+          ref={textareaRef}
+          value={value}
+          onChange={handleChange}
+          onKeyDown={handleKeyDown}
+          placeholder="Ask Copilot…"
+          rows={1}
+          disabled={disabled}
+          data-testid="copilot-textarea"
+          className={cn(
+            "flex-1 resize-none rounded-lg border border-input bg-background px-3 py-2 text-sm",
+            "placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-ring",
+            "disabled:cursor-not-allowed disabled:opacity-50",
+            "min-h-[36px] max-h-[120px]",
+          )}
+        />
+        <Button
+          size="icon"
+          className="h-9 w-9 shrink-0"
+          onClick={handleSend}
+          disabled={disabled || !value.trim()}
+          data-testid="copilot-send-btn"
+          aria-label="送出訊息"
+        >
+          <SendHorizontal className="h-4 w-4" />
+        </Button>
+      </div>
+      {disabled && (
+        <p className="mt-1 text-xs text-muted-foreground">Copilot is thinking…</p>
+      )}
+    </div>
+  );
+}

--- a/dev/frontend/components/copilot/message-list.tsx
+++ b/dev/frontend/components/copilot/message-list.tsx
@@ -1,0 +1,119 @@
+"use client";
+
+/**
+ * MessageList — 顯示 Copilot 對話訊息
+ *
+ * - 新訊息時自動 scroll to bottom
+ * - 使用者手動向上滾動時停止自動 scroll
+ * - AssistantMessage streaming：逐字渲染（isStreaming 時顯示游標）
+ */
+
+import { useEffect, useRef, useState } from "react";
+import { cn } from "@/lib/utils";
+import { type Message } from "@/lib/stores/copilot-store";
+import { Bot, User } from "lucide-react";
+
+interface MessageListProps {
+  messages: Message[];
+}
+
+export function MessageList({ messages }: MessageListProps) {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const [userScrolled, setUserScrolled] = useState(false);
+
+  // 監聽使用者手動向上滾動
+  useEffect(() => {
+    const el = containerRef.current;
+    if (!el) return;
+
+    const onScroll = () => {
+      const isAtBottom = el.scrollHeight - el.scrollTop - el.clientHeight < 40;
+      if (!isAtBottom) {
+        setUserScrolled(true);
+      } else {
+        setUserScrolled(false);
+      }
+    };
+
+    el.addEventListener("scroll", onScroll, { passive: true });
+    return () => el.removeEventListener("scroll", onScroll);
+  }, []);
+
+  // 新訊息 scroll to bottom（除非使用者已向上滾動）
+  useEffect(() => {
+    if (userScrolled) return;
+    const el = containerRef.current;
+    if (!el) return;
+    el.scrollTo({ top: el.scrollHeight, behavior: "smooth" });
+  }, [messages, userScrolled]);
+
+  if (messages.length === 0) {
+    return (
+      <div
+        className="flex flex-1 flex-col items-center justify-center gap-3 px-4 text-center"
+        data-testid="copilot-welcome"
+      >
+        <Bot className="h-8 w-8 text-muted-foreground/50" />
+        <p className="text-sm text-muted-foreground">
+          Ask me anything about your knowledge base.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div
+      ref={containerRef}
+      className="flex flex-1 flex-col gap-3 overflow-y-auto p-4"
+      data-testid="copilot-message-list"
+    >
+      {messages.map((msg) => (
+        <MessageBubble key={msg.id} message={msg} />
+      ))}
+    </div>
+  );
+}
+
+function MessageBubble({ message }: { message: Message }) {
+  const isUser = message.role === "user";
+
+  return (
+    <div
+      className={cn(
+        "flex gap-2",
+        isUser ? "flex-row-reverse" : "flex-row",
+      )}
+      data-testid={isUser ? "copilot-user-message" : "copilot-assistant-message"}
+    >
+      {/* Avatar */}
+      <div
+        className={cn(
+          "flex h-7 w-7 shrink-0 items-center justify-center rounded-full text-xs",
+          isUser
+            ? "bg-primary text-primary-foreground"
+            : "bg-muted text-muted-foreground",
+        )}
+      >
+        {isUser ? <User className="h-3.5 w-3.5" /> : <Bot className="h-3.5 w-3.5" />}
+      </div>
+
+      {/* Bubble */}
+      <div
+        className={cn(
+          "max-w-[85%] rounded-2xl px-3 py-2 text-sm",
+          isUser
+            ? "bg-primary text-primary-foreground rounded-tr-sm"
+            : "bg-muted text-foreground rounded-tl-sm",
+        )}
+      >
+        {message.content}
+        {message.isStreaming && (
+          <span
+            className="ml-0.5 inline-block h-3 w-0.5 animate-pulse bg-current opacity-70"
+            aria-hidden
+          />
+        )}
+      </div>
+    </div>
+  );
+}

--- a/dev/frontend/lib/api/copilot.ts
+++ b/dev/frontend/lib/api/copilot.ts
@@ -1,0 +1,48 @@
+/**
+ * Copilot API fetcher
+ * POST /api/v1/copilot/sessions  — 建立 session
+ * POST /api/v1/copilot/message   — 送出訊息
+ * GET  /api/v1/copilot/stream    — SSE 串流（由 useCopilotSSE hook 直接用 EventSource 開）
+ */
+
+import { apiClient } from "@/lib/api/client";
+
+export interface CopilotSession {
+  id: string;
+  created_at: string;
+}
+
+export interface CopilotMessageRequest {
+  session_id: string;
+  content: string;
+}
+
+export interface CopilotMessageResponse {
+  id: string;
+  session_id: string;
+  role: "user" | "assistant";
+  content: string;
+  created_at: string;
+}
+
+export interface ListMessagesResponse {
+  messages: CopilotMessageResponse[];
+}
+
+export async function createSession(): Promise<CopilotSession> {
+  return apiClient.post<CopilotSession>("/api/v1/copilot/sessions");
+}
+
+export async function postMessage(
+  req: CopilotMessageRequest,
+): Promise<CopilotMessageResponse> {
+  return apiClient.post<CopilotMessageResponse>("/api/v1/copilot/message", req);
+}
+
+export async function listMessages(
+  sessionId: string,
+): Promise<ListMessagesResponse> {
+  return apiClient.get<ListMessagesResponse>(
+    `/api/v1/copilot/sessions/${sessionId}/messages`,
+  );
+}

--- a/dev/frontend/lib/hooks/use-copilot-sse.ts
+++ b/dev/frontend/lib/hooks/use-copilot-sse.ts
@@ -1,0 +1,131 @@
+"use client";
+
+/**
+ * useCopilotSSE — EventSource 連線管理
+ *
+ * - Panel 開啟時建立 EventSource 連線至 /api/v1/copilot/stream
+ * - Panel 關閉時 es.close()
+ * - onerror：最多 3 次指數退避重連（1s / 2s / 4s）
+ * - event: message → appendStreamToken
+ * - event: done    → finishStreaming
+ * - event: error   → 重置 streaming 狀態
+ * - event: ping    → 忽略（F-039 skeleton ping）
+ */
+
+import { useEffect, useRef } from "react";
+import { useCopilotStore } from "@/lib/stores/copilot-store";
+
+const SSE_URL = "/api/v1/copilot/stream";
+const MAX_RETRIES = 3;
+const BASE_DELAY_MS = 1000;
+
+export function useCopilotSSE() {
+  const isOpen = useCopilotStore((s) => s.isOpen);
+  const sessionId = useCopilotStore((s) => s.sessionId);
+  const appendStreamToken = useCopilotStore((s) => s.appendStreamToken);
+  const finishStreaming = useCopilotStore((s) => s.finishStreaming);
+  const abortStreaming = useCopilotStore((s) => s.abortStreaming);
+  const clearError = useCopilotStore((s) => s.clearError);
+
+  const esRef = useRef<EventSource | null>(null);
+  const retryCountRef = useRef(0);
+  const retryTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  function cleanup() {
+    if (retryTimerRef.current) {
+      clearTimeout(retryTimerRef.current);
+      retryTimerRef.current = null;
+    }
+    if (esRef.current) {
+      esRef.current.close();
+      esRef.current = null;
+    }
+  }
+
+  function connect(sessionId: string | null) {
+    cleanup();
+    const url = sessionId
+      ? `${SSE_URL}?session_id=${encodeURIComponent(sessionId)}`
+      : SSE_URL;
+
+    const es = new EventSource(url, { withCredentials: true });
+    esRef.current = es;
+
+    es.addEventListener("message", (e) => {
+      retryCountRef.current = 0; // 成功收到資料，重置重試計數
+      appendStreamToken(e.data);
+    });
+
+    es.addEventListener("done", () => {
+      retryCountRef.current = 0;
+      finishStreaming();
+    });
+
+    es.addEventListener("error", (e) => {
+      // SSE server-sent error event
+      console.error("[CopilotSSE] server error event", e);
+      finishStreaming();
+    });
+
+    es.addEventListener("ping", () => {
+      // 忽略 F-039 skeleton ping
+    });
+
+    es.onerror = () => {
+      // 瀏覽器原生重連失敗（連線中斷）
+      if (retryCountRef.current >= MAX_RETRIES) {
+        console.warn("[CopilotSSE] max retries reached, giving up");
+        cleanup();
+        return;
+      }
+
+      const delay = BASE_DELAY_MS * Math.pow(2, retryCountRef.current);
+      retryCountRef.current++;
+
+      console.warn(
+        `[CopilotSSE] connection error, retry ${retryCountRef.current}/${MAX_RETRIES} in ${delay}ms`,
+      );
+
+      // 關閉舊連線，等待後重連
+      if (esRef.current) {
+        esRef.current.close();
+        esRef.current = null;
+      }
+
+      retryTimerRef.current = setTimeout(() => {
+        // 只在 panel 仍然開啟時重連
+        if (useCopilotStore.getState().isOpen) {
+          connect(useCopilotStore.getState().sessionId);
+        }
+      }, delay);
+    };
+  }
+
+  useEffect(() => {
+    if (isOpen) {
+      clearError();
+      retryCountRef.current = 0;
+      connect(sessionId);
+    } else {
+      // Panel 關閉：abort streaming + close EventSource
+      if (esRef.current) {
+        abortStreaming();
+        cleanup();
+      }
+    }
+
+    return () => {
+      cleanup();
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isOpen]);
+
+  // sessionId 變更時重新連線（清除 session 後新 session 建立）
+  useEffect(() => {
+    if (isOpen && sessionId) {
+      retryCountRef.current = 0;
+      connect(sessionId);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [sessionId]);
+}

--- a/dev/frontend/lib/hooks/use-keyboard-shortcuts.ts
+++ b/dev/frontend/lib/hooks/use-keyboard-shortcuts.ts
@@ -16,6 +16,7 @@ import { useCmdk } from "@/components/cmdk/cmdk-provider";
 
 export interface UseKeyboardShortcutsOptions {
   onOpenShortcutsModal: () => void;
+  onToggleCopilot?: () => void;
 }
 
 const SEQUENTIAL_TIMEOUT_MS = 500;
@@ -27,6 +28,7 @@ function isInputFocused(): boolean {
 
 export function useKeyboardShortcuts({
   onOpenShortcutsModal,
+  onToggleCopilot,
 }: UseKeyboardShortcutsOptions): void {
   const router = useRouter();
   const { toggle: toggleCmdk } = useCmdk();
@@ -43,6 +45,14 @@ export function useKeyboardShortcuts({
       if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === "k") {
         e.preventDefault();
         toggleCmdk();
+        lastKeyRef.current = null;
+        return;
+      }
+
+      // ⌘J — 開啟/關閉 Copilot Panel（不受 input focus 影響）
+      if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === "j") {
+        e.preventDefault();
+        onToggleCopilot?.();
         lastKeyRef.current = null;
         return;
       }

--- a/dev/frontend/lib/stores/copilot-store.ts
+++ b/dev/frontend/lib/stores/copilot-store.ts
@@ -1,0 +1,162 @@
+"use client";
+
+/**
+ * Copilot zustand store
+ *
+ * - 跨路由保持狀態（store 在 module scope，不受 component unmount 影響）
+ * - sendMessage：樂觀顯示 user message，POST 後等待 SSE stream 填充 assistant message
+ * - clearSession：清空訊息、重置 sessionId
+ */
+
+import { create } from "zustand";
+import { createSession, postMessage } from "@/lib/api/copilot";
+import { ApiError } from "@/lib/api/client";
+
+export interface Message {
+  id: string;
+  role: "user" | "assistant";
+  content: string;
+  /** streaming 中的 assistant message 是否尚未完成 */
+  isStreaming?: boolean;
+}
+
+export interface CopilotStore {
+  isOpen: boolean;
+  sessionId: string | null;
+  messages: Message[];
+  isStreaming: boolean;
+  /** SSE 錯誤訊息（顯示在 InputArea 底部） */
+  error: string | null;
+  open(): void;
+  close(): void;
+  sendMessage(content: string): Promise<void>;
+  clearSession(): void;
+  /** 由 useCopilotSSE hook 呼叫，逐字 append assistant message */
+  appendStreamToken(token: string): void;
+  /** 由 useCopilotSSE hook 呼叫，結束 streaming */
+  finishStreaming(): void;
+  /** 由 useCopilotSSE hook 呼叫，截斷 streaming（Panel 關閉時） */
+  abortStreaming(): void;
+  /** 清除 error */
+  clearError(): void;
+}
+
+let _msgCounter = 0;
+function nextId() {
+  return `local-${++_msgCounter}-${Date.now()}`;
+}
+
+export const useCopilotStore = create<CopilotStore>((set, get) => ({
+  isOpen: false,
+  sessionId: null,
+  messages: [],
+  isStreaming: false,
+  error: null,
+
+  open() {
+    set({ isOpen: true });
+  },
+
+  close() {
+    const { isStreaming } = get();
+    if (isStreaming) {
+      // 截斷 streaming 中的訊息，標示 "..."
+      set((state) => ({
+        isOpen: false,
+        isStreaming: false,
+        messages: state.messages.map((m) =>
+          m.isStreaming ? { ...m, content: m.content + "...", isStreaming: false } : m,
+        ),
+      }));
+    } else {
+      set({ isOpen: false });
+    }
+  },
+
+  async sendMessage(content: string) {
+    const { isStreaming } = get();
+    if (isStreaming) return;
+
+    // 樂觀顯示 user message
+    const userMsg: Message = { id: nextId(), role: "user", content };
+    // placeholder assistant message（streaming）
+    const assistantMsg: Message = {
+      id: nextId(),
+      role: "assistant",
+      content: "",
+      isStreaming: true,
+    };
+
+    set((state) => ({
+      messages: [...state.messages, userMsg, assistantMsg],
+      isStreaming: true,
+      error: null,
+    }));
+
+    try {
+      // 確保 session 存在
+      let { sessionId } = get();
+      if (!sessionId) {
+        const session = await createSession();
+        sessionId = session.id;
+        set({ sessionId });
+      }
+
+      await postMessage({ session_id: sessionId, content });
+      // SSE stream 接管後續 assistant message append（由 useCopilotSSE 處理）
+    } catch (err) {
+      const status = err instanceof ApiError ? err.status : 0;
+      const msg =
+        status === 503
+          ? "Copilot unavailable, please try again"
+          : "Copilot unavailable, please try again";
+
+      set((state) => ({
+        isStreaming: false,
+        error: msg,
+        messages: state.messages.map((m) =>
+          m.isStreaming ? { ...m, content: m.content || "", isStreaming: false } : m,
+        ),
+      }));
+    }
+  },
+
+  clearSession() {
+    set({ messages: [], sessionId: null, isStreaming: false, error: null });
+  },
+
+  appendStreamToken(token: string) {
+    set((state) => {
+      const msgs = [...state.messages];
+      // 找最後一個 isStreaming 的 assistant message
+      const idx = msgs.findLastIndex((m) => m.role === "assistant" && m.isStreaming);
+      if (idx === -1) return {};
+      msgs[idx] = { ...msgs[idx], content: msgs[idx].content + token };
+      return { messages: msgs };
+    });
+  },
+
+  finishStreaming() {
+    set((state) => ({
+      isStreaming: false,
+      messages: state.messages.map((m) =>
+        m.isStreaming ? { ...m, isStreaming: false } : m,
+      ),
+    }));
+  },
+
+  abortStreaming() {
+    set((state) => ({
+      isStreaming: false,
+      messages: state.messages.map((m) =>
+        m.isStreaming
+          ? { ...m, content: m.content + "...", isStreaming: false }
+          : m,
+      ),
+    }));
+  },
+
+  clearError() {
+    set({ error: null });
+  },
+}));

--- a/dev/frontend/package-lock.json
+++ b/dev/frontend/package-lock.json
@@ -49,7 +49,9 @@
         "sonner": "^1.7.1",
         "tailwind-merge": "^2.5.5",
         "tailwindcss-animate": "^1.0.7",
-        "zod": "^3.24.1"
+        "use-debounce": "^10.1.1",
+        "zod": "^3.24.1",
+        "zustand": "^5.0.12"
       },
       "devDependencies": {
         "@testing-library/jest-dom": "^6.6.3",
@@ -3710,6 +3712,34 @@
       "peerDependencies": {
         "react": ">=17",
         "react-dom": ">=17"
+      }
+    },
+    "node_modules/@xyflow/react/node_modules/zustand": {
+      "version": "4.5.7",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-4.5.7.tgz",
+      "integrity": "sha512-CHOUy7mu3lbD6o6LJLfllpjkzhHXSBlX8B9+qPddUsIfeF5S/UZ5q0kmCsnRqT1UHFQZchNFDDzMbQsuesHWlw==",
+      "license": "MIT",
+      "dependencies": {
+        "use-sync-external-store": "^1.2.2"
+      },
+      "engines": {
+        "node": ">=12.7.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.8",
+        "immer": ">=9.0.6",
+        "react": ">=16.8"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "immer": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        }
       }
     },
     "node_modules/@xyflow/system": {
@@ -11038,6 +11068,18 @@
         }
       }
     },
+    "node_modules/use-debounce": {
+      "version": "10.1.1",
+      "resolved": "https://registry.npmjs.org/use-debounce/-/use-debounce-10.1.1.tgz",
+      "integrity": "sha512-kvds8BHR2k28cFsxW8k3nc/tRga2rs1RHYCqmmGqb90MEeE++oALwzh2COiuBLO1/QXiOuShXoSN2ZpWnMmvuQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16.0.0"
+      },
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
     "node_modules/use-sidecar": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/use-sidecar/-/use-sidecar-1.1.3.tgz",
@@ -11615,20 +11657,18 @@
       }
     },
     "node_modules/zustand": {
-      "version": "4.5.7",
-      "resolved": "https://registry.npmjs.org/zustand/-/zustand-4.5.7.tgz",
-      "integrity": "sha512-CHOUy7mu3lbD6o6LJLfllpjkzhHXSBlX8B9+qPddUsIfeF5S/UZ5q0kmCsnRqT1UHFQZchNFDDzMbQsuesHWlw==",
+      "version": "5.0.12",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-5.0.12.tgz",
+      "integrity": "sha512-i77ae3aZq4dhMlRhJVCYgMLKuSiZAaUPAct2AksxQ+gOtimhGMdXljRT21P5BNpeT4kXlLIckvkPM029OljD7g==",
       "license": "MIT",
-      "dependencies": {
-        "use-sync-external-store": "^1.2.2"
-      },
       "engines": {
-        "node": ">=12.7.0"
+        "node": ">=12.20.0"
       },
       "peerDependencies": {
-        "@types/react": ">=16.8",
+        "@types/react": ">=18.0.0",
         "immer": ">=9.0.6",
-        "react": ">=16.8"
+        "react": ">=18.0.0",
+        "use-sync-external-store": ">=1.2.0"
       },
       "peerDependenciesMeta": {
         "@types/react": {
@@ -11638,6 +11678,9 @@
           "optional": true
         },
         "react": {
+          "optional": true
+        },
+        "use-sync-external-store": {
           "optional": true
         }
       }

--- a/dev/frontend/package.json
+++ b/dev/frontend/package.json
@@ -52,7 +52,9 @@
     "sonner": "^1.7.1",
     "tailwind-merge": "^2.5.5",
     "tailwindcss-animate": "^1.0.7",
-    "zod": "^3.24.1"
+    "use-debounce": "^10.1.1",
+    "zod": "^3.24.1",
+    "zustand": "^5.0.12"
   },
   "devDependencies": {
     "@testing-library/jest-dom": "^6.6.3",


### PR DESCRIPTION
## Summary

實作 F-047 Copilot Side Panel，包含 zustand store 狀態管理、EventSource SSE 連線、resizable panel UI、⌘J 快捷鍵整合。

## Changes

- `dev/frontend/lib/api/copilot.ts` — REST fetcher（createSession / postMessage / listMessages）
- `dev/frontend/lib/stores/copilot-store.ts` — zustand store（messages、isStreaming、sessionId、open state、stream actions）
- `dev/frontend/lib/hooks/use-copilot-sse.ts` — EventSource 連線 + 3 次指數退避重連（1s/2s/4s）
- `dev/frontend/components/copilot/message-list.tsx` — MessageList（auto scroll-to-bottom + streaming cursor）
- `dev/frontend/components/copilot/message-input.tsx` — MessageInput（Enter 送出 / Shift+Enter 換行 / auto resize）
- `dev/frontend/components/copilot/copilot-panel.tsx` — CopilotPanel（resizable 240-600px / header / typing indicator / error）
- `dev/frontend/lib/hooks/use-keyboard-shortcuts.ts` — 加入 ⌘J 快捷鍵 onToggleCopilot callback
- `dev/frontend/app/(shell)/layout.tsx` — 整合 CopilotPanel，以 zustand store 管理開關（跨路由保持）
- `dev/frontend/__tests__/lib/stores/copilot-store.test.ts` — store unit tests
- `dev/frontend/__tests__/lib/hooks/use-copilot-sse.test.ts` — SSE hook unit tests（mock EventSource）

## Scenario 覆蓋

- [x] Scenario: 開啟 Copilot Panel — ⌘J / close button，300ms ease-out 滑入
- [x] Scenario: 送出訊息並接收 SSE stream — 樂觀顯示 user message，postMessage API，逐字渲染
- [x] Scenario: 關閉 Panel 保持訊息 — zustand store 跨路由，SSE 持續
- [x] Scenario: 清除 Session — clearSession() 清空 messages + sessionId
- [x] Scenario: SSE 連線中斷自動重連 — EventSource onerror 指數退避（最多 3 次）
- [x] Scenario: 訊息送出失敗 — 503 顯示 error inline，streaming 重置，user message 保留
- [x] Scenario: Panel 關閉時中斷 SSE — es.close() + 截斷 streaming 訊息加 "..."

## 測試

- Unit tests：`dev/frontend/__tests__/lib/stores/copilot-store.test.ts`
- Unit tests：`dev/frontend/__tests__/lib/hooks/use-copilot-sse.test.ts`

## Related Issues

Closes #232