### PR TITLE
deploy: GitHub Actions + GHCR + self-hosted runner pipeline

### DIFF
--- a/.github/workflows/build-api.yml
+++ b/.github/workflows/build-api.yml
@@ -1,0 +1,60 @@
+name: build-api
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'dev/src/**'
+      - '.github/workflows/build-api.yml'
+  workflow_dispatch:
+
+env:
+  REGISTRY: ghcr.io
+  GHCR_OWNER: ${{ github.repository_owner }}
+  IMAGE_NAME: aibo-api
+  DOCKER_CONFIG: ${{ github.workspace }}/.docker-config
+
+jobs:
+  build:
+    runs-on: self-hosted
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup PATH
+        run: |
+          echo "/usr/local/bin" >> $GITHUB_PATH
+          echo "/opt/homebrew/bin" >> $GITHUB_PATH
+
+      - name: Setup isolated DOCKER_CONFIG with auth + cli-plugins
+        env:
+          GHCR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          mkdir -p "$DOCKER_CONFIG/cli-plugins"
+          for plugin in /Users/$(whoami)/.docker/cli-plugins/*; do
+            ln -sf "$plugin" "$DOCKER_CONFIG/cli-plugins/$(basename "$plugin")"
+          done
+          AUTH=$(printf '%s:%s' "${{ github.actor }}" "$GHCR_TOKEN" | base64)
+          cat > "$DOCKER_CONFIG/config.json" <<JSON
+          {
+            "auths": {
+              "${{ env.REGISTRY }}": { "auth": "$AUTH" }
+            }
+          }
+          JSON
+
+      - id: tag
+        run: echo "tag=$(date +%Y.%m.%d)-${GITHUB_SHA::7}" >> "$GITHUB_OUTPUT"
+
+      - name: Build & push (native arm64)
+        run: |
+          IMAGE_TAG="${{ env.REGISTRY }}/${{ env.GHCR_OWNER }}/${{ env.IMAGE_NAME }}"
+          docker buildx build \
+            --platform linux/arm64 \
+            --push \
+            -t "${IMAGE_TAG}:${{ steps.tag.outputs.tag }}" \
+            -t "${IMAGE_TAG}:prod" \
+            ./dev/src
+          echo "✓ pushed ${IMAGE_TAG}:${{ steps.tag.outputs.tag }} (also :prod)"

--- a/.github/workflows/build-frontend.yml
+++ b/.github/workflows/build-frontend.yml
@@ -1,0 +1,68 @@
+name: build-frontend
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'dev/frontend/**'
+      - '.github/workflows/build-frontend.yml'
+  workflow_dispatch:
+    inputs:
+      api_url:
+        description: 'NEXT_PUBLIC_API_URL build arg (預設: https://aibo.gwp4.com/api)'
+        required: false
+        default: 'https://aibo.gwp4.com/api'
+
+env:
+  REGISTRY: ghcr.io
+  GHCR_OWNER: ${{ github.repository_owner }}
+  IMAGE_NAME: aibo-frontend
+  DOCKER_CONFIG: ${{ github.workspace }}/.docker-config
+
+jobs:
+  build:
+    runs-on: self-hosted
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup PATH
+        run: |
+          echo "/usr/local/bin" >> $GITHUB_PATH
+          echo "/opt/homebrew/bin" >> $GITHUB_PATH
+
+      - name: Setup isolated DOCKER_CONFIG with auth + cli-plugins
+        env:
+          GHCR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          mkdir -p "$DOCKER_CONFIG/cli-plugins"
+          for plugin in /Users/$(whoami)/.docker/cli-plugins/*; do
+            ln -sf "$plugin" "$DOCKER_CONFIG/cli-plugins/$(basename "$plugin")"
+          done
+          AUTH=$(printf '%s:%s' "${{ github.actor }}" "$GHCR_TOKEN" | base64)
+          cat > "$DOCKER_CONFIG/config.json" <<JSON
+          {
+            "auths": {
+              "${{ env.REGISTRY }}": { "auth": "$AUTH" }
+            }
+          }
+          JSON
+
+      - id: tag
+        run: echo "tag=$(date +%Y.%m.%d)-${GITHUB_SHA::7}" >> "$GITHUB_OUTPUT"
+
+      - name: Build & push (native arm64)
+        env:
+          API_URL: ${{ inputs.api_url || 'https://aibo.gwp4.com/api' }}
+        run: |
+          IMAGE_TAG="${{ env.REGISTRY }}/${{ env.GHCR_OWNER }}/${{ env.IMAGE_NAME }}"
+          docker buildx build \
+            --platform linux/arm64 \
+            --push \
+            --build-arg "NEXT_PUBLIC_API_URL=${API_URL}" \
+            -t "${IMAGE_TAG}:${{ steps.tag.outputs.tag }}" \
+            -t "${IMAGE_TAG}:prod" \
+            ./dev/frontend
+          echo "✓ pushed ${IMAGE_TAG}:${{ steps.tag.outputs.tag }} (also :prod)"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,150 @@
+name: deploy
+
+on:
+  workflow_dispatch:
+    inputs:
+      api_tag:
+        description: 'api image tag (預設: prod)'
+        required: false
+        default: 'prod'
+      frontend_tag:
+        description: 'frontend image tag (預設: prod)'
+        required: false
+        default: 'prod'
+
+env:
+  REGISTRY: ghcr.io
+  GHCR_OWNER: ${{ github.repository_owner }}
+  SERVICE_NAME: aibo
+  NGINX_CONFD: /Volumes/2tb/project/common-service/infra/nginx/conf.d
+
+jobs:
+  deploy:
+    runs-on: self-hosted
+    environment: production
+    env:
+      DOCKER_CONFIG: ${{ github.workspace }}/.docker-config
+      API_TAG:      ${{ inputs.api_tag      || 'prod' }}
+      FRONTEND_TAG: ${{ inputs.frontend_tag || 'prod' }}
+      DATABASE_URL:        ${{ secrets.DATABASE_URL }}
+      AIBO_ENCRYPTION_KEY: ${{ secrets.AIBO_ENCRYPTION_KEY }}
+      NEXT_PUBLIC_API_URL: ${{ vars.NEXT_PUBLIC_API_URL || 'https://aibo.gwp4.com/api' }}
+      API_PORT:            ${{ vars.API_PORT      || '8080' }}
+      FRONTEND_PORT:       ${{ vars.FRONTEND_PORT || '3000' }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup PATH
+        run: |
+          echo "/usr/local/bin" >> $GITHUB_PATH
+          echo "/opt/homebrew/bin" >> $GITHUB_PATH
+          echo "/Users/$(whoami)/.orbstack/bin" >> $GITHUB_PATH
+
+      - name: Setup isolated DOCKER_CONFIG with auth + linked plugins
+        env:
+          GHCR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          mkdir -p "$DOCKER_CONFIG/cli-plugins"
+          for plugin in /Users/$(whoami)/.docker/cli-plugins/*; do
+            ln -sf "$plugin" "$DOCKER_CONFIG/cli-plugins/$(basename "$plugin")"
+          done
+          AUTH=$(printf '%s:%s' "${{ github.actor }}" "$GHCR_TOKEN" | base64)
+          cat > "$DOCKER_CONFIG/config.json" <<JSON
+          {
+            "auths": {
+              "${{ env.REGISTRY }}": { "auth": "$AUTH" }
+            }
+          }
+          JSON
+
+      - name: Sync nginx conf + reload (test 失敗會 abort)
+        run: |
+          if [[ -f "${NGINX_CONFD}/${SERVICE_NAME}.conf" ]]; then
+            cp "${NGINX_CONFD}/${SERVICE_NAME}.conf" \
+               "${NGINX_CONFD}/.${SERVICE_NAME}.conf.bak"
+          fi
+
+          cp "nginx/${SERVICE_NAME}.conf" "${NGINX_CONFD}/${SERVICE_NAME}.conf"
+
+          if ! docker exec nginx-proxy nginx -t -c /etc/nginx/nginx.conf; then
+            echo "✗ nginx -t 失敗，回退 conf"
+            if [[ -f "${NGINX_CONFD}/.${SERVICE_NAME}.conf.bak" ]]; then
+              mv "${NGINX_CONFD}/.${SERVICE_NAME}.conf.bak" \
+                 "${NGINX_CONFD}/${SERVICE_NAME}.conf"
+            else
+              rm "${NGINX_CONFD}/${SERVICE_NAME}.conf"
+            fi
+            exit 1
+          fi
+
+          docker exec nginx-proxy nginx -s reload
+          echo "✓ nginx conf synced + reloaded"
+
+          rm -f "${NGINX_CONFD}/.${SERVICE_NAME}.conf.bak"
+
+      - name: Snapshot current running tags (for rollback)
+        id: snap
+        run: |
+          for svc_container in api:${SERVICE_NAME}-api-1 frontend:${SERVICE_NAME}-frontend-1; do
+            svc="${svc_container%%:*}"
+            cn="${svc_container##*:}"
+            PREV=$(docker inspect --format='{{.Config.Image}}' "$cn" 2>/dev/null | awk -F: '{print $NF}' || true)
+            if [[ -z "${PREV}" || "${PREV}" == "latest" ]]; then PREV="prod"; fi
+            echo "${svc}_prev=${PREV}" >> "$GITHUB_OUTPUT"
+            echo "  ${svc}: 目前 ${PREV}"
+          done
+
+      - name: Deploy in ephemeral tmp dir
+        run: |
+          TMP=$(mktemp -d -t deploy-${SERVICE_NAME}.XXXXXX)
+          trap "rm -rf $TMP" EXIT
+
+          cp docker-compose.yml docker-compose.prod.yml "$TMP/"
+          cd "$TMP"
+
+          docker compose -p "${SERVICE_NAME}" \
+            -f docker-compose.yml -f docker-compose.prod.yml pull
+          docker compose -p "${SERVICE_NAME}" \
+            -f docker-compose.yml -f docker-compose.prod.yml up -d --remove-orphans
+
+      - name: Healthcheck (繞過 Cloudflare, 直連本機 nginx)
+        run: |
+          DOMAIN="${SERVICE_NAME}.gwp4.com"
+          for i in {1..20}; do
+            if curl -k -fsS -m 5 --resolve "${DOMAIN}:443:127.0.0.1" "https://${DOMAIN}/" >/dev/null \
+               && curl -k -fsS -m 5 --resolve "${DOMAIN}:443:127.0.0.1" "https://${DOMAIN}/api/" >/dev/null; then
+              echo "✓ healthy after ${i} attempts"
+              exit 0
+            fi
+            echo "… not ready (${i}/20)"
+            sleep 3
+          done
+          echo "✗ healthcheck failed" >&2
+          exit 1
+
+      - name: Auto-rollback
+        if: failure() && steps.snap.outcome == 'success'
+        env:
+          API_TAG:      ${{ steps.snap.outputs.api_prev }}
+          FRONTEND_TAG: ${{ steps.snap.outputs.frontend_prev }}
+        run: |
+          TMP=$(mktemp -d -t rollback-${SERVICE_NAME}.XXXXXX)
+          trap "rm -rf $TMP" EXIT
+
+          cp docker-compose.yml docker-compose.prod.yml "$TMP/"
+          cd "$TMP"
+
+          echo "✗ rollback to api=${API_TAG} frontend=${FRONTEND_TAG}"
+          docker compose -p "${SERVICE_NAME}" \
+            -f docker-compose.yml -f docker-compose.prod.yml pull
+          docker compose -p "${SERVICE_NAME}" \
+            -f docker-compose.yml -f docker-compose.prod.yml up -d
+          exit 1
+
+      - name: Summary
+        if: success()
+        run: |
+          echo "✓ ${SERVICE_NAME} deployed"
+          echo "  api:      ${API_TAG}"
+          echo "  frontend: ${FRONTEND_TAG}"
+          echo "  https://${SERVICE_NAME}.gwp4.com/"

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -1,0 +1,13 @@
+# Prod override — image 改用 GHCR，build 區塊清掉。
+# env 變數由 deploy.yml 從 GitHub Environment secrets/vars 注入。
+
+services:
+  api:
+    image: ghcr.io/${GHCR_OWNER:?GHCR_OWNER required}/aibo-api:${API_TAG:-prod}
+    pull_policy: always
+    build: !reset null
+
+  frontend:
+    image: ghcr.io/${GHCR_OWNER}/aibo-frontend:${FRONTEND_TAG:-prod}
+    pull_policy: always
+    build: !reset null

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,10 +1,15 @@
+# Base compose — 本地開發用 .env，prod 由 deploy.yml 從 GitHub Environment 注入 shell env
+# 不含 db service：本地開發連既有 OrbStack postgres，prod 連外部 DB
+
 services:
   api:
     build:
       context: ./dev/src
       dockerfile: Dockerfile
-    env_file:
-      - .env
+    environment:
+      DATABASE_URL: ${DATABASE_URL}
+      SERVER_PORT: "8080"
+      AIBO_ENCRYPTION_KEY: ${AIBO_ENCRYPTION_KEY}
     ports:
       - "${API_PORT:-8080}:8080"
     restart: unless-stopped
@@ -14,7 +19,7 @@ services:
       context: ./dev/frontend
       dockerfile: Dockerfile
       args:
-        # NEXT_PUBLIC_* 必須在 build 階段固定（runtime env 設定會觸發 Next.js 14 standalone bug，造成 (dashboard) routes 全 404）
+        # NEXT_PUBLIC_* 必須在 build 階段固定（Next.js 14 standalone bug）
         NEXT_PUBLIC_API_URL: ${NEXT_PUBLIC_API_URL}
     environment:
       NODE_ENV: production

--- a/nginx/aibo.conf
+++ b/nginx/aibo.conf
@@ -1,0 +1,38 @@
+# aibo nginx vhost — 由 deploy.yml sync 到 infra/nginx/conf.d/
+#
+# 前後端同網域：
+#   /api/ → backend (rewrite /api/foo → /foo)
+#   /     → frontend
+# Container hostname: <service>.<project>.orb.local；project = aibo (compose -p aibo)
+
+server {
+    listen 443 ssl;
+    server_name aibo.gwp4.com;
+    include /etc/nginx/snippets/ssl.conf;
+
+    location /api/ {
+        set $upstream http://api.aibo.orb.local:8080;
+        rewrite ^/api/(.*) /$1 break;
+        proxy_pass $upstream;
+        include /etc/nginx/snippets/proxy_headers.conf;
+    }
+
+    # SSE for Copilot streaming
+    location /api/v1/copilot/stream {
+        set $upstream http://api.aibo.orb.local:8080;
+        rewrite ^/api/(.*) /$1 break;
+        proxy_pass $upstream;
+        proxy_http_version 1.1;
+        proxy_set_header Connection '';
+        proxy_buffering off;
+        proxy_cache off;
+        proxy_read_timeout 24h;
+        include /etc/nginx/snippets/proxy_headers.conf;
+    }
+
+    location / {
+        set $upstream http://frontend.aibo.orb.local:3000;
+        proxy_pass $upstream;
+        include /etc/nginx/snippets/proxy_headers.conf;
+    }
+}


### PR DESCRIPTION
整合 mac-orbstack-deploy-pipeline。

## 新增
- 2 個 build workflow（path-filter 觸發）：build-api / build-frontend
- 1 個 deploy workflow（workflow_dispatch only）
- nginx/aibo.conf
- docker-compose.prod.yml
- 更新 docker-compose.yml 為 env 化版本

## 部署網域
- aibo.gwp4.com（前後端同網域，/api/ 反代 backend）

## 後續手動步驟
1. Transfer repo gpwork4u/aibo → gwp4-studio/aibo（needs user 確認）
2. 設定 production environment secrets：DATABASE_URL、AIBO_ENCRYPTION_KEY
3. 觸發 build-api + build-frontend
4. 觸發 deploy