### PR TITLE
chore: production docker-compose at repo root

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,15 @@
+# Production env — 複製為 .env 後填入實際值，.env 已在 .gitignore
+
+# Database（外部 PostgreSQL，非 docker-compose 內服務）
+DATABASE_URL=postgres://user:password@db-host:5432/aibo?sslmode=require
+
+# API
+SERVER_PORT=8080
+AIBO_ENCRYPTION_KEY=  # 64 hex chars (32 bytes)
+
+# Frontend（build-time，需在 docker compose build 之前設定）
+NEXT_PUBLIC_API_URL=https://api.your-domain.com
+
+# Port mapping（host → container 8080/3000）
+API_PORT=8080
+FRONTEND_PORT=3000

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,25 @@
+services:
+  api:
+    build:
+      context: ./dev/src
+      dockerfile: Dockerfile
+    env_file:
+      - .env
+    ports:
+      - "${API_PORT:-8080}:8080"
+    restart: unless-stopped
+
+  frontend:
+    build:
+      context: ./dev/frontend
+      dockerfile: Dockerfile
+      args:
+        # NEXT_PUBLIC_* 必須在 build 階段固定（runtime env 設定會觸發 Next.js 14 standalone bug，造成 (dashboard) routes 全 404）
+        NEXT_PUBLIC_API_URL: ${NEXT_PUBLIC_API_URL}
+    environment:
+      NODE_ENV: production
+    depends_on:
+      - api
+    ports:
+      - "${FRONTEND_PORT:-3000}:3000"
+    restart: unless-stopped

--- a/specs/logs/sprint-16-log.md
+++ b/specs/logs/sprint-16-log.md
@@ -1,0 +1,57 @@
+# Sprint 16 工作日誌：Copilot SSE + CmdK Power + Shortcuts
+
+**Milestone**: #16
+**Epic**: #187
+**Sprint Issue**: #191
+**完成日**: 2026-04-29
+
+## 交付清單
+
+| Feature | Issue | PR | 狀態 |
+|---------|-------|----|----|
+| F-047 Copilot Side Panel | #232 | #243 | ✅ MERGED |
+| F-048 Copilot Backend SSE | #231 | #240 | ✅ MERGED |
+| F-049 CmdK Power Actions | #233 | #241 | ✅ MERGED |
+| F-050 Keyboard Shortcuts | #234 | #238 | ✅ MERGED |
+| D-16 UI Components | #235 | #242 | ✅ MERGED |
+| QA-16 e2e skeleton | #236 | #239 | ✅ MERGED |
+| Tech Survey | — | #237 | ✅ MERGED |
+
+## 重點變更
+
+### Backend (`dev/src/`)
+- migration `020`：copilot_sessions + copilot_messages
+- `model.Copilot*` / `dto.Copilot*` / `repository.CopilotRepository`
+- `service.CopilotService`：context 注入（最近 entries）+ LLM streaming
+- `handler.CopilotHandler` 取代 F-039 skeleton：POST /copilot/messages、GET /copilot/stream、sessions CRUD
+- router.go + main.go DI
+
+### Frontend (`dev/frontend/`)
+- `lib/api/copilot.ts`、`lib/stores/copilot-store.ts`（zustand）
+- `lib/hooks/use-copilot-sse.ts`：EventSource + 指數退避重連（1s/2s/4s，最多 3 次）
+- `components/copilot/`：CopilotPanel（resizable 240-600px）+ MessageList（streaming cursor）+ MessageInput（Enter 送、Shift+Enter 換行）
+- `lib/hooks/use-keyboard-shortcuts.ts`：自訂 hook，G 系列 sequential（500ms timeout）+ ⌘K/⌘J/?
+- `components/shortcuts/shortcuts-modal.tsx`：5 sections kbd grid
+- CmdK power：entries-search（debounce 200ms）、ai-actions（`>` prefix）、quick-create-modal、create-actions
+- 整合 (shell) layout
+
+### Design (`design/`)
+- `components/copilot-panel/`、`cmdk-power/`、`shortcuts-modal/`（spec.md + .example.tsx）
+- `pages/f047-copilot.md`（layout + 響應式 + zustand 流程）
+
+### Test (`test/`)
+- 24 scenarios skeleton：CP-1~6、CB-1~5、CP-1~6、KS-1~6（test.skip）
+
+## 技術決策
+- 原生 EventSource + 自訂重連（不引入 reconnecting-eventsource）
+- zustand 不用 persist middleware（避免 SSR hydration mismatch）
+- 自訂 useKeyboardShortcuts（不用 react-hotkeys-hook）
+- 後端 SSE：X-Accel-Buffering: no、c.Stream() flush、15s ping
+
+## Sprint 16 完成 = 整個 visual redesign milestone 完成
+F-035~F-050 共 16 個 feature 全部 merged。aibo 從純表格列表型 UI 轉變為 editorial 紙本設計系統 + dashboard hub + canvas + copilot 整合。
+
+## Follow-up（跨 sprint）
+1. F-039 router 註冊（Sprint 13 遺留）— 已被 F-048 取代為 CopilotHandler
+2. F-043 frontend：saved-views-bar UI
+3. e2e 124+ scenarios 待 features 啟用後逐步解開 test.skip


### PR DESCRIPTION
Closes nothing — production deployment infra

## 內容
- 新增 `docker-compose.yml` 在 repo root（api + frontend，無 db）
- 新增 `.env.example` 範本
- 服務改用 `env_file: .env`，使用者自行填入 DATABASE_URL / AIBO_ENCRYPTION_KEY 等

## 注意
- NEXT_PUBLIC_API_URL 為 build arg（Next.js 14 standalone 限制）
- dev compose 仍保留在 `dev/docker-compose.yml`
- dev 服務已停止